### PR TITLE
feat(chat): 질의응답 파이프라인 구현 (#5)

### DIFF
--- a/ai-server/main.py
+++ b/ai-server/main.py
@@ -2,8 +2,10 @@ from fastapi import FastAPI, UploadFile, File, Form, HTTPException, Request
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
 from langchain_opendataloader_pdf import OpenDataLoaderPDFLoader
-from langchain_text_splitters import RecursiveCharacterTextSplitter
-from langchain_ollama import OllamaEmbeddings
+from langchain_text_splitters import MarkdownHeaderTextSplitter, RecursiveCharacterTextSplitter
+from langchain_core.documents import Document
+from langchain_ollama import OllamaEmbeddings, OllamaLLM
+from pydantic import BaseModel
 import chromadb
 import tempfile
 import os
@@ -16,9 +18,17 @@ app = FastAPI(title="DocuMind AI Server", version="1.0.0")
 # 로컬: OLLAMA_BASE_URL 미설정 시 localhost 사용
 # Docker: OLLAMA_BASE_URL=http://ollama:11434
 OLLAMA_BASE_URL = os.getenv("OLLAMA_BASE_URL", "http://localhost:11434")
+# 환경변수로 LLM 모델명 분기. Docker: OLLAMA_LLM_MODEL=exaone3.5:7.8b
+OLLAMA_LLM_MODEL = os.getenv("OLLAMA_LLM_MODEL", "exaone3.5:7.8b")
 
 embeddings = OllamaEmbeddings(
     model="qwen3-embedding:4b",
+    base_url=OLLAMA_BASE_URL
+)
+
+# 질의응답에 사용할 LLM. 임베딩 모델과 분리해 별도 관리
+llm = OllamaLLM(
+    model=OLLAMA_LLM_MODEL,
     base_url=OLLAMA_BASE_URL
 )
 
@@ -33,11 +43,21 @@ else:
 
 collection = client.get_or_create_collection("documents")
 
-splitter = RecursiveCharacterTextSplitter(
+# Two-Pass 청킹 설정
+# 1단계: 마크다운 헤더(#, ##, ###) 경계에서 분할, 헤더 경로를 메타데이터로 자동 부여
+_MD_HEADERS = [("#", "Header 1"), ("##", "Header 2"), ("###", "Header 3")]
+_md_splitter = MarkdownHeaderTextSplitter(headers_to_split_on=_MD_HEADERS)
+
+# 2단계: 500자 초과 청크만 재분할. 내장 overlap은 서로 다른 헤더 구간 간 미적용 버그가
+# 있으므로 0으로 두고 수동 후처리(_apply_overlap)로 대체한다.
+_char_splitter = RecursiveCharacterTextSplitter(
     chunk_size=500,
-    chunk_overlap=0,  # 후처리에서 정확한 문자 단위 overlap을 적용하므로 0으로 설정
+    chunk_overlap=0,
     length_function=len
 )
+
+# 허용 파일 확장자. Spring Boot DocumentService와 동기화 필요
+ALLOWED_EXTENSIONS = {"pdf", "docx", "pptx", "xlsx"}
 
 # LANGFUSE_SECRET_KEY 설정 시 Langfuse 클라이언트를 초기화한다.
 # 미설정 시 None으로 유지해 트레이싱 없이 파이프라인이 실행된다.
@@ -59,53 +79,114 @@ def health():
     return {"status": "ok"}
 
 
+def _load_documents(tmp_path: str, filename: str) -> list[Document]:
+    """
+    확장자에 따라 파서를 분기하고 LangChain Document 리스트를 반환한다.
+    두 파서 모두 Markdown 형태의 Document를 출력하므로 이후 청킹 코드는 동일하게 유지된다.
+    """
+    ext = filename.rsplit(".", 1)[-1].lower()
+    if ext == "pdf":
+        # opendataloader: 한글 PDF에 최적화, format="markdown"으로 구조 보존
+        loader = OpenDataLoaderPDFLoader(file_path=tmp_path, format="markdown")
+    else:
+        # docx/pptx/xlsx: MarkItDown으로 Markdown 변환
+        # Word 헤딩 스타일을 ATX(#, ##, ###)로 정확히 변환해 MarkdownHeaderTextSplitter와 연동
+        from markitdown import MarkItDown
+        markdown = MarkItDown().convert(tmp_path).text_content
+        return [Document(page_content=markdown)]
+    return loader.load()
+
+
+def _normalize_text(text: str) -> str:
+    """
+    opendataloader 아티팩트 제거: 한글 문장 중간에 삽입되는 과도한 개행을 정규화한다.
+    Docling 출력에도 동일하게 적용해도 무해하다.
+    """
+    # 한글 사이 3개 이상 개행 제거 (파서 버그로 삽입되는 아티팩트)
+    text = re.sub(r'([가-힣])\n{3,}([가-힣])', r'\1\2', text)
+    # 페이지 경계의 과도한 개행 정규화 (삼중 이상 → 이중)
+    text = re.sub(r'\n{3,}', '\n\n', text)
+    return text
+
+
+def _two_pass_split(full_text: str) -> list[Document]:
+    """
+    Two-Pass 청킹: MarkdownHeaderTextSplitter → RecursiveCharacterTextSplitter.
+
+    1단계: 헤더 경계에서 분할해 헤더 경로 메타데이터를 부여한다.
+    2단계: 500자 초과 청크만 char_splitter로 재분할한다.
+           split_documents()는 부모 Document의 metadata를 자식에게 복사하므로
+           1단계 헤더 메타데이터가 유지된다.
+    """
+    header_chunks = _md_splitter.split_text(full_text)
+
+    result: list[Document] = []
+    for doc in header_chunks:
+        if len(doc.page_content) > 500:
+            sub_docs = _char_splitter.split_documents([doc])
+            result.extend(sub_docs)
+        else:
+            result.append(doc)
+
+    return result
+
+
+def _apply_overlap(docs: list[Document]) -> list[Document]:
+    """
+    이전 청크 마지막 50글자를 다음 청크 앞에 prepend하는 수동 overlap 후처리.
+    RecursiveCharacterTextSplitter의 내장 overlap은 서로 다른 헤더 구간 간에
+    작동하지 않으므로 전체 청크 리스트에 수동으로 적용한다.
+    """
+    overlapped: list[Document] = []
+    for i, doc in enumerate(docs):
+        if i == 0:
+            overlapped.append(doc)
+        else:
+            overlap_text = docs[i - 1].page_content[-50:]
+            overlapped.append(Document(
+                page_content=overlap_text + "\n" + doc.page_content,
+                metadata=doc.metadata
+            ))
+    return overlapped
+
+
 async def _run_upload_pipeline(tmp_path: str, filename: str, document_id: int) -> int:
-    """PDF 전처리 파이프라인: 로딩 → 청킹 → overlap 후처리 → 임베딩 → ChromaDB 저장"""
+    """문서 전처리 파이프라인: 로딩 → 정규화 → Two-Pass 청킹 → overlap → 임베딩 → ChromaDB 저장"""
 
     async def _execute() -> int:
-        loader = OpenDataLoaderPDFLoader(
-            file_path=tmp_path,
-            format="markdown"
-        )
-        docs = loader.load()
+        # 파서 분기: 확장자에 따라 PDF 또는 Docling 로더 사용
+        raw_docs = _load_documents(tmp_path, filename)
 
-        # 전체 텍스트 합치기 (페이지 경계 무관하게 청킹하기 위함)
-        full_text = "\n".join([doc.page_content for doc in docs])
+        # 전체 텍스트 병합 후 정규화
+        full_text = "\n".join([doc.page_content for doc in raw_docs])
+        full_text = _normalize_text(full_text)
 
-        # PDF 파서 아티팩트: 문장 중간 삼중 개행 제거 (예: "같\n\n\n다" → "같다")
-        full_text = re.sub(r'([가-힣])\n{3,}([가-힣])', r'\1\2', full_text)
-        # 페이지 경계의 과도한 개행 정규화 (삼중 이상 → 이중)
-        # "\n".join()으로 붙인 페이지 경계에서 \n\n\n이 생겨 overlap 버퍼가 리셋되는 문제 방지
-        full_text = re.sub(r'\n{3,}', '\n\n', full_text)
+        # Two-Pass 청킹 + 수동 overlap 후처리
+        split_docs = _two_pass_split(full_text)
+        final_docs = _apply_overlap(split_docs)
 
-        # 합친 텍스트로 청킹 (chunk_overlap=0으로 clean하게 분리)
-        raw_texts = splitter.split_text(full_text)
+        # 임베딩 + ChromaDB 저장
+        for i, doc in enumerate(final_docs):
+            vector = embeddings.embed_query(doc.page_content)
 
-        # 문자 단위 50글자 overlap 후처리 적용
-        # create_documents()에 리스트를 넘기면 각 항목에 splitter를 재적용하므로
-        # 텍스트를 직접 조작한 뒤 embedding/저장 루프에서 바로 사용
-        overlapped_texts = []
-        for i, text in enumerate(raw_texts):
-            if i == 0:
-                overlapped_texts.append(text)
-            else:
-                overlap = raw_texts[i - 1][-50:]
-                overlapped_texts.append(overlap + "\n" + text)
+            # 헤더 메타데이터(Header 1, Header 2 등) + 문서 식별 메타데이터 병합
+            # ChromaDB는 str/int/float/bool 타입만 허용하므로 필터링한다
+            metadata: dict = {
+                "document_id": str(document_id),
+                "source": filename,
+            }
+            for k, v in doc.metadata.items():
+                if isinstance(v, (str, int, float, bool)):
+                    metadata[k] = v
 
-        for i, text in enumerate(overlapped_texts):
-            vector = embeddings.embed_query(text)
             collection.add(
                 ids=[f"{document_id}_{i}"],
                 embeddings=[vector],
-                documents=[text],
-                metadatas=[{
-                    "document_id": str(document_id),
-                    "source": filename,
-                    "page": ""
-                }]
+                documents=[doc.page_content],
+                metadatas=[metadata]
             )
 
-        return len(overlapped_texts)
+        return len(final_docs)
 
     # Langfuse 4.x: start_as_current_observation()은 async context manager로 동작한다
     # _langfuse가 None이면 트레이싱 없이 파이프라인을 그대로 실행한다
@@ -130,10 +211,16 @@ async def upload_document(
 ):
     import logging
     logging.warning(f"[DEBUG] filename={file.filename}, content_type={file.content_type}, document_id={document_id}")
-    if not file.filename.endswith(".pdf"):
-        raise HTTPException(status_code=400, detail="PDF 파일만 허용됩니다.")
 
-    with tempfile.NamedTemporaryFile(delete=False, suffix=".pdf") as tmp:
+    ext = file.filename.rsplit(".", 1)[-1].lower() if "." in file.filename else ""
+    if ext not in ALLOWED_EXTENSIONS:
+        raise HTTPException(
+            status_code=400,
+            detail=f"허용되지 않는 파일 형식입니다. 허용: {', '.join(sorted(ALLOWED_EXTENSIONS))}"
+        )
+
+    # 확장자를 임시 파일 suffix로 사용해야 파서가 형식을 올바르게 인식한다
+    with tempfile.NamedTemporaryFile(delete=False, suffix=f".{ext}") as tmp:
         content = await file.read()
         tmp.write(content)
         tmp_path = tmp.name
@@ -147,3 +234,68 @@ async def upload_document(
         }
     finally:
         os.unlink(tmp_path)
+
+
+# 질의응답 요청 스키마. Pydantic BaseModel로 JSON body를 자동 파싱·검증
+class QueryRequest(BaseModel):
+    question: str
+    top_k: int = 5  # 검색할 유사 청크 수. 기본값 5
+
+
+@app.post("/query")
+async def query_document(request: QueryRequest):
+    """
+    RAG 질의응답 파이프라인:
+    1. 질문 임베딩 → ChromaDB Top-K 유사도 검색
+    2. 검색된 청크를 컨텍스트로 프롬프트 조합
+    3. EXAONE (Ollama) 답변 생성
+    4. 답변 + 출처 반환
+    """
+    # 1. 질문 임베딩 후 ChromaDB에서 유사 청크 검색
+    question_vector = embeddings.embed_query(request.question)
+    results = collection.query(
+        query_embeddings=[question_vector],
+        n_results=request.top_k,
+        include=["documents", "metadatas", "distances"]
+    )
+
+    docs = results["documents"][0]
+    metadatas = results["metadatas"][0]
+
+    # 2. 검색된 청크를 하나의 컨텍스트 문자열로 합침
+    context = "\n\n".join(docs)
+
+    # 3. 프롬프트 조합: 문서 외 내용 답변 방지를 위해 명시적 제약 포함
+    prompt = f"""주어진 문서를 참고하여 질문에 답변하세요. 문서에 없는 내용은 "관련 내용을 문서에서 찾을 수 없습니다."라고 답하세요.
+
+[문서]
+{context}
+
+[질문]
+{request.question}
+
+[답변]
+"""
+
+    # 4. EXAONE LLM 호출. OllamaLLM.invoke()는 동기 함수이므로 await 없이 호출
+    answer = llm.invoke(prompt)
+
+    # 5. 출처 목록 구성: document_id, source(파일명), 청크 미리보기, 헤더 메타데이터 포함
+    sources = []
+    for doc, meta in zip(docs, metadatas):
+        source: dict = {
+            "document_id": meta.get("document_id", ""),
+            "source": meta.get("source", ""),
+            # 청크 전체를 반환하면 응답이 너무 커지므로 200자 미리보기만 포함
+            "content": doc[:200]
+        }
+        # MarkdownHeaderTextSplitter가 부여한 헤더 메타데이터(Header 1, Header 2 등)를 함께 반환
+        for k, v in meta.items():
+            if k.startswith("Header"):
+                source[k] = v
+        sources.append(source)
+
+    return {
+        "answer": answer,
+        "sources": sources
+    }

--- a/ai-server/main.py
+++ b/ai-server/main.py
@@ -259,8 +259,12 @@ async def query_document(request: QueryRequest):
         include=["documents", "metadatas", "distances"]
     )
 
-    docs = results["documents"][0]
-    metadatas = results["metadatas"][0]
+    # ChromaDB 컬렉션이 비어있거나 결과가 없으면 빈 리스트 반환
+    docs = results["documents"][0] if results["documents"] else []
+    metadatas = results["metadatas"][0] if results["metadatas"] else []
+
+    if not docs:
+        return {"answer": "관련 내용을 문서에서 찾을 수 없습니다.", "sources": []}
 
     # 2. 검색된 청크를 하나의 컨텍스트 문자열로 합침
     context = "\n\n".join(docs)
@@ -277,8 +281,8 @@ async def query_document(request: QueryRequest):
 [답변]
 """
 
-    # 4. EXAONE LLM 호출. OllamaLLM.invoke()는 동기 함수이므로 await 없이 호출
-    answer = llm.invoke(prompt)
+    # 4. EXAONE LLM 비동기 호출. async 핸들러에서 ainvoke()로 이벤트 루프 블로킹 방지
+    answer = await llm.ainvoke(prompt)
 
     # 5. 출처 목록 구성: document_id, source(파일명), 청크 미리보기, 헤더 메타데이터 포함
     sources = []

--- a/ai-server/requirements.txt
+++ b/ai-server/requirements.txt
@@ -40,6 +40,7 @@ jsonschema-specifications==2025.9.1
 kubernetes==35.0.0
 langchain==1.2.13
 langfuse==4.2.0
+markitdown[all]==0.1.5
 langchain-opendataloader-pdf==2.0.0
 opendataloader-pdf==2.2.1
 langchain-classic==1.0.3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ services:
     environment:
       MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
       MYSQL_DATABASE: ${MYSQL_DATABASE}
+      TZ: Asia/Seoul
     ports:
       - "3306:3306"
     volumes:
@@ -34,6 +35,8 @@ services:
       - "8001:8000"
     volumes:
       - chroma_data:/chroma/chroma
+    environment:
+      TZ: Asia/Seoul
     healthcheck:
       test: ["CMD-SHELL", "bash -c 'echo > /dev/tcp/localhost/8000'"]
       interval: 15s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,11 +52,13 @@ services:
         condition: service_healthy
     environment:
       OLLAMA_BASE_URL: http://ollama:11434
+      OLLAMA_LLM_MODEL: exaone3.5:7.8b
       CHROMA_HOST: chromadb
       CHROMA_PORT: 8000
       LANGFUSE_HOST: http://langfuse-web:3000
       LANGFUSE_SECRET_KEY: ${LANGFUSE_SECRET_KEY}
       LANGFUSE_PUBLIC_KEY: ${LANGFUSE_PUBLIC_KEY}
+      TZ: Asia/Seoul
 
   backend:
     build: ./documind
@@ -73,6 +75,8 @@ services:
       JWT_SECRET: ${JWT_SECRET}
       JWT_EXPIRATION: ${JWT_EXPIRATION}
       JWT_REFRESH_EXPIRATION: ${JWT_REFRESH_EXPIRATION}
+      # 컨테이너 기본 타임존은 UTC. KST(UTC+9) 로그 출력을 위해 명시적으로 설정
+      TZ: Asia/Seoul
 
   frontend:
     build: ./frontend

--- a/documind/build.gradle
+++ b/documind/build.gradle
@@ -28,6 +28,8 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
+	// JSON 직렬화/역직렬화. jjwt-jackson이 runtimeOnly라 컴파일 타임에 Jackson이 없으므로 명시적으로 추가
+	implementation 'com.fasterxml.jackson.core:jackson-databind'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
 	testImplementation 'org.springframework.boot:spring-boot-starter-security-test'

--- a/documind/build.gradle
+++ b/documind/build.gradle
@@ -28,8 +28,6 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
-	// JSON 직렬화/역직렬화. jjwt-jackson이 runtimeOnly라 컴파일 타임에 Jackson이 없으므로 명시적으로 추가
-	implementation 'com.fasterxml.jackson.core:jackson-databind'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
 	testImplementation 'org.springframework.boot:spring-boot-starter-security-test'

--- a/documind/src/main/java/com/documind/documind/domain/chat/ChatController.java
+++ b/documind/src/main/java/com/documind/documind/domain/chat/ChatController.java
@@ -1,12 +1,13 @@
 package com.documind.documind.domain.chat;
 
 import com.documind.documind.global.common.ApiResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 // 질의응답 API 엔드포인트. USER는 인증 불필요(SecurityConfig에서 permitAll)
-// @RestControllerAdvice: @Controller + @ResponseBody 결합. JSON 응답 자동 직렬화
+// @RestController: @Controller + @ResponseBody 결합. JSON 응답 자동 직렬화
 @RestController
 // @RequestMapping: 이 컨트롤러의 모든 엔드포인트에 /api/chat 접두사 적용
 @RequestMapping("/api/chat")
@@ -17,7 +18,7 @@ public class ChatController {
 
     // 질의응답 요청. USER는 로그인 불필요이므로 인증 없이 호출 가능
     @PostMapping
-    public ResponseEntity<ApiResponse<ChatResponse>> chat(@RequestBody ChatRequest request) {
+    public ResponseEntity<ApiResponse<ChatResponse>> chat(@Valid @RequestBody ChatRequest request) {
         ChatResponse response = chatService.chat(request);
         return ResponseEntity.ok(ApiResponse.success(response));
     }

--- a/documind/src/main/java/com/documind/documind/domain/chat/ChatController.java
+++ b/documind/src/main/java/com/documind/documind/domain/chat/ChatController.java
@@ -1,0 +1,24 @@
+package com.documind.documind.domain.chat;
+
+import com.documind.documind.global.common.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+// 질의응답 API 엔드포인트. USER는 인증 불필요(SecurityConfig에서 permitAll)
+// @RestControllerAdvice: @Controller + @ResponseBody 결합. JSON 응답 자동 직렬화
+@RestController
+// @RequestMapping: 이 컨트롤러의 모든 엔드포인트에 /api/chat 접두사 적용
+@RequestMapping("/api/chat")
+@RequiredArgsConstructor
+public class ChatController {
+
+    private final ChatService chatService;
+
+    // 질의응답 요청. USER는 로그인 불필요이므로 인증 없이 호출 가능
+    @PostMapping
+    public ResponseEntity<ApiResponse<ChatResponse>> chat(@RequestBody ChatRequest request) {
+        ChatResponse response = chatService.chat(request);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+}

--- a/documind/src/main/java/com/documind/documind/domain/chat/ChatMessage.java
+++ b/documind/src/main/java/com/documind/documind/domain/chat/ChatMessage.java
@@ -47,4 +47,18 @@ public class ChatMessage {
     protected void onCreate() {
         this.createdAt = LocalDateTime.now();
     }
+
+    // 메시지 생성 팩토리 메서드. answer/sourceDocs는 LLM 응답 후 complete()로 채운다
+    public static ChatMessage create(ChatSession chatSession, String question) {
+        ChatMessage message = new ChatMessage();
+        message.chatSession = chatSession;
+        message.question = question;
+        return message;
+    }
+
+    // LLM 응답 수신 후 answer와 sourceDocs를 저장. sourceDocs는 JSON 직렬화 문자열
+    public void complete(String answer, String sourceDocs) {
+        this.answer = answer;
+        this.sourceDocs = sourceDocs;
+    }
 }

--- a/documind/src/main/java/com/documind/documind/domain/chat/ChatMessageRepository.java
+++ b/documind/src/main/java/com/documind/documind/domain/chat/ChatMessageRepository.java
@@ -1,0 +1,7 @@
+package com.documind.documind.domain.chat;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+// chat_messages 테이블 CRUD를 담당하는 JPA Repository
+public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
+}

--- a/documind/src/main/java/com/documind/documind/domain/chat/ChatRequest.java
+++ b/documind/src/main/java/com/documind/documind/domain/chat/ChatRequest.java
@@ -1,5 +1,6 @@
 package com.documind.documind.domain.chat;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -8,7 +9,8 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class ChatRequest {
 
-    // 사용자가 입력한 질문
+    // 사용자가 입력한 질문. 빈 문자열·공백·null 모두 거부
+    @NotBlank(message = "질문은 필수입니다.")
     private String question;
 
     // 비로그인 사용자 세션 식별 키. 프론트엔드가 UUID를 생성해 전달. NULL 허용(비로그인 신규 세션)

--- a/documind/src/main/java/com/documind/documind/domain/chat/ChatRequest.java
+++ b/documind/src/main/java/com/documind/documind/domain/chat/ChatRequest.java
@@ -1,0 +1,19 @@
+package com.documind.documind.domain.chat;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+// POST /api/chat 요청 DTO
+@Getter
+@NoArgsConstructor
+public class ChatRequest {
+
+    // 사용자가 입력한 질문
+    private String question;
+
+    // 비로그인 사용자 세션 식별 키. 프론트엔드가 UUID를 생성해 전달. NULL 허용(비로그인 신규 세션)
+    private String sessionKey;
+
+    // 검색할 유사 청크 수. NULL이면 FastAPI 기본값(5) 사용
+    private Integer topK;
+}

--- a/documind/src/main/java/com/documind/documind/domain/chat/ChatResponse.java
+++ b/documind/src/main/java/com/documind/documind/domain/chat/ChatResponse.java
@@ -1,0 +1,26 @@
+package com.documind.documind.domain.chat;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+import java.util.Map;
+
+// POST /api/chat 응답 DTO
+// @Builder: 서비스 레이어에서 필드를 명시적으로 지정해 객체를 생성
+@Getter
+@Builder
+public class ChatResponse {
+
+    // 생성되거나 재사용된 채팅 세션 ID
+    private Long sessionId;
+
+    // 저장된 메시지 ID
+    private Long messageId;
+
+    // LLM이 생성한 답변
+    private String answer;
+
+    // 답변 근거로 사용된 문서 청크 목록. 각 항목에 document_id, source, content, Header 경로 포함
+    private List<Map<String, Object>> sources;
+}

--- a/documind/src/main/java/com/documind/documind/domain/chat/ChatService.java
+++ b/documind/src/main/java/com/documind/documind/domain/chat/ChatService.java
@@ -1,0 +1,85 @@
+package com.documind.documind.domain.chat;
+
+import com.documind.documind.global.infra.fastapi.FastApiClient;
+import com.documind.documind.global.infra.fastapi.FastApiQueryResponse;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+// 질의응답 비즈니스 로직. 세션 관리 → FastAPI 호출 → 메시지 저장을 담당
+// @RequiredArgsConstructor: final 필드를 인자로 받는 생성자를 자동 생성 (Lombok)
+@Service
+@RequiredArgsConstructor
+public class ChatService {
+
+    private final ChatSessionRepository chatSessionRepository;
+    private final ChatMessageRepository chatMessageRepository;
+    private final FastApiClient fastApiClient;
+    // ObjectMapper는 스레드 안전하므로 static으로 선언해 재사용
+    // spring-boot-starter-webmvc가 Jackson 자동 설정을 포함하지 않아 빈 주입 불가
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    // 기본 Top-K 값. FastAPI 기본값과 동기화
+    private static final int DEFAULT_TOP_K = 5;
+
+    @Transactional
+    public ChatResponse chat(ChatRequest request) {
+        // 1. 세션 조회 또는 신규 생성
+        // sessionKey가 있으면 기존 세션 재사용, 없거나 DB에 없으면 새 세션 생성
+        ChatSession session = resolveSession(request);
+
+        // 2. 메시지를 question만 먼저 저장 (answer는 LLM 응답 후 채움)
+        ChatMessage message = ChatMessage.create(session, request.getQuestion());
+        chatMessageRepository.save(message);
+
+        // 3. FastAPI RAG 파이프라인 호출
+        int topK = request.getTopK() != null ? request.getTopK() : DEFAULT_TOP_K;
+        FastApiQueryResponse fastApiResponse = fastApiClient.query(request.getQuestion(), topK);
+
+        // 4. sources 리스트를 JSON 문자열로 직렬화해 chat_messages.source_docs에 저장
+        String sourceDocsJson = serializeSources(fastApiResponse);
+
+        // 5. 메시지에 answer와 sourceDocs를 채워 DB에 반영
+        message.complete(fastApiResponse.getAnswer(), sourceDocsJson);
+        chatMessageRepository.save(message);
+
+        return ChatResponse.builder()
+                .sessionId(session.getId())
+                .messageId(message.getId())
+                .answer(fastApiResponse.getAnswer())
+                .sources(fastApiResponse.getSources())
+                .build();
+    }
+
+    // sessionKey로 기존 세션을 찾거나, 없으면 새 세션을 생성해 반환
+    private ChatSession resolveSession(ChatRequest request) {
+        if (request.getSessionKey() != null) {
+            return chatSessionRepository.findBySessionKey(request.getSessionKey())
+                    .orElseGet(() -> createSession(request));
+        }
+        return createSession(request);
+    }
+
+    // 새 채팅 세션 생성. 제목은 첫 질문 앞 50자로 설정
+    private ChatSession createSession(ChatRequest request) {
+        String title = request.getQuestion().length() > 50
+                ? request.getQuestion().substring(0, 50)
+                : request.getQuestion();
+        ChatSession session = ChatSession.create(null, request.getSessionKey(), title);
+        return chatSessionRepository.save(session);
+    }
+
+    // sources 리스트를 JSON 문자열로 변환. 직렬화 실패 시 빈 배열 문자열로 폴백
+    private String serializeSources(FastApiQueryResponse response) {
+        if (response.getSources() == null) {
+            return "[]";
+        }
+        try {
+            return objectMapper.writeValueAsString(response.getSources());
+        } catch (JsonProcessingException e) {
+            return "[]";
+        }
+    }
+}

--- a/documind/src/main/java/com/documind/documind/domain/chat/ChatService.java
+++ b/documind/src/main/java/com/documind/documind/domain/chat/ChatService.java
@@ -5,11 +5,13 @@ import com.documind.documind.global.infra.fastapi.FastApiQueryResponse;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 // 질의응답 비즈니스 로직. 세션 관리 → FastAPI 호출 → 메시지 저장을 담당
 // @RequiredArgsConstructor: final 필드를 인자로 받는 생성자를 자동 생성 (Lombok)
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class ChatService {
@@ -17,9 +19,8 @@ public class ChatService {
     private final ChatSessionRepository chatSessionRepository;
     private final ChatMessageRepository chatMessageRepository;
     private final FastApiClient fastApiClient;
-    // ObjectMapper는 스레드 안전하므로 static으로 선언해 재사용
-    // spring-boot-starter-webmvc가 Jackson 자동 설정을 포함하지 않아 빈 주입 불가
-    private static final ObjectMapper objectMapper = new ObjectMapper();
+    // Spring Boot가 자동 설정한 ObjectMapper 빈을 주입해 Jackson 전역 설정을 공유
+    private final ObjectMapper objectMapper;
 
     // 기본 Top-K 값. FastAPI 기본값과 동기화
     private static final int DEFAULT_TOP_K = 5;
@@ -41,9 +42,8 @@ public class ChatService {
         // 4. sources 리스트를 JSON 문자열로 직렬화해 chat_messages.source_docs에 저장
         String sourceDocsJson = serializeSources(fastApiResponse);
 
-        // 5. 메시지에 answer와 sourceDocs를 채워 DB에 반영
+        // 5. 메시지에 answer와 sourceDocs를 채움. @Transactional dirty checking으로 자동 UPDATE
         message.complete(fastApiResponse.getAnswer(), sourceDocsJson);
-        chatMessageRepository.save(message);
 
         return ChatResponse.builder()
                 .sessionId(session.getId())
@@ -79,6 +79,7 @@ public class ChatService {
         try {
             return objectMapper.writeValueAsString(response.getSources());
         } catch (JsonProcessingException e) {
+            log.error("sources 직렬화 실패. 빈 배열로 폴백합니다.", e);
             return "[]";
         }
     }

--- a/documind/src/main/java/com/documind/documind/domain/chat/ChatSession.java
+++ b/documind/src/main/java/com/documind/documind/domain/chat/ChatSession.java
@@ -56,4 +56,13 @@ public class ChatSession {
     protected void onUpdate() {
         this.updatedAt = LocalDateTime.now();
     }
+
+    // 세션 생성 팩토리 메서드. title은 첫 질문 앞 50자를 잘라 전달
+    public static ChatSession create(User user, String sessionKey, String title) {
+        ChatSession session = new ChatSession();
+        session.user = user;
+        session.sessionKey = sessionKey;
+        session.title = title;
+        return session;
+    }
 }

--- a/documind/src/main/java/com/documind/documind/domain/chat/ChatSessionRepository.java
+++ b/documind/src/main/java/com/documind/documind/domain/chat/ChatSessionRepository.java
@@ -1,0 +1,12 @@
+package com.documind.documind.domain.chat;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+// chat_sessions 테이블 CRUD를 담당하는 JPA Repository
+public interface ChatSessionRepository extends JpaRepository<ChatSession, Long> {
+
+    // 비로그인 사용자의 sessionKey로 기존 세션을 조회
+    Optional<ChatSession> findBySessionKey(String sessionKey);
+}

--- a/documind/src/main/java/com/documind/documind/domain/document/DocumentService.java
+++ b/documind/src/main/java/com/documind/documind/domain/document/DocumentService.java
@@ -24,9 +24,12 @@ public class DocumentService {
     private final UserRepository userRepository;
     private final FastApiClient fastApiClient;
 
-    // 허용 MIME 타입 목록. PDF만 허용 (추후 docx, md 추가 예정)
+    // 허용 MIME 타입 목록. FastAPI 파서가 지원하는 형식과 동기화
     private static final List<String> ALLOWED_MIME_TYPES = Arrays.asList(
-            "application/pdf"
+            "application/pdf",
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document", // DOCX
+            "application/vnd.openxmlformats-officedocument.presentationml.presentation", // PPTX
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" // XLSX
     );
 
     @Transactional

--- a/documind/src/main/java/com/documind/documind/global/exception/ErrorCode.java
+++ b/documind/src/main/java/com/documind/documind/global/exception/ErrorCode.java
@@ -22,6 +22,7 @@ public enum ErrorCode {
     // 문서
     FILE_READ_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "파일을 읽는 중 오류가 발생했습니다."),
     FASTAPI_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "AI 서버 문서 처리 중 오류가 발생했습니다."),
+    FASTAPI_QUERY_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "AI 서버 질의응답 처리 중 오류가 발생했습니다."),
     DOCUMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "문서를 찾을 수 없습니다."),
     INVALID_FILE_TYPE(HttpStatus.BAD_REQUEST, "지원하지 않는 파일 형식입니다."),
 

--- a/documind/src/main/java/com/documind/documind/global/infra/fastapi/FastApiClient.java
+++ b/documind/src/main/java/com/documind/documind/global/infra/fastapi/FastApiClient.java
@@ -14,6 +14,7 @@ import org.springframework.web.client.RestTemplate;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.util.Objects;
 
 // FastAPI 서버와 통신하는 HTTP 클라이언트
 // @Component: 스프링 빈으로 등록
@@ -63,5 +64,28 @@ public class FastApiClient {
                 requestEntity,
                 FastApiUploadResponse.class
         );
+    }
+
+    // 질문을 FastAPI에 전송해 RAG 파이프라인(임베딩 → 검색 → LLM 추론) 실행을 요청
+    public FastApiQueryResponse query(String question, int topK) {
+        // 업로드와 달리 파일 전송이 없으므로 JSON body로 전송
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        FastApiQueryRequest queryRequest = FastApiQueryRequest.builder()
+                .question(question)
+                .topK(topK)
+                .build();
+
+        HttpEntity<FastApiQueryRequest> requestEntity = new HttpEntity<>(queryRequest, headers);
+
+        FastApiQueryResponse response = restTemplate.postForObject(
+                baseUrl + "/query",
+                requestEntity,
+                FastApiQueryResponse.class
+        );
+
+        // FastAPI 응답이 null인 경우 명시적 예외로 변환
+        return Objects.requireNonNull(response, "FastAPI /query 응답이 null입니다.");
     }
 }

--- a/documind/src/main/java/com/documind/documind/global/infra/fastapi/FastApiClient.java
+++ b/documind/src/main/java/com/documind/documind/global/infra/fastapi/FastApiClient.java
@@ -7,9 +7,11 @@ import org.springframework.core.io.ByteArrayResource;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.stereotype.Component;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -26,7 +28,11 @@ public class FastApiClient {
 
     // application.yaml의 fastapi.url 값을 주입. Docker에서는 환경변수 FASTAPI_URL로 오버라이드
     public FastApiClient(@Value("${fastapi.url}") String baseUrl) {
-        this.restTemplate = new RestTemplate();
+        // LLM 추론이 길어질 수 있으므로 readTimeout을 120초로 설정. connectTimeout은 서버 다운 감지용 5초
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(5_000);
+        factory.setReadTimeout(120_000);
+        this.restTemplate = new RestTemplate(factory);
         this.baseUrl = baseUrl;
     }
 
@@ -79,13 +85,16 @@ public class FastApiClient {
 
         HttpEntity<FastApiQueryRequest> requestEntity = new HttpEntity<>(queryRequest, headers);
 
-        FastApiQueryResponse response = restTemplate.postForObject(
-                baseUrl + "/query",
-                requestEntity,
-                FastApiQueryResponse.class
-        );
-
-        // FastAPI 응답이 null인 경우 명시적 예외로 변환
-        return Objects.requireNonNull(response, "FastAPI /query 응답이 null입니다.");
+        try {
+            FastApiQueryResponse response = restTemplate.postForObject(
+                    baseUrl + "/query",
+                    requestEntity,
+                    FastApiQueryResponse.class
+            );
+            // FastAPI 응답이 null인 경우 명시적 예외로 변환
+            return Objects.requireNonNull(response, "FastAPI /query 응답이 null입니다.");
+        } catch (RestClientException e) {
+            throw new CustomException(ErrorCode.FASTAPI_QUERY_FAILED);
+        }
     }
 }

--- a/documind/src/main/java/com/documind/documind/global/infra/fastapi/FastApiQueryRequest.java
+++ b/documind/src/main/java/com/documind/documind/global/infra/fastapi/FastApiQueryRequest.java
@@ -1,0 +1,18 @@
+package com.documind.documind.global.infra.fastapi;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Getter;
+
+// FastAPI POST /query 요청 DTO. JSON body로 전송
+@Getter
+@Builder
+public class FastApiQueryRequest {
+
+    // 사용자 질문 텍스트
+    private String question;
+
+    // 검색할 유사 청크 수. FastAPI 필드명이 snake_case이므로 명시
+    @JsonProperty("top_k")
+    private int topK;
+}

--- a/documind/src/main/java/com/documind/documind/global/infra/fastapi/FastApiQueryResponse.java
+++ b/documind/src/main/java/com/documind/documind/global/infra/fastapi/FastApiQueryResponse.java
@@ -1,0 +1,20 @@
+package com.documind.documind.global.infra.fastapi;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+import java.util.Map;
+
+// FastAPI POST /query 응답을 역직렬화하는 DTO
+// FastAPI 응답 형식: {"answer": "...", "sources": [{"document_id": "...", "source": "...", "content": "...", ...}]}
+@Getter
+@NoArgsConstructor
+public class FastApiQueryResponse {
+
+    // LLM이 생성한 답변 텍스트
+    private String answer;
+
+    // 답변 근거 청크 목록. 헤더 메타데이터 키(Header 1 등)가 동적이므로 Map으로 수신
+    private List<Map<String, Object>> sources;
+}

--- a/documind/src/main/resources/application.yaml
+++ b/documind/src/main/resources/application.yaml
@@ -18,8 +18,8 @@ spring:
 server:
   port: 8080
   tomcat:
-    # -1: Tomcat 레벨 POST 크기 제한 비활성화
-    max-http-form-post-size: -1
+    # 512MB (바이트): Spring multipart 설정과 동일하게 맞춰 Tomcat 레벨 DoS 방어
+    max-http-form-post-size: 536870912
     # Tomcat 11 기본값 512바이트를 초과하는 긴 Content-Type(DOCX 등) 처리를 위해 증가
     max-part-header-size: 4096
 

--- a/documind/src/main/resources/application.yaml
+++ b/documind/src/main/resources/application.yaml
@@ -3,10 +3,9 @@ spring:
     name: documind
   servlet:
     multipart:
-      # 단일 파일 최대 크기. PDF 문서 업로드 대응
-      max-file-size: 50MB
-      # 요청 전체 최대 크기
-      max-request-size: 50MB
+      # 512MB: MVP 개발 중 파일 크기 제한 없이 테스트. 운영 배포 시 정책에 맞게 조정
+      max-file-size: 512MB
+      max-request-size: 512MB
   datasource:
     url: jdbc:mysql://localhost:3306/documind
     username: root
@@ -18,6 +17,11 @@ spring:
     show-sql: true
 server:
   port: 8080
+  tomcat:
+    # -1: Tomcat 레벨 POST 크기 제한 비활성화
+    max-http-form-post-size: -1
+    # Tomcat 11 기본값 512바이트를 초과하는 긴 Content-Type(DOCX 등) 처리를 위해 증가
+    max-part-header-size: 4096
 
 fastapi:
   # FastAPI 서버 URL. Docker에서는 환경변수 FASTAPI_URL로 오버라이드


### PR DESCRIPTION
## 🔗 관련 이슈                                                                                                    
  closes #5                                                                                                          
                                          
  ## 📝 작업 내용
  - `POST /api/chat` 엔드포인트 구현 (ChatController, ChatService)                                                   
  - ChatSession / ChatMessage DB 저장 및 세션 키 기반 세션 관리   
  - FastApiClient `query()` 메서드 추가 → FastAPI `POST /query` 연동                                                 
  - FastAPI `/query`: 질문 임베딩 → ChromaDB Top-K 검색 → EXAONE 답변 생성 → sources 반환
  - AI 서버 파서 MarkItDown 전환 (DOCX/PPTX/XLSX ATX 헤딩 변환, mammoth 제거)                                        
  - Tomcat `max-part-header-size: 4096` 설정으로 DOCX 업로드 413 오류 수정                                           
  - docker-compose 컨테이너 TZ Asia/Seoul 적용                                                                       
                                                                                                                     
  ## 🔄 변경 유형                                                                                                    
  - [x] ✨ Feature                                                                                                   
  - [x] 🐛 Bug Fix
                                                                                                                     
  ## ✅ 셀프 리뷰 체크리스트              
  - [ ] 컨벤션을 준수했는가?                                                                                         
  - [ ] 불필요한 print / log 문을 제거했는가?
  - [ ] 하드코딩된 값이 없는가?                                                                                      
  - [ ] 이해하기 어려운 로직에 주석을 추가했는가?
                                                                                                                     
  ## 💡 참고 사항 (선택)
  - DOCX 413 오류 근본 원인: Tomcat 11 기본 `maxPartHeaderSize` 512바이트 제한                                       
  - MarkItDown 전환 배경: mammoth+markdownify의 setext 헤딩 기본값이 MarkdownHeaderTextSplitter와 호환되지 않음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * AI 챗봇을 통한 문서 질의응답 기능 추가
  * PDF, DOCX, PPTX, XLSX 등 다양한 문서 형식 지원
  * 질문에 대한 답변 생성 시 참고 자료의 출처 제공
  * 파일 업로드 제한을 512MB로 확대

* **Chores**
  * 의존성 추가 및 Docker 환경 설정 업데이트
<!-- end of auto-generated comment: release notes by coderabbit.ai -->