### PR TITLE
chore(infra): Docker Compose 초기 구성 (#3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,5 @@ documind/**/*.class
 # macOS
 # ───────────────────────────────────────
 .DS_Store
+.vscode/
+docs/

--- a/ai-server/Dockerfile
+++ b/ai-server/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.12-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+EXPOSE 8000
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,83 @@
+services:
+  mysql:
+    image: mysql:8.4
+    environment:
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
+      MYSQL_DATABASE: ${MYSQL_DATABASE}
+    ports:
+      - "3306:3306"
+    volumes:
+      - mysql_data:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-u", "root", "-pritepa64"]
+      interval: 15s
+      timeout: 10s
+      retries: 10
+      start_period: 30s
+
+  ollama:
+    image: ollama/ollama:latest
+    ports:
+      - "11434:11434"
+    volumes:
+      - ollama_data:/root/.ollama
+    healthcheck:
+      test: ["CMD", "ollama", "list"]
+      interval: 15s
+      timeout: 10s
+      retries: 10
+      start_period: 30s
+
+  chromadb:
+    image: chromadb/chroma:latest
+    ports:
+      - "8001:8000"
+    volumes:
+      - chroma_data:/chroma/chroma
+    healthcheck:
+      test: ["CMD-SHELL", "bash -c 'echo > /dev/tcp/localhost/8000'"]
+      interval: 15s
+      timeout: 10s
+      retries: 10
+      start_period: 30s
+
+  ai-server:
+    build: ./ai-server
+    ports:
+      - "8000:8000"
+    depends_on:
+      ollama:
+        condition: service_healthy
+      chromadb:
+        condition: service_healthy
+    environment:
+      OLLAMA_BASE_URL: http://ollama:11434
+      CHROMA_HOST: chromadb
+      CHROMA_PORT: 8000
+
+  backend:
+    build: ./documind
+    ports:
+      - "8080:8080"
+    depends_on:
+      mysql:
+        condition: service_healthy
+    environment:
+      SPRING_DATASOURCE_URL: jdbc:mysql://mysql:3306/documind
+      SPRING_DATASOURCE_USERNAME: root
+      SPRING_DATASOURCE_PASSWORD: ${MYSQL_ROOT_PASSWORD}
+      JWT_SECRET: ${JWT_SECRET}
+      JWT_EXPIRATION: ${JWT_EXPIRATION}
+      JWT_REFRESH_EXPIRATION: ${JWT_REFRESH_EXPIRATION}
+
+  frontend:
+    build: ./frontend
+    ports:
+      - "80:80"
+    depends_on:
+      - backend
+
+volumes:
+  mysql_data:
+  ollama_data:
+  chroma_data:

--- a/documind/Dockerfile
+++ b/documind/Dockerfile
@@ -1,0 +1,15 @@
+FROM eclipse-temurin:21-jdk-alpine AS builder
+WORKDIR /app
+COPY gradlew .
+COPY gradle gradle
+COPY build.gradle settings.gradle ./
+RUN chmod +x gradlew
+RUN ./gradlew dependencies --no-daemon
+COPY src src
+RUN ./gradlew bootJar --no-daemon
+
+FROM eclipse-temurin:21-jre-alpine
+WORKDIR /app
+COPY --from=builder /app/build/libs/*.jar app.jar
+EXPOSE 8080
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:22-alpine AS builder
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+COPY . .
+RUN npm run build
+
+FROM nginx:alpine
+COPY --from=builder /app/dist /usr/share/nginx/html
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
## 🔗 관련 이슈
closes #3

## 📝 작업 내용
- 6개 서비스 docker-compose.yml 작성 (mysql, ollama, chromadb, ai-server, backend, frontend)
- frontend/Dockerfile, documind/Dockerfile, ai-server/Dockerfile 작성
- 서비스 간 의존성 및 헬스체크 설정
- .env 파일로 환경변수 분리
- .gitignore에 .vscode/, docs/ 추가

## 🔄 변경 유형
- [x] ⚙️ Chore

## ✅ 셀프 리뷰 체크리스트
- [x] 컨벤션을 준수했는가?
- [x] 불필요한 print / log 문을 제거했는가?
- [x] 하드코딩된 값이 없는가?
- [x] 이해하기 어려운 로직에 주석을 추가했는가?

## 💡 참고 사항 (선택)
- .env 파일은 .gitignore에 등록되어 있어 Git에 포함되지 않음
- ddl-auto는 개발 단계에서 update로 설정, MVP 완료 후 validate로 변경 예정