### PR TITLE
feat(document): 문서 업로드 API 구현 및 FastAPI 연동 (#4)

### DIFF
--- a/ai-server/.dockerignore
+++ b/ai-server/.dockerignore
@@ -1,0 +1,8 @@
+venv/
+chroma_db/
+__pycache__/
+*.pyc
+*.pyo
+debug_text.py
+check_chunks.py
+chunking_report.md

--- a/ai-server/Dockerfile
+++ b/ai-server/Dockerfile
@@ -1,4 +1,10 @@
 FROM python:3.12-slim
+
+# opendataloader-pdf가 내부적으로 Java CLI를 사용하므로 JRE 설치 필요
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends default-jre-headless && \
+    rm -rf /var/lib/apt/lists/*
+
 WORKDIR /app
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt

--- a/ai-server/check_chunks.py
+++ b/ai-server/check_chunks.py
@@ -1,0 +1,39 @@
+import chromadb
+import os
+
+# 환경변수로 로컬/Docker 분기
+# 로컬: python check_chunks.py
+# Docker 확인: CHROMA_HOST=localhost CHROMA_PORT=8001 python check_chunks.py
+CHROMA_HOST = os.getenv("CHROMA_HOST")
+CHROMA_PORT = int(os.getenv("CHROMA_PORT", "8001"))
+
+if CHROMA_HOST:
+    client = chromadb.HttpClient(host=CHROMA_HOST, port=CHROMA_PORT)
+else:
+    client = chromadb.PersistentClient(path="./chroma_db")
+
+collection = client.get_collection("documents")
+
+import sys
+if len(sys.argv) == 1:
+    # 인자 없으면 목록만 출력
+    all_results = collection.get(include=["metadatas"])
+    doc_ids = sorted(set(m["document_id"] for m in all_results["metadatas"]))
+    print(f"저장된 document_id 목록: {doc_ids}")
+    print(f"전체 청크 수: {len(all_results['metadatas'])}개\n")
+    for doc_id in doc_ids:
+        count = sum(1 for m in all_results["metadatas"] if m["document_id"] == doc_id)
+        source = next(m["source"] for m in all_results["metadatas"] if m["document_id"] == doc_id)
+        print(f"  document_id={doc_id} | {source} | {count}청크")
+else:
+    # 인자로 document_id 지정하면 청크 내용 출력
+    doc_id = sys.argv[1]
+    results = collection.get(
+        where={"document_id": doc_id},
+        include=["documents"]
+    )
+    print(f"document_id={doc_id} 총 청크 수: {len(results['documents'])}개\n")
+    for i, doc in enumerate(results["documents"]):
+        print(f"=== 청크 {i+1} === ({len(doc)}글자)")
+        print(doc)
+        print()

--- a/ai-server/langfuse_callback.py
+++ b/ai-server/langfuse_callback.py
@@ -1,0 +1,21 @@
+import os
+
+# LANGFUSE_SECRET_KEY가 설정된 경우에만 Langfuse SDK를 임포트해 트레이싱을 활성화한다.
+# 환경변수가 없으면 None을 반환해 파이프라인이 그대로 실행되도록 한다 (트레이싱 선택적 적용).
+_LANGFUSE_ENABLED = bool(os.getenv("LANGFUSE_SECRET_KEY"))
+
+
+def get_langfuse_handler(**kwargs):
+    """
+    LangChain 체인에 주입할 Langfuse CallbackHandler를 반환한다.
+    LANGFUSE_SECRET_KEY 미설정 시 None을 반환한다.
+
+    langfuse 4.x에서 CallbackHandler는 langfuse.langchain 모듈에 위치한다.
+    SDK는 LANGFUSE_SECRET_KEY, LANGFUSE_PUBLIC_KEY, LANGFUSE_HOST 환경변수를
+    자동으로 읽으므로 별도 인자 없이 호출 가능하다.
+    """
+    if not _LANGFUSE_ENABLED:
+        return None
+
+    from langfuse.langchain import CallbackHandler
+    return CallbackHandler(**kwargs)

--- a/ai-server/main.py
+++ b/ai-server/main.py
@@ -1,17 +1,149 @@
-from fastapi import FastAPI
-from langchain_ollama import ChatOllama
+from fastapi import FastAPI, UploadFile, File, Form, HTTPException, Request
+from fastapi.exceptions import RequestValidationError
+from fastapi.responses import JSONResponse
+from langchain_opendataloader_pdf import OpenDataLoaderPDFLoader
+from langchain_text_splitters import RecursiveCharacterTextSplitter
+from langchain_ollama import OllamaEmbeddings
 import chromadb
+import tempfile
+import os
+import re
+from langfuse_callback import get_langfuse_handler
 
-app = FastAPI()
+app = FastAPI(title="DocuMind AI Server", version="1.0.0")
 
-llm = ChatOllama(
-    model="exaone3.5:7.8b",
-    base_url="http://localhost:11434"
+# 환경변수로 로컬/Docker 환경 분기
+# 로컬: OLLAMA_BASE_URL 미설정 시 localhost 사용
+# Docker: OLLAMA_BASE_URL=http://ollama:11434
+OLLAMA_BASE_URL = os.getenv("OLLAMA_BASE_URL", "http://localhost:11434")
+
+embeddings = OllamaEmbeddings(
+    model="qwen3-embedding:4b",
+    base_url=OLLAMA_BASE_URL
 )
 
-client = chromadb.PersistentClient(path="./chroma_db")
+# 환경변수로 ChromaDB 모드 분기
+# 로컬: CHROMA_HOST 미설정 시 in-process PersistentClient 사용
+# Docker: CHROMA_HOST=chromadb 설정 시 서버 모드 HttpClient 사용
+CHROMA_HOST = os.getenv("CHROMA_HOST")
+if CHROMA_HOST:
+    client = chromadb.HttpClient(host=CHROMA_HOST, port=8000)
+else:
+    client = chromadb.PersistentClient(path="./chroma_db")
+
 collection = client.get_or_create_collection("documents")
+
+splitter = RecursiveCharacterTextSplitter(
+    chunk_size=500,
+    chunk_overlap=0,  # 후처리에서 정확한 문자 단위 overlap을 적용하므로 0으로 설정
+    length_function=len
+)
+
+# LANGFUSE_SECRET_KEY 설정 시 Langfuse 클라이언트를 초기화한다.
+# 미설정 시 None으로 유지해 트레이싱 없이 파이프라인이 실행된다.
+_langfuse = None
+if os.getenv("LANGFUSE_SECRET_KEY"):
+    from langfuse import Langfuse
+    _langfuse = Langfuse()
+
+
+@app.exception_handler(RequestValidationError)
+async def validation_exception_handler(request: Request, exc: RequestValidationError):
+    import logging
+    logging.error(f"[422 DETAIL] {exc.errors()}")
+    return JSONResponse(status_code=422, content={"detail": exc.errors()})
+
 
 @app.get("/health")
 def health():
     return {"status": "ok"}
+
+
+async def _run_upload_pipeline(tmp_path: str, filename: str, document_id: int) -> int:
+    """PDF 전처리 파이프라인: 로딩 → 청킹 → overlap 후처리 → 임베딩 → ChromaDB 저장"""
+
+    async def _execute() -> int:
+        loader = OpenDataLoaderPDFLoader(
+            file_path=tmp_path,
+            format="markdown"
+        )
+        docs = loader.load()
+
+        # 전체 텍스트 합치기 (페이지 경계 무관하게 청킹하기 위함)
+        full_text = "\n".join([doc.page_content for doc in docs])
+
+        # PDF 파서 아티팩트: 문장 중간 삼중 개행 제거 (예: "같\n\n\n다" → "같다")
+        full_text = re.sub(r'([가-힣])\n{3,}([가-힣])', r'\1\2', full_text)
+        # 페이지 경계의 과도한 개행 정규화 (삼중 이상 → 이중)
+        # "\n".join()으로 붙인 페이지 경계에서 \n\n\n이 생겨 overlap 버퍼가 리셋되는 문제 방지
+        full_text = re.sub(r'\n{3,}', '\n\n', full_text)
+
+        # 합친 텍스트로 청킹 (chunk_overlap=0으로 clean하게 분리)
+        raw_texts = splitter.split_text(full_text)
+
+        # 문자 단위 50글자 overlap 후처리 적용
+        # create_documents()에 리스트를 넘기면 각 항목에 splitter를 재적용하므로
+        # 텍스트를 직접 조작한 뒤 embedding/저장 루프에서 바로 사용
+        overlapped_texts = []
+        for i, text in enumerate(raw_texts):
+            if i == 0:
+                overlapped_texts.append(text)
+            else:
+                overlap = raw_texts[i - 1][-50:]
+                overlapped_texts.append(overlap + "\n" + text)
+
+        for i, text in enumerate(overlapped_texts):
+            vector = embeddings.embed_query(text)
+            collection.add(
+                ids=[f"{document_id}_{i}"],
+                embeddings=[vector],
+                documents=[text],
+                metadatas=[{
+                    "document_id": str(document_id),
+                    "source": filename,
+                    "page": ""
+                }]
+            )
+
+        return len(overlapped_texts)
+
+    # Langfuse 4.x: start_as_current_observation()은 async context manager로 동작한다
+    # _langfuse가 None이면 트레이싱 없이 파이프라인을 그대로 실행한다
+    if _langfuse:
+        with _langfuse.start_as_current_observation(
+            name="document-upload-pipeline",
+            as_type="chain",
+            metadata={"document_id": document_id, "filename": filename}
+        ):
+            chunk_count = await _execute()
+            _langfuse.set_current_trace_io(output={"chunks": chunk_count})
+            _langfuse.flush()
+            return chunk_count
+    else:
+        return await _execute()
+
+
+@app.post("/documents")
+async def upload_document(
+    file: UploadFile = File(...),
+    document_id: int = Form(None)
+):
+    import logging
+    logging.warning(f"[DEBUG] filename={file.filename}, content_type={file.content_type}, document_id={document_id}")
+    if not file.filename.endswith(".pdf"):
+        raise HTTPException(status_code=400, detail="PDF 파일만 허용됩니다.")
+
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".pdf") as tmp:
+        content = await file.read()
+        tmp.write(content)
+        tmp_path = tmp.name
+
+    try:
+        chunk_count = await _run_upload_pipeline(tmp_path, file.filename, document_id)
+        return {
+            "status": "success",
+            "filename": file.filename,
+            "chunks": chunk_count
+        }
+    finally:
+        os.unlink(tmp_path)

--- a/ai-server/requirements.txt
+++ b/ai-server/requirements.txt
@@ -39,6 +39,9 @@ jsonschema==4.26.0
 jsonschema-specifications==2025.9.1
 kubernetes==35.0.0
 langchain==1.2.13
+langfuse==4.2.0
+langchain-opendataloader-pdf==2.0.0
+opendataloader-pdf==2.2.1
 langchain-classic==1.0.3
 langchain-community==0.4.1
 langchain-core==1.2.23

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,6 +54,9 @@ services:
       OLLAMA_BASE_URL: http://ollama:11434
       CHROMA_HOST: chromadb
       CHROMA_PORT: 8000
+      LANGFUSE_HOST: http://langfuse-web:3000
+      LANGFUSE_SECRET_KEY: ${LANGFUSE_SECRET_KEY}
+      LANGFUSE_PUBLIC_KEY: ${LANGFUSE_PUBLIC_KEY}
 
   backend:
     build: ./documind
@@ -63,6 +66,7 @@ services:
       mysql:
         condition: service_healthy
     environment:
+      FASTAPI_URL: http://ai-server:8000
       SPRING_DATASOURCE_URL: jdbc:mysql://mysql:3306/documind
       SPRING_DATASOURCE_USERNAME: root
       SPRING_DATASOURCE_PASSWORD: ${MYSQL_ROOT_PASSWORD}
@@ -77,7 +81,192 @@ services:
     depends_on:
       - backend
 
+  # ── Langfuse 스택 ────────────────────────────────────────────────────────────
+
+  # Langfuse 전용 PostgreSQL. DocuMind MySQL과 완전히 분리
+  langfuse-postgres:
+    image: postgres:16
+    environment:
+      POSTGRES_USER: langfuse
+      POSTGRES_PASSWORD: ${LANGFUSE_POSTGRES_PASSWORD}
+      POSTGRES_DB: langfuse
+    volumes:
+      - langfuse_postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U langfuse -d langfuse"]
+      interval: 15s
+      timeout: 10s
+      retries: 10
+      start_period: 30s
+
+  # 트레이스/분석 데이터 저장소. Langfuse v3 필수 요구사항
+  langfuse-clickhouse:
+    image: clickhouse/clickhouse-server:latest
+    environment:
+      CLICKHOUSE_USER: clickhouse
+      CLICKHOUSE_PASSWORD: ${LANGFUSE_CLICKHOUSE_PASSWORD}
+      CLICKHOUSE_DB: default
+    volumes:
+      - langfuse_clickhouse_data:/var/lib/clickhouse
+      # Keeper 설정 주입: ReplicatedMergeTree + ON CLUSTER default 사용을 위해 필수
+      - ./langfuse/clickhouse/keeper.xml:/etc/clickhouse-server/config.d/keeper.xml
+    healthcheck:
+      test: ["CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:8123/ping || exit 1"]
+      interval: 15s
+      timeout: 10s
+      retries: 10
+      start_period: 30s
+
+  # web ↔ worker 비동기 작업 큐
+  langfuse-redis:
+    image: redis:7
+    command: redis-server --requirepass ${LANGFUSE_REDIS_PASSWORD}
+    volumes:
+      - langfuse_redis_data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "-a", "${LANGFUSE_REDIS_PASSWORD}", "ping"]
+      interval: 15s
+      timeout: 10s
+      retries: 10
+      start_period: 20s
+
+  # 트레이스·미디어 파일 저장용 오브젝트 스토리지. Langfuse v3 필수 요구사항
+  langfuse-minio:
+    image: minio/minio:latest
+    command: server /data --console-address ":9001"
+    environment:
+      MINIO_ROOT_USER: ${LANGFUSE_MINIO_ROOT_USER}
+      MINIO_ROOT_PASSWORD: ${LANGFUSE_MINIO_ROOT_PASSWORD}
+    volumes:
+      - langfuse_minio_data:/data
+    healthcheck:
+      test: ["CMD-SHELL", "bash -c 'echo > /dev/tcp/localhost/9000'"]
+      interval: 15s
+      timeout: 10s
+      retries: 10
+      start_period: 20s
+
+  # MinIO 버킷 초기화. langfuse-minio가 healthy 상태가 된 직후 한 번 실행하고 종료
+  langfuse-minio-init:
+    image: minio/mc:latest
+    depends_on:
+      langfuse-minio:
+        condition: service_healthy
+    entrypoint: >
+      /bin/sh -c "
+      mc alias set local http://langfuse-minio:9000 ${LANGFUSE_MINIO_ROOT_USER} ${LANGFUSE_MINIO_ROOT_PASSWORD} &&
+      mc mb local/langfuse --ignore-existing;
+      "
+
+  # Langfuse REST API 서버 + 웹 UI (localhost:3000으로 접속)
+  langfuse-web:
+    image: langfuse/langfuse:3
+    ports:
+      - "3000:3000"
+    depends_on:
+      langfuse-postgres:
+        condition: service_healthy
+      langfuse-clickhouse:
+        condition: service_healthy
+      langfuse-redis:
+        condition: service_healthy
+      langfuse-minio:
+        condition: service_healthy
+    environment:
+      DATABASE_URL: postgresql://langfuse:${LANGFUSE_POSTGRES_PASSWORD}@langfuse-postgres:5432/langfuse
+      NEXTAUTH_URL: http://localhost:3000
+      NEXTAUTH_SECRET: ${LANGFUSE_NEXTAUTH_SECRET}
+      SALT: ${LANGFUSE_SALT}
+      ENCRYPTION_KEY: ${LANGFUSE_ENCRYPTION_KEY}
+      CLICKHOUSE_MIGRATION_URL: clickhouse://langfuse-clickhouse:9000
+      CLICKHOUSE_URL: http://langfuse-clickhouse:8123
+      CLICKHOUSE_USER: clickhouse
+      CLICKHOUSE_PASSWORD: ${LANGFUSE_CLICKHOUSE_PASSWORD}
+      REDIS_HOST: langfuse-redis
+      REDIS_PORT: 6379
+      REDIS_AUTH: ${LANGFUSE_REDIS_PASSWORD}
+      # S3 이벤트 업로드: 트레이스 raw 이벤트 저장
+      LANGFUSE_S3_EVENT_UPLOAD_ENABLED: "true"
+      LANGFUSE_S3_EVENT_UPLOAD_BUCKET: langfuse
+      LANGFUSE_S3_EVENT_UPLOAD_ENDPOINT: http://langfuse-minio:9000
+      LANGFUSE_S3_EVENT_UPLOAD_ACCESS_KEY_ID: ${LANGFUSE_MINIO_ROOT_USER}
+      LANGFUSE_S3_EVENT_UPLOAD_SECRET_ACCESS_KEY: ${LANGFUSE_MINIO_ROOT_PASSWORD}
+      LANGFUSE_S3_EVENT_UPLOAD_FORCE_PATH_STYLE: "true"
+      LANGFUSE_S3_EVENT_UPLOAD_REGION: us-east-1
+      # S3 미디어 업로드: 트레이스에 첨부된 이미지·파일 저장
+      LANGFUSE_S3_MEDIA_UPLOAD_ENABLED: "true"
+      LANGFUSE_S3_MEDIA_UPLOAD_BUCKET: langfuse
+      LANGFUSE_S3_MEDIA_UPLOAD_ENDPOINT: http://langfuse-minio:9000
+      LANGFUSE_S3_MEDIA_UPLOAD_ACCESS_KEY_ID: ${LANGFUSE_MINIO_ROOT_USER}
+      LANGFUSE_S3_MEDIA_UPLOAD_SECRET_ACCESS_KEY: ${LANGFUSE_MINIO_ROOT_PASSWORD}
+      LANGFUSE_S3_MEDIA_UPLOAD_FORCE_PATH_STYLE: "true"
+      LANGFUSE_S3_MEDIA_UPLOAD_REGION: us-east-1
+      # S3 배치 내보내기
+      LANGFUSE_S3_BATCH_EXPORT_ENABLED: "true"
+      LANGFUSE_S3_BATCH_EXPORT_BUCKET: langfuse
+      LANGFUSE_S3_BATCH_EXPORT_ENDPOINT: http://langfuse-minio:9000
+      LANGFUSE_S3_BATCH_EXPORT_ACCESS_KEY_ID: ${LANGFUSE_MINIO_ROOT_USER}
+      LANGFUSE_S3_BATCH_EXPORT_SECRET_ACCESS_KEY: ${LANGFUSE_MINIO_ROOT_PASSWORD}
+      LANGFUSE_S3_BATCH_EXPORT_FORCE_PATH_STYLE: "true"
+      LANGFUSE_S3_BATCH_EXPORT_REGION: us-east-1
+    healthcheck:
+      test: ["CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:3000/api/public/health || exit 1"]
+      interval: 15s
+      timeout: 10s
+      retries: 10
+      start_period: 60s
+
+  # 비동기 트레이스 처리 워커. web과 동일한 환경변수 공유
+  langfuse-worker:
+    image: langfuse/langfuse-worker:3
+    depends_on:
+      langfuse-postgres:
+        condition: service_healthy
+      langfuse-clickhouse:
+        condition: service_healthy
+      langfuse-redis:
+        condition: service_healthy
+      langfuse-minio:
+        condition: service_healthy
+    environment:
+      DATABASE_URL: postgresql://langfuse:${LANGFUSE_POSTGRES_PASSWORD}@langfuse-postgres:5432/langfuse
+      NEXTAUTH_SECRET: ${LANGFUSE_NEXTAUTH_SECRET}
+      SALT: ${LANGFUSE_SALT}
+      ENCRYPTION_KEY: ${LANGFUSE_ENCRYPTION_KEY}
+      CLICKHOUSE_MIGRATION_URL: clickhouse://langfuse-clickhouse:9000
+      CLICKHOUSE_URL: http://langfuse-clickhouse:8123
+      CLICKHOUSE_USER: clickhouse
+      CLICKHOUSE_PASSWORD: ${LANGFUSE_CLICKHOUSE_PASSWORD}
+      REDIS_HOST: langfuse-redis
+      REDIS_PORT: 6379
+      REDIS_AUTH: ${LANGFUSE_REDIS_PASSWORD}
+      LANGFUSE_S3_EVENT_UPLOAD_ENABLED: "true"
+      LANGFUSE_S3_EVENT_UPLOAD_BUCKET: langfuse
+      LANGFUSE_S3_EVENT_UPLOAD_ENDPOINT: http://langfuse-minio:9000
+      LANGFUSE_S3_EVENT_UPLOAD_ACCESS_KEY_ID: ${LANGFUSE_MINIO_ROOT_USER}
+      LANGFUSE_S3_EVENT_UPLOAD_SECRET_ACCESS_KEY: ${LANGFUSE_MINIO_ROOT_PASSWORD}
+      LANGFUSE_S3_EVENT_UPLOAD_FORCE_PATH_STYLE: "true"
+      LANGFUSE_S3_EVENT_UPLOAD_REGION: us-east-1
+      LANGFUSE_S3_MEDIA_UPLOAD_ENABLED: "true"
+      LANGFUSE_S3_MEDIA_UPLOAD_BUCKET: langfuse
+      LANGFUSE_S3_MEDIA_UPLOAD_ENDPOINT: http://langfuse-minio:9000
+      LANGFUSE_S3_MEDIA_UPLOAD_ACCESS_KEY_ID: ${LANGFUSE_MINIO_ROOT_USER}
+      LANGFUSE_S3_MEDIA_UPLOAD_SECRET_ACCESS_KEY: ${LANGFUSE_MINIO_ROOT_PASSWORD}
+      LANGFUSE_S3_MEDIA_UPLOAD_FORCE_PATH_STYLE: "true"
+      LANGFUSE_S3_MEDIA_UPLOAD_REGION: us-east-1
+      LANGFUSE_S3_BATCH_EXPORT_ENABLED: "true"
+      LANGFUSE_S3_BATCH_EXPORT_BUCKET: langfuse
+      LANGFUSE_S3_BATCH_EXPORT_ENDPOINT: http://langfuse-minio:9000
+      LANGFUSE_S3_BATCH_EXPORT_ACCESS_KEY_ID: ${LANGFUSE_MINIO_ROOT_USER}
+      LANGFUSE_S3_BATCH_EXPORT_SECRET_ACCESS_KEY: ${LANGFUSE_MINIO_ROOT_PASSWORD}
+      LANGFUSE_S3_BATCH_EXPORT_REGION: us-east-1
+      LANGFUSE_S3_BATCH_EXPORT_FORCE_PATH_STYLE: "true"
+
 volumes:
   mysql_data:
   ollama_data:
   chroma_data:
+  langfuse_postgres_data:
+  langfuse_clickhouse_data:
+  langfuse_redis_data:
+  langfuse_minio_data:

--- a/documind/src/main/java/com/documind/documind/domain/auth/AuthController.java
+++ b/documind/src/main/java/com/documind/documind/domain/auth/AuthController.java
@@ -5,7 +5,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.userdetails.UserDetails;
+
 import org.springframework.web.bind.annotation.*;
 
 // 인증 관련 엔드포인트를 처리하는 컨트롤러
@@ -27,10 +27,10 @@ public class AuthController {
     }
 
     // POST /api/auth/logout - 로그아웃
-    // @AuthenticationPrincipal: SecurityContext에서 현재 인증된 사용자 정보를 주입
+    // @AuthenticationPrincipal: SecurityContext에 저장된 principal을 주입. 필터에서 String(username)으로 저장했으므로 String으로 받는다
     @PostMapping("/logout")
-    public ResponseEntity<ApiResponse<Void>> logout(@AuthenticationPrincipal UserDetails userDetails) {
-        authService.logout(userDetails.getUsername());
+    public ResponseEntity<ApiResponse<Void>> logout(@AuthenticationPrincipal String username) {
+        authService.logout(username);
         return ResponseEntity.ok(ApiResponse.success("로그아웃 되었습니다."));
     }
 

--- a/documind/src/main/java/com/documind/documind/domain/document/Document.java
+++ b/documind/src/main/java/com/documind/documind/domain/document/Document.java
@@ -71,4 +71,25 @@ public class Document {
     protected void onCreate() {
         this.createdAt = LocalDateTime.now();
     }
+
+    // 정적 팩토리 메서드. 외부에서 new Document() 대신 이 메서드로 생성
+    public static Document create(User uploadedBy, Category category,
+                                  String fileName, String originalName,
+                                  Long fileSize, String mimeType) {
+        Document doc = new Document();
+        doc.uploadedBy = uploadedBy;
+        doc.category = category;
+        doc.fileName = fileName;
+        doc.originalName = originalName;
+        doc.fileSize = fileSize;
+        doc.mimeType = mimeType;
+        doc.chunkCount = 0;
+        doc.isActive = true;
+        return doc;
+    }
+
+    // FastAPI 처리 완료 후 청크 수를 업데이트하는 메서드
+    public void updateChunkCount(int chunkCount) {
+        this.chunkCount = chunkCount;
+    }
 }

--- a/documind/src/main/java/com/documind/documind/domain/document/DocumentController.java
+++ b/documind/src/main/java/com/documind/documind/domain/document/DocumentController.java
@@ -1,0 +1,31 @@
+package com.documind.documind.domain.document;
+
+import com.documind.documind.global.common.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+// 문서 관련 엔드포인트를 처리하는 컨트롤러
+@RestController
+@RequestMapping("/api/documents")
+@RequiredArgsConstructor
+public class DocumentController {
+
+    private final DocumentService documentService;
+
+    // POST /api/documents - 문서 업로드 (ADMIN 전용)
+    // @RequestParam: multipart/form-data에서 각 파트를 개별 파라미터로 바인딩
+    @PostMapping
+    public ResponseEntity<ApiResponse<DocumentUploadResponse>> upload(
+            @RequestParam("file") MultipartFile file,
+            @AuthenticationPrincipal String username
+    ) {
+        DocumentUploadResponse response = documentService.upload(file, username);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+}

--- a/documind/src/main/java/com/documind/documind/domain/document/DocumentRepository.java
+++ b/documind/src/main/java/com/documind/documind/domain/document/DocumentRepository.java
@@ -1,0 +1,7 @@
+package com.documind.documind.domain.document;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+// JpaRepository<엔티티, PK타입>를 상속받으면 기본 CRUD 메서드가 자동 생성됨
+public interface DocumentRepository extends JpaRepository<Document, Long> {
+}

--- a/documind/src/main/java/com/documind/documind/domain/document/DocumentService.java
+++ b/documind/src/main/java/com/documind/documind/domain/document/DocumentService.java
@@ -1,0 +1,72 @@
+package com.documind.documind.domain.document;
+
+import com.documind.documind.domain.auth.User;
+import com.documind.documind.domain.auth.UserRepository;
+import com.documind.documind.global.exception.CustomException;
+import com.documind.documind.global.exception.ErrorCode;
+import com.documind.documind.global.infra.fastapi.FastApiClient;
+import com.documind.documind.global.infra.fastapi.FastApiUploadResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+
+// 문서 업로드 비즈니스 로직을 담당
+@Service
+@RequiredArgsConstructor
+public class DocumentService {
+
+    private final DocumentRepository documentRepository;
+    private final UserRepository userRepository;
+    private final FastApiClient fastApiClient;
+
+    // 허용 MIME 타입 목록. PDF만 허용 (추후 docx, md 추가 예정)
+    private static final List<String> ALLOWED_MIME_TYPES = Arrays.asList(
+            "application/pdf"
+    );
+
+    @Transactional
+    public DocumentUploadResponse upload(MultipartFile file, String username) {
+        // 파일 형식 검증
+        String mimeType = file.getContentType();
+        if (mimeType == null || !ALLOWED_MIME_TYPES.contains(mimeType)) {
+            throw new CustomException(ErrorCode.INVALID_FILE_TYPE);
+        }
+
+        // 업로더 조회
+        User uploader = userRepository.findByUsername(username)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        // UUID 기반 서버 저장 파일명 생성 (확장자 유지)
+        String originalName = file.getOriginalFilename();
+        String extension = originalName != null && originalName.contains(".")
+                ? originalName.substring(originalName.lastIndexOf("."))
+                : "";
+        String fileName = UUID.randomUUID() + extension;
+
+        // Document를 DB에 먼저 저장해 PK(document_id)를 확보
+        // FastAPI 호출 시 document_id가 필요하므로 저장 후 호출 순서를 지킨다
+        Document document = Document.create(
+                uploader, null, fileName, originalName,
+                file.getSize(), mimeType
+        );
+        documentRepository.save(document);
+
+        // FastAPI에 파일 전송 → 청킹·임베딩·ChromaDB 저장 요청
+        FastApiUploadResponse fastApiResponse = fastApiClient.uploadDocument(file, document.getId());
+
+        // FastAPI 처리 완료 후 청크 수 업데이트
+        document.updateChunkCount(fastApiResponse.getChunks());
+
+        return DocumentUploadResponse.builder()
+                .documentId(document.getId())
+                .originalName(document.getOriginalName())
+                .fileSize(document.getFileSize())
+                .chunkCount(document.getChunkCount())
+                .build();
+    }
+}

--- a/documind/src/main/java/com/documind/documind/domain/document/DocumentUploadResponse.java
+++ b/documind/src/main/java/com/documind/documind/domain/document/DocumentUploadResponse.java
@@ -1,0 +1,15 @@
+package com.documind.documind.domain.document;
+
+import lombok.Builder;
+import lombok.Getter;
+
+// 문서 업로드 성공 시 클라이언트에 반환하는 DTO
+@Getter
+@Builder
+public class DocumentUploadResponse {
+
+    private Long documentId;
+    private String originalName;
+    private Long fileSize;
+    private int chunkCount;
+}

--- a/documind/src/main/java/com/documind/documind/global/config/SecurityConfig.java
+++ b/documind/src/main/java/com/documind/documind/global/config/SecurityConfig.java
@@ -7,6 +7,7 @@ import com.documind.documind.global.auth.JwtProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -40,6 +41,9 @@ public class SecurityConfig {
             .authorizeHttpRequests(auth -> auth
                     // 관리자 전용 경로: ADMIN 권한 필요
                     .requestMatchers("/api/admin/**").hasRole("ADMIN")
+                    // 문서 업로드·삭제는 ADMIN 전용
+                    .requestMatchers(HttpMethod.POST, "/api/documents").hasRole("ADMIN")
+                    .requestMatchers(HttpMethod.DELETE, "/api/documents/**").hasRole("ADMIN")
                     // 로그인 엔드포인트: 인증 없이 접근 허용
                     .requestMatchers("/api/auth/login").permitAll()
                     // 나머지: USER는 로그인 불필요이므로 전체 허용

--- a/documind/src/main/java/com/documind/documind/global/exception/ErrorCode.java
+++ b/documind/src/main/java/com/documind/documind/global/exception/ErrorCode.java
@@ -19,6 +19,12 @@ public enum ErrorCode {
     // 권한
     ACCESS_DENIED(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
 
+    // 문서
+    FILE_READ_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "파일을 읽는 중 오류가 발생했습니다."),
+    FASTAPI_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "AI 서버 문서 처리 중 오류가 발생했습니다."),
+    DOCUMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "문서를 찾을 수 없습니다."),
+    INVALID_FILE_TYPE(HttpStatus.BAD_REQUEST, "지원하지 않는 파일 형식입니다."),
+
     // 서버
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다.");
 

--- a/documind/src/main/java/com/documind/documind/global/exception/GlobalExceptionHandler.java
+++ b/documind/src/main/java/com/documind/documind/global/exception/GlobalExceptionHandler.java
@@ -4,6 +4,7 @@ import com.documind.documind.global.common.ApiResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.client.RestClientException;
 
 // 컨트롤러에서 발생하는 예외를 전역으로 처리. @RestControllerAdvice: 모든 컨트롤러에 적용
 @RestControllerAdvice
@@ -13,6 +14,15 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(CustomException.class)
     public ResponseEntity<ApiResponse<Void>> handleCustomException(CustomException e) {
         ErrorCode errorCode = e.getErrorCode();
+        return ResponseEntity
+                .status(errorCode.getHttpStatus())
+                .body(ApiResponse.fail(errorCode.getMessage()));
+    }
+
+    // FastAPI 호출 실패(연결 오류, 타임아웃, 4xx/5xx 등) 시 FASTAPI_UPLOAD_FAILED로 래핑
+    @ExceptionHandler(RestClientException.class)
+    public ResponseEntity<ApiResponse<Void>> handleRestClientException(RestClientException e) {
+        ErrorCode errorCode = ErrorCode.FASTAPI_UPLOAD_FAILED;
         return ResponseEntity
                 .status(errorCode.getHttpStatus())
                 .body(ApiResponse.fail(errorCode.getMessage()));

--- a/documind/src/main/java/com/documind/documind/global/infra/fastapi/FastApiClient.java
+++ b/documind/src/main/java/com/documind/documind/global/infra/fastapi/FastApiClient.java
@@ -1,0 +1,67 @@
+package com.documind.documind.global.infra.fastapi;
+
+import com.documind.documind.global.exception.CustomException;
+import com.documind.documind.global.exception.ErrorCode;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+
+// FastAPI 서버와 통신하는 HTTP 클라이언트
+// @Component: 스프링 빈으로 등록
+@Component
+public class FastApiClient {
+
+    private final RestTemplate restTemplate;
+    private final String baseUrl;
+
+    // application.yaml의 fastapi.url 값을 주입. Docker에서는 환경변수 FASTAPI_URL로 오버라이드
+    public FastApiClient(@Value("${fastapi.url}") String baseUrl) {
+        this.restTemplate = new RestTemplate();
+        this.baseUrl = baseUrl;
+    }
+
+    // PDF 파일과 document_id를 FastAPI에 전송해 청킹·임베딩·저장을 요청
+    public FastApiUploadResponse uploadDocument(MultipartFile file, Long documentId) {
+        // RestTemplate + HttpEntity<MultiValueMap> 방식: multipart/form-data 전송의 검증된 방법
+        // FormHttpMessageConverter가 boundary를 자동 생성하고 Content-Type 헤더에 주입함
+        MultiValueMap<String, Object> body = new LinkedMultiValueMap<>();
+
+        try {
+            byte[] bytes = file.getBytes();
+            // getFilename() 오버라이드: Content-Disposition의 filename 파라미터로 원본 파일명 전달
+            ByteArrayResource fileResource = new ByteArrayResource(bytes) {
+                @Override
+                public String getFilename() {
+                    return file.getOriginalFilename();
+                }
+            };
+            body.add("file", fileResource);
+        } catch (IOException e) {
+            throw new CustomException(ErrorCode.FILE_READ_FAILED);
+        }
+
+        // document_id는 String으로 추가: FormHttpMessageConverter가 문자열 파트로 직렬화
+        // FastAPI Form 필드는 문자열로 수신 후 int로 자동 변환함
+        body.add("document_id", documentId.toString());
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.MULTIPART_FORM_DATA);
+
+        HttpEntity<MultiValueMap<String, Object>> requestEntity = new HttpEntity<>(body, headers);
+
+        return restTemplate.postForObject(
+                baseUrl + "/documents",
+                requestEntity,
+                FastApiUploadResponse.class
+        );
+    }
+}

--- a/documind/src/main/java/com/documind/documind/global/infra/fastapi/FastApiUploadResponse.java
+++ b/documind/src/main/java/com/documind/documind/global/infra/fastapi/FastApiUploadResponse.java
@@ -1,0 +1,17 @@
+package com.documind.documind.global.infra.fastapi;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+// FastAPI POST /documents 응답을 역직렬화하는 DTO
+// FastAPI 응답 형식: {"status": "success", "filename": "...", "chunks": 42}
+@Getter
+public class FastApiUploadResponse {
+
+    private String status;
+    private String filename;
+
+    // FastAPI가 "chunks"로 내려주므로 JSON 필드명을 명시
+    @JsonProperty("chunks")
+    private int chunks;
+}

--- a/documind/src/main/resources/application.yaml
+++ b/documind/src/main/resources/application.yaml
@@ -1,6 +1,12 @@
 spring:
   application:
     name: documind
+  servlet:
+    multipart:
+      # 단일 파일 최대 크기. PDF 문서 업로드 대응
+      max-file-size: 50MB
+      # 요청 전체 최대 크기
+      max-request-size: 50MB
   datasource:
     url: jdbc:mysql://localhost:3306/documind
     username: root
@@ -8,10 +14,14 @@ spring:
     driver-class-name: com.mysql.cj.jdbc.Driver
   jpa:
     hibernate:
-      ddl-auto: validate
+      ddl-auto: update
     show-sql: true
 server:
   port: 8080
+
+fastapi:
+  # FastAPI 서버 URL. Docker에서는 환경변수 FASTAPI_URL로 오버라이드
+  url: http://localhost:8000
 
 jwt:
   # HS256 최소 256bit(32자 이상) 필요. 운영 환경에서는 환경변수로 교체

--- a/langfuse/clickhouse/keeper.xml
+++ b/langfuse/clickhouse/keeper.xml
@@ -1,0 +1,51 @@
+<clickhouse>
+    <!--
+        ClickHouse Keeper: ZooKeeper를 대체하는 내장 합의 모듈.
+        단일 노드에서 ReplicatedMergeTree 테이블을 사용하려면 반드시 활성화해야 한다.
+        Langfuse v3는 ON CLUSTER default 구문으로 테이블을 생성하므로 이 설정이 필수다.
+    -->
+    <keeper_server>
+        <tcp_port>9181</tcp_port>
+        <server_id>1</server_id>
+        <log_storage_path>/var/lib/clickhouse/coordination/log</log_storage_path>
+        <snapshot_storage_path>/var/lib/clickhouse/coordination/snapshots</snapshot_storage_path>
+        <coordination_settings>
+            <operation_timeout_ms>10000</operation_timeout_ms>
+            <session_timeout_ms>30000</session_timeout_ms>
+            <raft_logs_level>warning</raft_logs_level>
+        </coordination_settings>
+        <raft_configuration>
+            <server>
+                <id>1</id>
+                <hostname>localhost</hostname>
+                <port>9234</port>
+            </server>
+        </raft_configuration>
+    </keeper_server>
+
+    <!-- ZooKeeper 연결 정보: Keeper가 내장돼 있으므로 localhost를 가리킨다 -->
+    <zookeeper>
+        <node>
+            <host>localhost</host>
+            <port>9181</port>
+        </node>
+    </zookeeper>
+
+    <!-- 클러스터 정의: Langfuse가 ON CLUSTER default로 테이블을 생성할 때 이 클러스터를 찾는다 -->
+    <remote_servers>
+        <default>
+            <shard>
+                <replica>
+                    <host>langfuse-clickhouse</host>
+                    <port>9000</port>
+                </replica>
+            </shard>
+        </default>
+    </remote_servers>
+
+    <!-- 복제 테이블 경로에 삽입되는 매크로 값 -->
+    <macros>
+        <shard>01</shard>
+        <replica>01</replica>
+    </macros>
+</clickhouse>


### PR DESCRIPTION
## 🔗 관련 이슈
closes #4 

## 📝 작업 내용
 - POST /api/documents 문서 업로드 API 구현
 - FastAPI PDF 전처리 파이프라인 (청킹·임베딩·ChromaDB 저장)                                                      
 - Langfuse 트레이싱 연동        

## 🔄 변경 유형
- [x] ✨ Feature

## ✅ 셀프 리뷰 체크리스트
- [ ] 컨벤션을 준수했는가?
- [ ] 불필요한 print / log 문을 제거했는가?
- [ ] 하드코딩된 값이 없는가?
- [ ] 이해하기 어려운 로직에 주석을 추가했는가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# 릴리스 노트

* **새로운 기능**
  * PDF 업로드 처리 파이프라인 및 POST /api/documents 업로드 엔드포인트 추가
  * 업로드 청크 생성/저장 및 청크 수 반환
  * FastAPI 연동 클라이언트 및 업로드 응답 DTO 추가
  * Langfuse 연동 선택적 콜백 및 로컬/원격 벡터 DB 검사 스크립트 추가

* **보안**
  * 문서 업로드·삭제에 ADMIN 권한 요구 추가

* **Chores**
  * Langfuse 서비스 및 환경 구성 추가(도커 컴포즈), Docker 이미지에 JRE 설치, 파일 업로드 제한 50MB 설정
* **오류 처리**
  * FastAPI 연동 실패 전용 예외 처리 및 새로운 에러 코드 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->