### PR TITLE
fix(auth): 이슈 #2 누락 파일 추가 (#2)

### DIFF
--- a/documind/src/main/java/com/documind/documind/domain/auth/AuthController.java
+++ b/documind/src/main/java/com/documind/documind/domain/auth/AuthController.java
@@ -1,0 +1,43 @@
+package com.documind.documind.domain.auth;
+
+import com.documind.documind.global.common.ApiResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.*;
+
+// 인증 관련 엔드포인트를 처리하는 컨트롤러
+// @RestController: @Controller + @ResponseBody. JSON 응답을 기본으로 반환
+// @RequestMapping: 공통 URL 접두사를 지정
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final AuthService authService;
+
+    // POST /api/auth/login - 로그인
+    // @Valid: @NotBlank 등 DTO 유효성 검사를 활성화
+    @PostMapping("/login")
+    public ResponseEntity<ApiResponse<LoginResponse>> login(@Valid @RequestBody LoginRequest request) {
+        LoginResponse response = authService.login(request.getUsername(), request.getPassword());
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    // POST /api/auth/logout - 로그아웃
+    // @AuthenticationPrincipal: SecurityContext에서 현재 인증된 사용자 정보를 주입
+    @PostMapping("/logout")
+    public ResponseEntity<ApiResponse<Void>> logout(@AuthenticationPrincipal UserDetails userDetails) {
+        authService.logout(userDetails.getUsername());
+        return ResponseEntity.ok(ApiResponse.success("로그아웃 되었습니다."));
+    }
+
+    // POST /api/auth/reissue - Access Token 재발급
+    @PostMapping("/reissue")
+    public ResponseEntity<ApiResponse<String>> reissue(@RequestHeader("Refresh-Token") String refreshToken) {
+        String newAccessToken = authService.reissue(refreshToken);
+        return ResponseEntity.ok(ApiResponse.success(newAccessToken));
+    }
+}

--- a/documind/src/main/java/com/documind/documind/domain/auth/AuthService.java
+++ b/documind/src/main/java/com/documind/documind/domain/auth/AuthService.java
@@ -1,0 +1,66 @@
+package com.documind.documind.domain.auth;
+
+import com.documind.documind.global.auth.JwtProvider;
+import com.documind.documind.global.exception.CustomException;
+import com.documind.documind.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+// 로그인, 로그아웃, 토큰 재발급 비즈니스 로직을 담당
+// @Service: 스프링 빈으로 등록
+// @RequiredArgsConstructor: final 필드를 인자로 받는 생성자를 자동 생성 (Lombok)
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtProvider jwtProvider;
+
+    // 로그인: username/password 검증 후 Access Token과 Refresh Token을 발급
+    // @Transactional: 메서드 실행 전 트랜잭션을 시작하고, 정상 종료 시 커밋, 예외 발생 시 롤백
+    @Transactional
+    public LoginResponse login(String username, String password) {
+        User user = userRepository.findByUsername(username)
+                .orElseThrow(() -> new CustomException(ErrorCode.INVALID_CREDENTIALS));
+
+        // DB에 저장된 BCrypt 해시와 입력한 평문 비밀번호를 비교
+        if (!passwordEncoder.matches(password, user.getPassword())) {
+            throw new CustomException(ErrorCode.INVALID_CREDENTIALS);
+        }
+
+        String accessToken = jwtProvider.generateToken(user.getUsername(), user.getRole().name());
+        String refreshToken = jwtProvider.generateRefreshToken(user.getUsername());
+
+        // Refresh Token 저장 및 마지막 로그인 시각 갱신
+        user.login(refreshToken);
+
+        return LoginResponse.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
+    }
+
+    // 로그아웃: DB의 Refresh Token을 NULL로 초기화하여 재사용 차단
+    @Transactional
+    public void logout(String username) {
+        User user = userRepository.findByUsername(username)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        user.logout();
+    }
+
+    // Access Token 재발급: Refresh Token 유효성 검증 후 새로운 Access Token 발급
+    @Transactional
+    public String reissue(String refreshToken) {
+        if (!jwtProvider.validateToken(refreshToken)) {
+            throw new CustomException(ErrorCode.INVALID_TOKEN);
+        }
+
+        User user = userRepository.findByRefreshToken(refreshToken)
+                .orElseThrow(() -> new CustomException(ErrorCode.INVALID_TOKEN));
+
+        return jwtProvider.generateToken(user.getUsername(), user.getRole().name());
+    }
+}

--- a/documind/src/main/java/com/documind/documind/domain/auth/LoginRequest.java
+++ b/documind/src/main/java/com/documind/documind/domain/auth/LoginRequest.java
@@ -1,0 +1,17 @@
+package com.documind.documind.domain.auth;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+// 로그인 요청 바디를 받는 DTO
+// @Getter: 모든 필드의 getter 메서드 자동 생성 (Lombok)
+@Getter
+public class LoginRequest {
+
+    // @NotBlank: null, 빈 문자열, 공백 문자열 모두 거부
+    @NotBlank
+    private String username;
+
+    @NotBlank
+    private String password;
+}

--- a/documind/src/main/java/com/documind/documind/domain/auth/LoginResponse.java
+++ b/documind/src/main/java/com/documind/documind/domain/auth/LoginResponse.java
@@ -1,0 +1,14 @@
+package com.documind.documind.domain.auth;
+
+import lombok.Builder;
+import lombok.Getter;
+
+// 로그인 성공 시 프론트엔드에 전달하는 DTO
+// @Builder: 빌더 패턴으로 객체를 생성할 수 있도록 지원 (Lombok)
+@Getter
+@Builder
+public class LoginResponse {
+
+    private String accessToken;
+    private String refreshToken;
+}

--- a/documind/src/main/java/com/documind/documind/domain/auth/User.java
+++ b/documind/src/main/java/com/documind/documind/domain/auth/User.java
@@ -35,12 +35,27 @@ public class User {
     @Column(nullable = false)
     private Boolean isActive = true;
 
+    // Refresh Token 저장. 로그아웃 시 NULL로 초기화하여 무효화
+    @Column(length = 512)
+    private String refreshToken;
+
     // NULL 허용 (로그인 전에는 값 없음)
     private LocalDateTime lastLoginAt;
 
     // NOT NULL, updatable=false: 최초 저장 후 변경 불가
     @Column(nullable = false, updatable = false)
     private LocalDateTime createdAt;
+
+    // 로그인 시 Refresh Token 저장 및 마지막 로그인 시각 갱신
+    public void login(String refreshToken) {
+        this.refreshToken = refreshToken;
+        this.lastLoginAt = LocalDateTime.now();
+    }
+
+    // 로그아웃 시 Refresh Token을 NULL로 초기화하여 재사용 차단
+    public void logout() {
+        this.refreshToken = null;
+    }
 
     // DB에 INSERT 되기 직전에 자동 실행되는 메서드
     @PrePersist

--- a/documind/src/main/java/com/documind/documind/domain/auth/UserRepository.java
+++ b/documind/src/main/java/com/documind/documind/domain/auth/UserRepository.java
@@ -9,4 +9,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     // username으로 사용자를 조회. 로그인 시 사용
     Optional<User> findByUsername(String username);
+
+    // Refresh Token으로 사용자를 조회. 토큰 재발급 시 사용
+    Optional<User> findByRefreshToken(String refreshToken);
 }

--- a/documind/src/main/java/com/documind/documind/global/auth/AccessDeniedHandlerImpl.java
+++ b/documind/src/main/java/com/documind/documind/global/auth/AccessDeniedHandlerImpl.java
@@ -1,0 +1,27 @@
+package com.documind.documind.global.auth;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+// 인증은 됐지만 권한이 없는 요청(USER가 /api/admin 접근 등)이 발생할 때 403을 반환
+// AccessDeniedHandler: Spring Security의 권한 부족 핸들러 인터페이스
+@Component
+public class AccessDeniedHandlerImpl implements AccessDeniedHandler {
+
+    @Override
+    public void handle(HttpServletRequest request,
+                       HttpServletResponse response,
+                       AccessDeniedException accessDeniedException) throws IOException {
+
+        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter().write("{\"success\":false,\"data\":null,\"message\":\"접근 권한이 없습니다.\"}");
+    }
+}

--- a/documind/src/main/java/com/documind/documind/global/auth/AuthEntryPoint.java
+++ b/documind/src/main/java/com/documind/documind/global/auth/AuthEntryPoint.java
@@ -1,0 +1,27 @@
+package com.documind.documind.global.auth;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+// 인증되지 않은 요청(토큰 없음 또는 만료)이 보호된 경로에 접근할 때 401을 반환
+// AuthenticationEntryPoint: Spring Security의 인증 실패 진입점 인터페이스
+@Component
+public class AuthEntryPoint implements AuthenticationEntryPoint {
+
+    @Override
+    public void commence(HttpServletRequest request,
+                         HttpServletResponse response,
+                         AuthenticationException authException) throws IOException {
+
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter().write("{\"success\":false,\"data\":null,\"message\":\"인증이 필요합니다.\"}");
+    }
+}

--- a/documind/src/main/java/com/documind/documind/global/auth/JwtProvider.java
+++ b/documind/src/main/java/com/documind/documind/global/auth/JwtProvider.java
@@ -23,6 +23,9 @@ public class JwtProvider {
     @Value("${jwt.expiration}")
     private long expiration;
 
+    @Value("${jwt.refresh-expiration}")
+    private long refreshExpiration;
+
     private SecretKey key;
 
     // @PostConstruct: 빈 생성 후 의존성 주입이 완료된 시점에 실행. secret으로 서명 키를 초기화
@@ -39,6 +42,17 @@ public class JwtProvider {
                 .claim("role", role)
                 .issuedAt(now)
                 .expiration(new Date(now.getTime() + expiration))
+                .signWith(key)
+                .compact();
+    }
+
+    // username만 담아 Refresh Token을 생성. role 정보는 포함하지 않음
+    public String generateRefreshToken(String username) {
+        Date now = new Date();
+        return Jwts.builder()
+                .subject(username)
+                .issuedAt(now)
+                .expiration(new Date(now.getTime() + refreshExpiration))
                 .signWith(key)
                 .compact();
     }

--- a/documind/src/main/java/com/documind/documind/global/common/ApiResponse.java
+++ b/documind/src/main/java/com/documind/documind/global/common/ApiResponse.java
@@ -1,0 +1,34 @@
+package com.documind.documind.global.common;
+
+import lombok.Getter;
+
+// 모든 API 응답을 감싸는 공통 응답 형식. 프론트엔드가 success 필드로 성공/실패를 판단
+// @Getter: 모든 필드의 getter 메서드 자동 생성 (Lombok)
+@Getter
+public class ApiResponse<T> {
+
+    private final boolean success;
+    private final T data;
+    private final String message;
+
+    private ApiResponse(boolean success, T data, String message) {
+        this.success = success;
+        this.data = data;
+        this.message = message;
+    }
+
+    // 성공 응답 (data 포함)
+    public static <T> ApiResponse<T> success(T data) {
+        return new ApiResponse<>(true, data, null);
+    }
+
+    // 성공 응답 (data 없이 메시지만)
+    public static <T> ApiResponse<T> success(String message) {
+        return new ApiResponse<>(true, null, message);
+    }
+
+    // 실패 응답
+    public static <T> ApiResponse<T> fail(String message) {
+        return new ApiResponse<>(false, null, message);
+    }
+}

--- a/documind/src/main/java/com/documind/documind/global/config/SecurityConfig.java
+++ b/documind/src/main/java/com/documind/documind/global/config/SecurityConfig.java
@@ -1,5 +1,7 @@
 package com.documind.documind.global.config;
 
+import com.documind.documind.global.auth.AccessDeniedHandlerImpl;
+import com.documind.documind.global.auth.AuthEntryPoint;
 import com.documind.documind.global.auth.JwtAuthenticationFilter;
 import com.documind.documind.global.auth.JwtProvider;
 import lombok.RequiredArgsConstructor;
@@ -23,6 +25,8 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 public class SecurityConfig {
 
     private final JwtProvider jwtProvider;
+    private final AuthEntryPoint authEntryPoint;
+    private final AccessDeniedHandlerImpl accessDeniedHandler;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -40,6 +44,11 @@ public class SecurityConfig {
                     .requestMatchers("/api/auth/login").permitAll()
                     // 나머지: USER는 로그인 불필요이므로 전체 허용
                     .anyRequest().permitAll()
+            )
+            // 인증/권한 예외 처리 핸들러 등록
+            .exceptionHandling(ex -> ex
+                    .authenticationEntryPoint(authEntryPoint)
+                    .accessDeniedHandler(accessDeniedHandler)
             )
             // JWT 필터를 UsernamePasswordAuthenticationFilter 앞에 등록
             .addFilterBefore(


### PR DESCRIPTION
## 🔗 관련 이슈
closes #2

  ## 📝 작업 내용
  - 이슈 #2 커밋 시 누락된 인증 관련 파일 추가
    - AuthController, AuthService, LoginRequest,
  LoginResponse
    - AuthEntryPoint, AccessDeniedHandlerImpl
    - ApiResponse, ErrorCode, CustomException,
  GlobalExceptionHandler
  - User.java refreshToken 필드 및 login/logout 메서드
  추가
  - UserRepository.java findByRefreshToken 추가
  - JwtProvider.java generateRefreshToken 추가
  - SecurityConfig.java exceptionHandling 추가
  - application.yaml refresh-expiration 추가

  ## 🔄 변경 유형
  - [x] 🐛 Bug Fix

  ## ✅ 셀프 리뷰 체크리스트
  - [x] 컨벤션을 준수했는가?
  - [x] 불필요한 print / log 문을 제거했는가?
  - [x] 하드코딩된 값이 없는가?
  - [x] 이해하기 어려운 로직에 주석을 추가했는가?