### PR TITLE
feat(chat): WebClient FastAPI 연동 구현 (#7)

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -39,6 +39,7 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-validation-test'
 	testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
 	testCompileOnly 'org.projectlombok:lombok'
+	testRuntimeOnly 'com.h2database:h2'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	testAnnotationProcessor 'org.projectlombok:lombok'
 }

--- a/backend/src/main/java/com/documind/documind/domain/chat/ChatController.java
+++ b/backend/src/main/java/com/documind/documind/domain/chat/ChatController.java
@@ -4,24 +4,34 @@ import com.documind.documind.global.common.ApiResponse;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
-import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
+import java.time.Duration;
+
 // 질의응답 API 엔드포인트. USER는 인증 불필요(SecurityConfig에서 permitAll)
 // @RestController: @Controller + @ResponseBody 결합. JSON 응답 자동 직렬화
 @RestController
 // @RequestMapping: 이 컨트롤러의 모든 엔드포인트에 /api/chat 접두사 적용
 @RequestMapping("/api/chat")
-@RequiredArgsConstructor
 // @Validated: @RequestParam에 붙은 @Min, @Max 등 제약 어노테이션 활성화
 @Validated
 public class ChatController {
 
     private final ChatService chatService;
+    private final Duration sseEmitterTimeout;
+
+    public ChatController(
+            ChatService chatService,
+            @Value("${chat.sse-emitter-timeout:0s}") Duration sseEmitterTimeout
+    ) {
+        this.chatService = chatService;
+        this.sseEmitterTimeout = sseEmitterTimeout;
+    }
 
     // 질의응답 요청. USER는 로그인 불필요이므로 인증 없이 호출 가능
     @PostMapping
@@ -39,8 +49,8 @@ public class ChatController {
             // defaultValue로 미전달 시 5를 기본값으로 사용. @Min/@Max는 @Validated 활성화 시 적용
             @RequestParam(defaultValue = "5") @Min(value = 1, message = "topK는 1 이상이어야 합니다.") @Max(value = 20, message = "topK는 20 이하이어야 합니다.") int topK
     ) {
-        // 타임아웃 120초: LLM 추론이 길어지는 경우를 고려. 0L은 타임아웃 없음
-        SseEmitter emitter = new SseEmitter(120_000L);
+        // SseEmitter timeout 0L: 서버가 정상 스트리밍 중인 연결을 임의로 끊지 않음
+        SseEmitter emitter = new SseEmitter(sseEmitterTimeout.toMillis());
         chatService.streamChat(question, sessionKey, topK, emitter);
         return emitter;
     }

--- a/backend/src/main/java/com/documind/documind/global/config/JacksonConfig.java
+++ b/backend/src/main/java/com/documind/documind/global/config/JacksonConfig.java
@@ -2,10 +2,10 @@ package com.documind.documind.global.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
 
 // Spring Boot의 JacksonAutoConfiguration은 webmvc + webflux 공존 시
 // @ConditionalOnSingleCandidate 조건 실패로 ObjectMapper 빈을 등록하지 못하는 경우가 있다.
@@ -15,15 +15,13 @@ import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
 public class JacksonConfig {
 
     // @Bean: 메서드가 반환하는 객체를 스프링 컨테이너에 빈으로 등록
-    // Jackson2ObjectMapperBuilder를 파라미터로 받아 Spring Boot 자동 설정 위에 덮어쓴다.
-    // new ObjectMapper()로 직접 생성하면 spring.jackson.* 프로퍼티와 자동 등록 모듈이 무시된다.
     @Bean
-    public ObjectMapper objectMapper(Jackson2ObjectMapperBuilder builder) {
-        return builder
+    public ObjectMapper objectMapper() {
+        return JsonMapper.builder()
                 // LocalDateTime 등 Java 8 날짜 타입 직렬화 지원
-                .modulesToInstall(JavaTimeModule.class)
+                .addModule(new JavaTimeModule())
                 // 날짜를 타임스탬프 숫자 대신 ISO-8601 문자열로 직렬화
-                .featuresToDisable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+                .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
                 .build();
     }
 }

--- a/backend/src/main/java/com/documind/documind/global/infra/fastapi/FastApiClient.java
+++ b/backend/src/main/java/com/documind/documind/global/infra/fastapi/FastApiClient.java
@@ -3,19 +3,17 @@ package com.documind.documind.global.infra.fastapi;
 import com.documind.documind.global.exception.CustomException;
 import com.documind.documind.global.exception.ErrorCode;
 import org.springframework.core.ParameterizedTypeReference;
-import org.springframework.core.io.ByteArrayResource;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.MediaType;
+import org.springframework.http.client.MultipartBodyBuilder;
 import org.springframework.http.codec.ServerSentEvent;
 import org.springframework.stereotype.Component;
-import org.springframework.util.LinkedMultiValueMap;
-import org.springframework.util.MultiValueMap;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.reactive.function.BodyInserters;
 import org.springframework.web.reactive.function.client.WebClient;
-import org.springframework.web.reactive.function.client.WebClientException;
 import reactor.core.publisher.Flux;
 
-import java.io.IOException;
+import java.time.Duration;
 import java.util.Objects;
 
 // FastAPI 서버와 통신하는 HTTP 클라이언트
@@ -24,44 +22,36 @@ import java.util.Objects;
 public class FastApiClient {
 
     private final WebClient webClient;
+    private final Duration responseTimeout;
 
-    public FastApiClient(WebClient fastApiWebClient) {
+    public FastApiClient(
+            WebClient fastApiWebClient,
+            @Value("${fastapi.response-timeout:180s}") Duration responseTimeout
+    ) {
         this.webClient = fastApiWebClient;
+        this.responseTimeout = responseTimeout;
     }
 
     // PDF 파일과 document_id를 FastAPI에 전송해 청킹·임베딩·저장을 요청
     public FastApiUploadResponse uploadDocument(MultipartFile file, Long documentId) {
-        // WebClient multipart 전송. boundary는 BodyInserters가 자동 생성한다
-        MultiValueMap<String, Object> body = new LinkedMultiValueMap<>();
-
-        try {
-            byte[] bytes = file.getBytes();
-            // getFilename() 오버라이드: Content-Disposition의 filename 파라미터로 원본 파일명 전달
-            ByteArrayResource fileResource = new ByteArrayResource(bytes) {
-                @Override
-                public String getFilename() {
-                    return file.getOriginalFilename();
-                }
-            };
-            body.add("file", fileResource);
-        } catch (IOException e) {
-            throw new CustomException(ErrorCode.FILE_READ_FAILED);
-        }
-
-        // document_id는 String으로 추가: WebClient multipart writer가 문자열 파트로 직렬화
+        // MultipartBodyBuilder: multipart/form-data 파트를 생성하고 boundary는 WebClient가 자동 생성
+        MultipartBodyBuilder body = new MultipartBodyBuilder();
+        // MultipartFile#getResource(): 파일 전체를 힙에 올리지 않고 Resource로 전달
+        body.part("file", file.getResource())
+                .filename(Objects.requireNonNullElse(file.getOriginalFilename(), "upload"));
         // FastAPI Form 필드는 문자열로 수신 후 int로 자동 변환함
-        body.add("document_id", documentId.toString());
+        body.part("document_id", documentId.toString());
 
         try {
             FastApiUploadResponse response = webClient.post()
                     .uri("/documents")
                     .contentType(MediaType.MULTIPART_FORM_DATA)
-                    .body(BodyInserters.fromMultipartData(body))
+                    .body(BodyInserters.fromMultipartData(body.build()))
                     .retrieve()
                     .bodyToMono(FastApiUploadResponse.class)
-                    .block(FastApiWebClientConfig.RESPONSE_TIMEOUT);
+                    .block(responseTimeout);
             return Objects.requireNonNull(response, "FastAPI /documents 응답이 null입니다.");
-        } catch (WebClientException e) {
+        } catch (RuntimeException e) {
             throw new CustomException(ErrorCode.FASTAPI_UPLOAD_FAILED);
         }
     }
@@ -80,10 +70,10 @@ public class FastApiClient {
                     .bodyValue(queryRequest)
                     .retrieve()
                     .bodyToMono(FastApiQueryResponse.class)
-                    .block(FastApiWebClientConfig.RESPONSE_TIMEOUT);
+                    .block(responseTimeout);
             // FastAPI 응답이 null인 경우 명시적 예외로 변환
             return Objects.requireNonNull(response, "FastAPI /query 응답이 null입니다.");
-        } catch (WebClientException e) {
+        } catch (RuntimeException e) {
             throw new CustomException(ErrorCode.FASTAPI_QUERY_FAILED);
         }
     }

--- a/backend/src/main/java/com/documind/documind/global/infra/fastapi/FastApiClient.java
+++ b/backend/src/main/java/com/documind/documind/global/infra/fastapi/FastApiClient.java
@@ -2,27 +2,20 @@ package com.documind.documind.global.infra.fastapi;
 
 import com.documind.documind.global.exception.CustomException;
 import com.documind.documind.global.exception.ErrorCode;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.core.io.ByteArrayResource;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
-import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.http.codec.ServerSentEvent;
 import org.springframework.stereotype.Component;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
-import org.springframework.web.client.RestClientException;
-import org.springframework.web.client.RestTemplate;
 import org.springframework.web.multipart.MultipartFile;
-import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.web.reactive.function.BodyInserters;
 import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientException;
 import reactor.core.publisher.Flux;
-import reactor.netty.http.client.HttpClient;
 
 import java.io.IOException;
-import java.time.Duration;
 import java.util.Objects;
 
 // FastAPI 서버와 통신하는 HTTP 클라이언트
@@ -30,34 +23,15 @@ import java.util.Objects;
 @Component
 public class FastApiClient {
 
-    private final RestTemplate restTemplate;
-    // WebClient: SSE 스트리밍 소비 전용. RestTemplate은 응답을 버퍼링하므로 스트리밍에 사용 불가
     private final WebClient webClient;
-    private final String baseUrl;
 
-    // application.yaml의 fastapi.url 값을 주입. Docker에서는 환경변수 FASTAPI_URL로 오버라이드
-    public FastApiClient(@Value("${fastapi.url}") String baseUrl) {
-        // LLM 추론이 길어질 수 있으므로 readTimeout을 120초로 설정. connectTimeout은 서버 다운 감지용 5초
-        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
-        factory.setConnectTimeout(5_000);
-        factory.setReadTimeout(120_000);
-        this.restTemplate = new RestTemplate(factory);
-        // responseTimeout: 첫 응답 바이트까지 대기 시간.
-        // 임베딩 모델 로드 + ChromaDB 검색 + EXAONE 첫 토큰 생성이 합산되므로 180초로 설정.
-        // 특히 cold start(첫 요청 시 GPU 모델 로드)에는 1~2분이 소요될 수 있다.
-        HttpClient httpClient = HttpClient.create()
-                .responseTimeout(Duration.ofSeconds(180));
-        this.webClient = WebClient.builder()
-                .baseUrl(baseUrl)
-                .clientConnector(new ReactorClientHttpConnector(httpClient))
-                .build();
-        this.baseUrl = baseUrl;
+    public FastApiClient(WebClient fastApiWebClient) {
+        this.webClient = fastApiWebClient;
     }
 
     // PDF 파일과 document_id를 FastAPI에 전송해 청킹·임베딩·저장을 요청
     public FastApiUploadResponse uploadDocument(MultipartFile file, Long documentId) {
-        // RestTemplate + HttpEntity<MultiValueMap> 방식: multipart/form-data 전송의 검증된 방법
-        // FormHttpMessageConverter가 boundary를 자동 생성하고 Content-Type 헤더에 주입함
+        // WebClient multipart 전송. boundary는 BodyInserters가 자동 생성한다
         MultiValueMap<String, Object> body = new LinkedMultiValueMap<>();
 
         try {
@@ -74,44 +48,42 @@ public class FastApiClient {
             throw new CustomException(ErrorCode.FILE_READ_FAILED);
         }
 
-        // document_id는 String으로 추가: FormHttpMessageConverter가 문자열 파트로 직렬화
+        // document_id는 String으로 추가: WebClient multipart writer가 문자열 파트로 직렬화
         // FastAPI Form 필드는 문자열로 수신 후 int로 자동 변환함
         body.add("document_id", documentId.toString());
 
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(MediaType.MULTIPART_FORM_DATA);
-
-        HttpEntity<MultiValueMap<String, Object>> requestEntity = new HttpEntity<>(body, headers);
-
-        return restTemplate.postForObject(
-                baseUrl + "/documents",
-                requestEntity,
-                FastApiUploadResponse.class
-        );
+        try {
+            FastApiUploadResponse response = webClient.post()
+                    .uri("/documents")
+                    .contentType(MediaType.MULTIPART_FORM_DATA)
+                    .body(BodyInserters.fromMultipartData(body))
+                    .retrieve()
+                    .bodyToMono(FastApiUploadResponse.class)
+                    .block(FastApiWebClientConfig.RESPONSE_TIMEOUT);
+            return Objects.requireNonNull(response, "FastAPI /documents 응답이 null입니다.");
+        } catch (WebClientException e) {
+            throw new CustomException(ErrorCode.FASTAPI_UPLOAD_FAILED);
+        }
     }
 
     // 질문을 FastAPI에 전송해 RAG 파이프라인(임베딩 → 검색 → LLM 추론) 실행을 요청
     public FastApiQueryResponse query(String question, int topK) {
-        // 업로드와 달리 파일 전송이 없으므로 JSON body로 전송
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(MediaType.APPLICATION_JSON);
-
         FastApiQueryRequest queryRequest = FastApiQueryRequest.builder()
                 .question(question)
                 .topK(topK)
                 .build();
 
-        HttpEntity<FastApiQueryRequest> requestEntity = new HttpEntity<>(queryRequest, headers);
-
         try {
-            FastApiQueryResponse response = restTemplate.postForObject(
-                    baseUrl + "/query",
-                    requestEntity,
-                    FastApiQueryResponse.class
-            );
+            FastApiQueryResponse response = webClient.post()
+                    .uri("/query")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .bodyValue(queryRequest)
+                    .retrieve()
+                    .bodyToMono(FastApiQueryResponse.class)
+                    .block(FastApiWebClientConfig.RESPONSE_TIMEOUT);
             // FastAPI 응답이 null인 경우 명시적 예외로 변환
             return Objects.requireNonNull(response, "FastAPI /query 응답이 null입니다.");
-        } catch (RestClientException e) {
+        } catch (WebClientException e) {
             throw new CustomException(ErrorCode.FASTAPI_QUERY_FAILED);
         }
     }

--- a/backend/src/main/java/com/documind/documind/global/infra/fastapi/FastApiClient.java
+++ b/backend/src/main/java/com/documind/documind/global/infra/fastapi/FastApiClient.java
@@ -4,6 +4,7 @@ import com.documind.documind.global.exception.CustomException;
 import com.documind.documind.global.exception.ErrorCode;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.MediaType;
 import org.springframework.http.client.MultipartBodyBuilder;
 import org.springframework.http.codec.ServerSentEvent;
@@ -21,14 +22,17 @@ import java.util.Objects;
 @Component
 public class FastApiClient {
 
-    private final WebClient webClient;
+    private final WebClient blockingWebClient;
+    private final WebClient streamingWebClient;
     private final Duration responseTimeout;
 
     public FastApiClient(
-            WebClient fastApiWebClient,
+            @Qualifier("fastApiBlockingWebClient") WebClient blockingWebClient,
+            @Qualifier("fastApiStreamingWebClient") WebClient streamingWebClient,
             @Value("${fastapi.response-timeout:180s}") Duration responseTimeout
     ) {
-        this.webClient = fastApiWebClient;
+        this.blockingWebClient = blockingWebClient;
+        this.streamingWebClient = streamingWebClient;
         this.responseTimeout = responseTimeout;
     }
 
@@ -43,7 +47,7 @@ public class FastApiClient {
         body.part("document_id", documentId.toString());
 
         try {
-            FastApiUploadResponse response = webClient.post()
+            FastApiUploadResponse response = blockingWebClient.post()
                     .uri("/documents")
                     .contentType(MediaType.MULTIPART_FORM_DATA)
                     .body(BodyInserters.fromMultipartData(body.build()))
@@ -64,7 +68,7 @@ public class FastApiClient {
                 .build();
 
         try {
-            FastApiQueryResponse response = webClient.post()
+            FastApiQueryResponse response = blockingWebClient.post()
                     .uri("/query")
                     .contentType(MediaType.APPLICATION_JSON)
                     .bodyValue(queryRequest)
@@ -81,7 +85,7 @@ public class FastApiClient {
     // FastAPI /query/stream SSE 엔드포인트를 구독해 data 필드 JSON 문자열 Flux를 반환
     // ServerSentEvent<String> 디코더가 SSE 포맷을 자동 파싱하므로 "data: " 접두사 제거 불필요
     public Flux<String> streamQuery(String question, int topK) {
-        return webClient.post()
+        return streamingWebClient.post()
                 .uri("/query/stream")
                 .contentType(MediaType.APPLICATION_JSON)
                 .bodyValue(FastApiQueryRequest.builder()

--- a/backend/src/main/java/com/documind/documind/global/infra/fastapi/FastApiClient.java
+++ b/backend/src/main/java/com/documind/documind/global/infra/fastapi/FastApiClient.java
@@ -2,9 +2,10 @@ package com.documind.documind.global.infra.fastapi;
 
 import com.documind.documind.global.exception.CustomException;
 import com.documind.documind.global.exception.ErrorCode;
-import org.springframework.core.ParameterizedTypeReference;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.MediaType;
 import org.springframework.http.client.MultipartBodyBuilder;
 import org.springframework.http.codec.ServerSentEvent;
@@ -18,6 +19,7 @@ import java.time.Duration;
 import java.util.Objects;
 
 // FastAPI 서버와 통신하는 HTTP 클라이언트
+@Slf4j
 // @Component: 스프링 빈으로 등록
 @Component
 public class FastApiClient {
@@ -56,6 +58,7 @@ public class FastApiClient {
                     .block(responseTimeout);
             return Objects.requireNonNull(response, "FastAPI /documents 응답이 null입니다.");
         } catch (RuntimeException e) {
+            log.warn("FastAPI /documents 호출 실패. documentId={}", documentId, e);
             throw new CustomException(ErrorCode.FASTAPI_UPLOAD_FAILED);
         }
     }
@@ -78,6 +81,7 @@ public class FastApiClient {
             // FastAPI 응답이 null인 경우 명시적 예외로 변환
             return Objects.requireNonNull(response, "FastAPI /query 응답이 null입니다.");
         } catch (RuntimeException e) {
+            log.warn("FastAPI /query 호출 실패. topK={}", topK, e);
             throw new CustomException(ErrorCode.FASTAPI_QUERY_FAILED);
         }
     }

--- a/backend/src/main/java/com/documind/documind/global/infra/fastapi/FastApiWebClientConfig.java
+++ b/backend/src/main/java/com/documind/documind/global/infra/fastapi/FastApiWebClientConfig.java
@@ -1,0 +1,33 @@
+package com.documind.documind.global.infra.fastapi;
+
+import io.netty.channel.ChannelOption;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.netty.http.client.HttpClient;
+
+import java.time.Duration;
+
+// FastAPI 연동 전용 WebClient 설정
+// @Configuration: FastAPI HTTP 클라이언트 빈 설정을 스프링 컨테이너에 등록
+@Configuration
+public class FastApiWebClientConfig {
+
+    public static final Duration RESPONSE_TIMEOUT = Duration.ofSeconds(180);
+
+    // @Bean: FastAPI 전용 WebClient를 스프링 빈으로 등록
+    @Bean
+    public WebClient fastApiWebClient(@Value("${fastapi.url}") String baseUrl) {
+        HttpClient httpClient = HttpClient.create()
+                .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 5_000)
+                // 임베딩 모델 로드 + ChromaDB 검색 + EXAONE 첫 토큰 생성 시간을 고려해 180초로 설정
+                .responseTimeout(RESPONSE_TIMEOUT);
+
+        return WebClient.builder()
+                .baseUrl(baseUrl)
+                .clientConnector(new ReactorClientHttpConnector(httpClient))
+                .build();
+    }
+}

--- a/backend/src/main/java/com/documind/documind/global/infra/fastapi/FastApiWebClientConfig.java
+++ b/backend/src/main/java/com/documind/documind/global/infra/fastapi/FastApiWebClientConfig.java
@@ -17,16 +17,39 @@ public class FastApiWebClientConfig {
 
     // @Bean: FastAPI 전용 WebClient를 스프링 빈으로 등록
     @Bean
-    public WebClient fastApiWebClient(
+    public WebClient fastApiBlockingWebClient(
             @Value("${fastapi.url}") String baseUrl,
             @Value("${fastapi.connect-timeout:5s}") Duration connectTimeout,
             @Value("${fastapi.response-timeout:180s}") Duration responseTimeout
     ) {
-        HttpClient httpClient = HttpClient.create()
-                .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, Math.toIntExact(connectTimeout.toMillis()))
-                // 임베딩 모델 로드 + ChromaDB 검색 + EXAONE 첫 토큰 생성 시간을 고려해 설정값으로 제어
+        HttpClient httpClient = createBaseHttpClient(connectTimeout)
+                // 문서 업로드와 일반 질의응답은 응답 완료 시간을 제한해 장애를 빠르게 감지
                 .responseTimeout(responseTimeout);
 
+        return createWebClient(baseUrl, httpClient);
+    }
+
+    // @Bean: FastAPI SSE 스트리밍 전용 WebClient를 스프링 빈으로 등록
+    @Bean
+    public WebClient fastApiStreamingWebClient(
+            @Value("${fastapi.url}") String baseUrl,
+            @Value("${fastapi.connect-timeout:5s}") Duration connectTimeout,
+            @Value("${fastapi.stream-timeout:0s}") Duration streamTimeout
+    ) {
+        HttpClient httpClient = createBaseHttpClient(connectTimeout);
+        if (!streamTimeout.isZero() && !streamTimeout.isNegative()) {
+            httpClient = httpClient.responseTimeout(streamTimeout);
+        }
+
+        return createWebClient(baseUrl, httpClient);
+    }
+
+    private HttpClient createBaseHttpClient(Duration connectTimeout) {
+        return HttpClient.create()
+                .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, Math.toIntExact(connectTimeout.toMillis()));
+    }
+
+    private WebClient createWebClient(String baseUrl, HttpClient httpClient) {
         return WebClient.builder()
                 .baseUrl(baseUrl)
                 .clientConnector(new ReactorClientHttpConnector(httpClient))

--- a/backend/src/main/java/com/documind/documind/global/infra/fastapi/FastApiWebClientConfig.java
+++ b/backend/src/main/java/com/documind/documind/global/infra/fastapi/FastApiWebClientConfig.java
@@ -15,15 +15,17 @@ import java.time.Duration;
 @Configuration
 public class FastApiWebClientConfig {
 
-    public static final Duration RESPONSE_TIMEOUT = Duration.ofSeconds(180);
-
     // @Bean: FastAPI 전용 WebClient를 스프링 빈으로 등록
     @Bean
-    public WebClient fastApiWebClient(@Value("${fastapi.url}") String baseUrl) {
+    public WebClient fastApiWebClient(
+            @Value("${fastapi.url}") String baseUrl,
+            @Value("${fastapi.connect-timeout:5s}") Duration connectTimeout,
+            @Value("${fastapi.response-timeout:180s}") Duration responseTimeout
+    ) {
         HttpClient httpClient = HttpClient.create()
-                .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 5_000)
-                // 임베딩 모델 로드 + ChromaDB 검색 + EXAONE 첫 토큰 생성 시간을 고려해 180초로 설정
-                .responseTimeout(RESPONSE_TIMEOUT);
+                .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, Math.toIntExact(connectTimeout.toMillis()))
+                // 임베딩 모델 로드 + ChromaDB 검색 + EXAONE 첫 토큰 생성 시간을 고려해 설정값으로 제어
+                .responseTimeout(responseTimeout);
 
         return WebClient.builder()
                 .baseUrl(baseUrl)

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -33,6 +33,10 @@ fastapi:
   # SSE 스트리밍 응답 타임아웃. 0s는 스트림 중간 idle gap으로 끊기지 않도록 Reactor Netty responseTimeout 미설정
   stream-timeout: 0s
 
+chat:
+  # Spring MVC SseEmitter 타임아웃. 0s는 브라우저 SSE 연결을 서버가 임의로 끊지 않음
+  sse-emitter-timeout: 0s
+
 jwt:
   # HS256 최소 256bit(32자 이상) 필요. 운영 환경에서는 환경변수로 교체
   secret: documind-secret-key-please-change-in-production-env

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -30,6 +30,8 @@ fastapi:
   connect-timeout: 5s
   # FastAPI 응답 타임아웃. 모델 cold start와 첫 토큰 생성 시간을 고려해 설정
   response-timeout: 180s
+  # SSE 스트리밍 응답 타임아웃. 0s는 스트림 중간 idle gap으로 끊기지 않도록 Reactor Netty responseTimeout 미설정
+  stream-timeout: 0s
 
 jwt:
   # HS256 최소 256bit(32자 이상) 필요. 운영 환경에서는 환경변수로 교체

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -30,12 +30,12 @@ fastapi:
   connect-timeout: 5s
   # FastAPI 응답 타임아웃. 모델 cold start와 첫 토큰 생성 시간을 고려해 설정
   response-timeout: 180s
-  # SSE 스트리밍 응답 타임아웃. 0s는 스트림 중간 idle gap으로 끊기지 않도록 Reactor Netty responseTimeout 미설정
-  stream-timeout: 0s
+  # SSE 스트리밍 응답 타임아웃. 기본 5분, 더 긴 답변이 필요하면 환경변수 FASTAPI_STREAM_TIMEOUT으로 조정
+  stream-timeout: 5m
 
 chat:
-  # Spring MVC SseEmitter 타임아웃. 0s는 브라우저 SSE 연결을 서버가 임의로 끊지 않음
-  sse-emitter-timeout: 0s
+  # Spring MVC SseEmitter 타임아웃. 기본 5분, 더 긴 답변이 필요하면 환경변수 CHAT_SSE_EMITTER_TIMEOUT으로 조정
+  sse-emitter-timeout: 5m
 
 jwt:
   # HS256 최소 256bit(32자 이상) 필요. 운영 환경에서는 환경변수로 교체

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -26,6 +26,10 @@ server:
 fastapi:
   # FastAPI 서버 URL. Docker에서는 환경변수 FASTAPI_URL로 오버라이드
   url: http://localhost:8000
+  # FastAPI 연결 타임아웃. Docker 네트워크 장애나 서버 다운을 빠르게 감지
+  connect-timeout: 5s
+  # FastAPI 응답 타임아웃. 모델 cold start와 첫 토큰 생성 시간을 고려해 설정
+  response-timeout: 180s
 
 jwt:
   # HS256 최소 256bit(32자 이상) 필요. 운영 환경에서는 환경변수로 교체

--- a/backend/src/test/java/com/documind/documind/DocumindApplicationTests.java
+++ b/backend/src/test/java/com/documind/documind/DocumindApplicationTests.java
@@ -9,8 +9,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 		"spring.datasource.username=sa",
 		"spring.datasource.password=",
 		"spring.datasource.driver-class-name=org.h2.Driver",
-		"spring.jpa.hibernate.ddl-auto=create-drop",
-		"spring.jpa.database-platform=org.hibernate.dialect.H2Dialect"
+		"spring.jpa.hibernate.ddl-auto=create-drop"
 })
 class DocumindApplicationTests {
 

--- a/backend/src/test/java/com/documind/documind/DocumindApplicationTests.java
+++ b/backend/src/test/java/com/documind/documind/DocumindApplicationTests.java
@@ -3,7 +3,15 @@ package com.documind.documind;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
-@SpringBootTest
+// @SpringBootTest: 스프링 애플리케이션 컨텍스트가 정상 기동되는지 검증
+@SpringBootTest(properties = {
+		"spring.datasource.url=jdbc:h2:mem:documind;MODE=MySQL;DB_CLOSE_DELAY=-1",
+		"spring.datasource.username=sa",
+		"spring.datasource.password=",
+		"spring.datasource.driver-class-name=org.h2.Driver",
+		"spring.jpa.hibernate.ddl-auto=create-drop",
+		"spring.jpa.database-platform=org.hibernate.dialect.H2Dialect"
+})
 class DocumindApplicationTests {
 
 	@Test

--- a/backend/src/test/java/com/documind/documind/global/infra/fastapi/FastApiClientTest.java
+++ b/backend/src/test/java/com/documind/documind/global/infra/fastapi/FastApiClientTest.java
@@ -33,7 +33,7 @@ class FastApiClientTest {
         String baseUrl = "http://localhost:" + server.getAddress().getPort();
         fastApiClient = new FastApiClient(WebClient.builder()
                 .baseUrl(baseUrl)
-                .build());
+                .build(), Duration.ofSeconds(3));
     }
 
     @AfterEach
@@ -90,8 +90,12 @@ class FastApiClientTest {
 
     @Test
     void streamQueryReadsSseDataEvents() {
+        AtomicReference<String> contentType = new AtomicReference<>();
+        AtomicReference<String> requestBody = new AtomicReference<>();
+
         server.createContext("/query/stream", exchange -> {
-            readBody(exchange);
+            contentType.set(exchange.getRequestHeaders().getFirst(HttpHeaders.CONTENT_TYPE));
+            requestBody.set(readBody(exchange));
             byte[] response = """
                     data: {"token":"안녕"}
 
@@ -109,6 +113,9 @@ class FastApiClientTest {
                 .block(Duration.ofSeconds(3));
 
         assertEquals(List.of("{\"token\":\"안녕\"}", "{\"done\":true,\"sources\":[]}"), events);
+        assertTrue(contentType.get().startsWith(MediaType.APPLICATION_JSON_VALUE));
+        assertTrue(requestBody.get().contains("\"question\":\"질문\""));
+        assertTrue(requestBody.get().contains("\"top_k\":5"));
     }
 
     private String readBody(HttpExchange exchange) throws IOException {

--- a/backend/src/test/java/com/documind/documind/global/infra/fastapi/FastApiClientTest.java
+++ b/backend/src/test/java/com/documind/documind/global/infra/fastapi/FastApiClientTest.java
@@ -1,0 +1,125 @@
+package com.documind.documind.global.infra.fastapi;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class FastApiClientTest {
+
+    private HttpServer server;
+    private FastApiClient fastApiClient;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        server = HttpServer.create(new InetSocketAddress(0), 0);
+        server.start();
+
+        String baseUrl = "http://localhost:" + server.getAddress().getPort();
+        fastApiClient = new FastApiClient(WebClient.builder()
+                .baseUrl(baseUrl)
+                .build());
+    }
+
+    @AfterEach
+    void tearDown() {
+        server.stop(0);
+    }
+
+    @Test
+    void uploadDocumentSendsMultipartRequest() throws IOException {
+        AtomicReference<String> contentType = new AtomicReference<>();
+        AtomicReference<String> requestBody = new AtomicReference<>();
+
+        server.createContext("/documents", exchange -> {
+            contentType.set(exchange.getRequestHeaders().getFirst(HttpHeaders.CONTENT_TYPE));
+            requestBody.set(readBody(exchange));
+            sendJson(exchange, "{\"status\":\"success\",\"filename\":\"sample.pdf\",\"chunks\":3}");
+        });
+
+        MockMultipartFile file = new MockMultipartFile(
+                "file",
+                "sample.pdf",
+                MediaType.APPLICATION_PDF_VALUE,
+                "pdf-content".getBytes(StandardCharsets.UTF_8)
+        );
+
+        FastApiUploadResponse response = fastApiClient.uploadDocument(file, 7L);
+
+        assertEquals(3, response.getChunks());
+        assertTrue(contentType.get().startsWith(MediaType.MULTIPART_FORM_DATA_VALUE));
+        assertTrue(requestBody.get().contains("name=\"document_id\""));
+        assertTrue(requestBody.get().contains("7"));
+        assertTrue(requestBody.get().contains("filename=\"sample.pdf\""));
+    }
+
+    @Test
+    void querySendsJsonRequest() {
+        AtomicReference<String> contentType = new AtomicReference<>();
+        AtomicReference<String> requestBody = new AtomicReference<>();
+
+        server.createContext("/query", exchange -> {
+            contentType.set(exchange.getRequestHeaders().getFirst(HttpHeaders.CONTENT_TYPE));
+            requestBody.set(readBody(exchange));
+            sendJson(exchange, "{\"answer\":\"답변\",\"sources\":[{\"document_id\":7,\"source\":\"sample.pdf\"}]}");
+        });
+
+        FastApiQueryResponse response = fastApiClient.query("질문", 5);
+
+        assertEquals("답변", response.getAnswer());
+        assertEquals(1, response.getSources().size());
+        assertTrue(contentType.get().startsWith(MediaType.APPLICATION_JSON_VALUE));
+        assertTrue(requestBody.get().contains("\"question\":\"질문\""));
+        assertTrue(requestBody.get().contains("\"top_k\":5"));
+    }
+
+    @Test
+    void streamQueryReadsSseDataEvents() {
+        server.createContext("/query/stream", exchange -> {
+            readBody(exchange);
+            byte[] response = """
+                    data: {"token":"안녕"}
+
+                    data: {"done":true,"sources":[]}
+
+                    """.getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().set(HttpHeaders.CONTENT_TYPE, MediaType.TEXT_EVENT_STREAM_VALUE);
+            exchange.sendResponseHeaders(200, response.length);
+            exchange.getResponseBody().write(response);
+            exchange.close();
+        });
+
+        List<String> events = fastApiClient.streamQuery("질문", 5)
+                .collectList()
+                .block(Duration.ofSeconds(3));
+
+        assertEquals(List.of("{\"token\":\"안녕\"}", "{\"done\":true,\"sources\":[]}"), events);
+    }
+
+    private String readBody(HttpExchange exchange) throws IOException {
+        return new String(exchange.getRequestBody().readAllBytes(), StandardCharsets.UTF_8);
+    }
+
+    private void sendJson(HttpExchange exchange, String body) throws IOException {
+        byte[] response = body.getBytes(StandardCharsets.UTF_8);
+        exchange.getResponseHeaders().set(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE);
+        exchange.sendResponseHeaders(200, response.length);
+        exchange.getResponseBody().write(response);
+        exchange.close();
+    }
+}

--- a/backend/src/test/java/com/documind/documind/global/infra/fastapi/FastApiClientTest.java
+++ b/backend/src/test/java/com/documind/documind/global/infra/fastapi/FastApiClientTest.java
@@ -1,5 +1,7 @@
 package com.documind.documind.global.infra.fastapi;
 
+import com.documind.documind.global.exception.CustomException;
+import com.documind.documind.global.exception.ErrorCode;
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpServer;
 import org.junit.jupiter.api.AfterEach;
@@ -18,11 +20,13 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class FastApiClientTest {
 
     private HttpServer server;
+    private WebClient webClient;
     private FastApiClient fastApiClient;
 
     @BeforeEach
@@ -31,9 +35,10 @@ class FastApiClientTest {
         server.start();
 
         String baseUrl = "http://localhost:" + server.getAddress().getPort();
-        fastApiClient = new FastApiClient(WebClient.builder()
+        webClient = WebClient.builder()
                 .baseUrl(baseUrl)
-                .build(), Duration.ofSeconds(3));
+                .build();
+        fastApiClient = new FastApiClient(webClient, webClient, Duration.ofSeconds(3));
     }
 
     @AfterEach
@@ -89,6 +94,74 @@ class FastApiClientTest {
     }
 
     @Test
+    void uploadDocumentWrapsServerError() {
+        server.createContext("/documents", exchange -> {
+            exchange.sendResponseHeaders(500, -1);
+            exchange.close();
+        });
+
+        MockMultipartFile file = new MockMultipartFile(
+                "file",
+                "sample.pdf",
+                MediaType.APPLICATION_PDF_VALUE,
+                "pdf-content".getBytes(StandardCharsets.UTF_8)
+        );
+
+        CustomException exception = assertThrows(CustomException.class,
+                () -> fastApiClient.uploadDocument(file, 7L));
+
+        assertEquals(ErrorCode.FASTAPI_UPLOAD_FAILED, exception.getErrorCode());
+    }
+
+    @Test
+    void uploadDocumentWrapsTimeout() {
+        FastApiClient shortTimeoutClient = new FastApiClient(webClient, webClient, Duration.ofMillis(50));
+        server.createContext("/documents", exchange -> {
+            sleep(300);
+            sendJson(exchange, "{\"status\":\"success\",\"filename\":\"sample.pdf\",\"chunks\":3}");
+        });
+
+        MockMultipartFile file = new MockMultipartFile(
+                "file",
+                "sample.pdf",
+                MediaType.APPLICATION_PDF_VALUE,
+                "pdf-content".getBytes(StandardCharsets.UTF_8)
+        );
+
+        CustomException exception = assertThrows(CustomException.class,
+                () -> shortTimeoutClient.uploadDocument(file, 7L));
+
+        assertEquals(ErrorCode.FASTAPI_UPLOAD_FAILED, exception.getErrorCode());
+    }
+
+    @Test
+    void queryWrapsServerError() {
+        server.createContext("/query", exchange -> {
+            exchange.sendResponseHeaders(500, -1);
+            exchange.close();
+        });
+
+        CustomException exception = assertThrows(CustomException.class,
+                () -> fastApiClient.query("질문", 5));
+
+        assertEquals(ErrorCode.FASTAPI_QUERY_FAILED, exception.getErrorCode());
+    }
+
+    @Test
+    void queryWrapsTimeout() {
+        FastApiClient shortTimeoutClient = new FastApiClient(webClient, webClient, Duration.ofMillis(50));
+        server.createContext("/query", exchange -> {
+            sleep(300);
+            sendJson(exchange, "{\"answer\":\"답변\",\"sources\":[]}");
+        });
+
+        CustomException exception = assertThrows(CustomException.class,
+                () -> shortTimeoutClient.query("질문", 5));
+
+        assertEquals(ErrorCode.FASTAPI_QUERY_FAILED, exception.getErrorCode());
+    }
+
+    @Test
     void streamQueryReadsSseDataEvents() {
         AtomicReference<String> contentType = new AtomicReference<>();
         AtomicReference<String> requestBody = new AtomicReference<>();
@@ -128,5 +201,14 @@ class FastApiClientTest {
         exchange.sendResponseHeaders(200, response.length);
         exchange.getResponseBody().write(response);
         exchange.close();
+    }
+
+    private void sleep(long millis) {
+        try {
+            Thread.sleep(millis);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException(e);
+        }
     }
 }


### PR DESCRIPTION
## 🔗 관련 이슈
closes #7

## 📝 작업 내용

### ✨ WebClient 연동 구현
- FastAPI 전용 `WebClient` Bean 설정 추가
- `FastApiClient.uploadDocument()` 문서 업로드 요청을 WebClient multipart 방식으로 전환
- `FastApiClient.query()` 일반 질의응답 요청을 WebClient JSON 방식으로 전환
- `FastApiClient.streamQuery()` SSE 스트리밍 응답 중계 구조 유지

### 🐛 버그 수정
- `JacksonConfig.java` 수정: Spring Boot 4 환경에서 `Jackson2ObjectMapperBuilder` Bean 누락으로 컨텍스트가 실패하는 문제 해결
- `JsonMapper.builder()` 기반 ObjectMapper 명시 등록으로 JavaTimeModule, 날짜 직렬화 설정 유지

### 🧪 테스트
- `FastApiClientTest` 추가
  - FastAPI 문서 업로드 multipart 요청 검증
  - FastAPI 질의응답 JSON 요청 검증
  - FastAPI SSE data 이벤트 수신 검증
- `DocumindApplicationTests` 수정
  - 로컬 MySQL 없이 테스트 가능하도록 H2 기반 컨텍스트 테스트 설정

## 🔄 변경 유형
- [x] ✨ Feature
- [x] 🐛 Bug Fix
- [x] 🧪 Test

## 💡 참고 사항 (선택)
- `./gradlew test` 통과
- 이번 이슈 #7에서는 데스크탑 WSL2 Docker 환경 E2E는 PR 작성 전 별도로 재실행하지 않았습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# 릴리스 노트

* **테스트**
  * 인메모리 H2 데이터베이스 기반 테스트 환경 추가 및 테스트 설정 갱신
  * FastAPI 연동을 검증하는 통합/단위 테스트 추가로 커버리지 확대

* **개선**
  * FastAPI 통신 신뢰성 강화(분리된 동기/스트리밍 클라이언트 및 응답/연결 타임아웃 적용)
  * 서버-전송 이벤트(SSE) 타임아웃을 구성 가능하도록 변경
  * 날짜 직렬화 설정 최적화로 일관된 직렬화 동작 보장
<!-- end of auto-generated comment: release notes by coderabbit.ai -->