### PR TITLE
feat(chat): 채팅 이력 API 구현 (#8)

### DIFF
--- a/backend/src/main/java/com/documind/documind/domain/auth/AuthService.java
+++ b/backend/src/main/java/com/documind/documind/domain/auth/AuthService.java
@@ -31,7 +31,7 @@ public class AuthService {
             throw new CustomException(ErrorCode.INVALID_CREDENTIALS);
         }
 
-        String accessToken = jwtProvider.generateToken(user.getUsername(), user.getRole().name());
+        String accessToken = jwtProvider.generateToken(user.getUsername(), user.getRole().name(), user.getId());
         String refreshToken = jwtProvider.generateRefreshToken(user.getUsername());
 
         // Refresh Token 저장 및 마지막 로그인 시각 갱신
@@ -61,6 +61,6 @@ public class AuthService {
         User user = userRepository.findByRefreshToken(refreshToken)
                 .orElseThrow(() -> new CustomException(ErrorCode.INVALID_TOKEN));
 
-        return jwtProvider.generateToken(user.getUsername(), user.getRole().name());
+        return jwtProvider.generateToken(user.getUsername(), user.getRole().name(), user.getId());
     }
 }

--- a/backend/src/main/java/com/documind/documind/domain/auth/User.java
+++ b/backend/src/main/java/com/documind/documind/domain/auth/User.java
@@ -63,6 +63,19 @@ public class User {
         this.createdAt = LocalDateTime.now();
     }
 
+    /**
+     * User 인스턴스를 생성하는 팩토리 메서드.
+     * @param encodedPassword BCrypt 등으로 인코딩된 비밀번호
+     */
+    public static User create(String username, String encodedPassword, Role role) {
+        User user = new User();
+        user.username = username;
+        user.password = encodedPassword;
+        user.role = role;
+        user.isActive = true;
+        return user;
+    }
+
     // User 클래스 안에 Role Enum 정의
     public enum Role {
         ADMIN, USER

--- a/backend/src/main/java/com/documind/documind/domain/chat/ChatController.java
+++ b/backend/src/main/java/com/documind/documind/domain/chat/ChatController.java
@@ -1,5 +1,6 @@
 package com.documind.documind.domain.chat;
 
+import com.documind.documind.global.auth.JwtAuthenticationDetails;
 import com.documind.documind.global.common.ApiResponse;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Max;
@@ -43,7 +44,11 @@ public class ChatController {
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
-    // 채팅 세션 목록 조회. 로그인: JWT로 사용자 전체 세션 반환, 비로그인: X-Session-Key 헤더로 단일 세션 반환
+    /**
+     * 채팅 세션 목록을 조회한다.
+     * 로그인 사용자(ADMIN)는 JWT userId 기반 전체 세션을 최신 활동 순으로 반환하고,
+     * 비로그인 사용자는 X-Session-Key 헤더 기반 단일 세션을 반환한다.
+     */
     @GetMapping("/sessions")
     public ResponseEntity<ApiResponse<List<ChatSessionSummaryResponse>>> getSessions(
             Authentication authentication,
@@ -53,7 +58,10 @@ public class ChatController {
         return ResponseEntity.ok(ApiResponse.success(chatService.getSessions(userId, sessionKey)));
     }
 
-    // 채팅 세션 상세 조회. 세션 정보와 시간순 메시지 목록을 반환. 소유권 검증 실패 시 404
+    /**
+     * 채팅 세션 상세 정보와 시간순 메시지 목록을 조회한다.
+     * sessionId와 소유자(userId 또는 sessionKey)가 일치하지 않으면 404를 반환한다.
+     */
     @GetMapping("/sessions/{id}")
     public ResponseEntity<ApiResponse<ChatSessionDetailResponse>> getSessionDetail(
             @PathVariable Long id,
@@ -64,7 +72,10 @@ public class ChatController {
         return ResponseEntity.ok(ApiResponse.success(chatService.getSessionDetail(id, userId, sessionKey)));
     }
 
-    // 채팅 세션 삭제. 메시지 포함 물리삭제. 소유권 검증 실패 시 404
+    /**
+     * 채팅 세션과 소속 메시지를 물리삭제한다.
+     * 소유권 검증 실패 시 404를 반환한다.
+     */
     @DeleteMapping("/sessions/{id}")
     public ResponseEntity<ApiResponse<Void>> deleteSession(
             @PathVariable Long id,
@@ -76,8 +87,11 @@ public class ChatController {
         return ResponseEntity.ok(ApiResponse.success("채팅 세션이 삭제되었습니다."));
     }
 
-    // AnonymousAuthenticationToken.isAuthenticated()는 true를 반환하므로 instanceof로 로그인 여부를 구분.
-    // 로그인 사용자이면 details에서 userId를 꺼내고, 비로그인이면 null을 반환해 sessionKey 분기로 처리
+    /**
+     * Authentication 객체에서 userId를 추출한다.
+     * AnonymousAuthenticationToken.isAuthenticated()는 true를 반환하므로 instanceof로 명시적으로 구분한다.
+     * 비로그인이거나 details가 JwtAuthenticationDetails가 아니면 null을 반환해 sessionKey 분기로 처리한다.
+     */
     private Long extractUserId(Authentication authentication) {
         if (authentication == null
                 || authentication instanceof AnonymousAuthenticationToken
@@ -85,7 +99,7 @@ public class ChatController {
             return null;
         }
         Object details = authentication.getDetails();
-        return details instanceof Long ? (Long) details : null;
+        return details instanceof JwtAuthenticationDetails jad ? jad.getUserId() : null;
     }
 
     // SSE 스트리밍 질의응답. EventSource는 GET만 지원하므로 question을 query param으로 전달

--- a/backend/src/main/java/com/documind/documind/domain/chat/ChatController.java
+++ b/backend/src/main/java/com/documind/documind/domain/chat/ChatController.java
@@ -7,11 +7,14 @@ import jakarta.validation.constraints.Min;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.Authentication;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import java.time.Duration;
+import java.util.List;
 
 // 질의응답 API 엔드포인트. USER는 인증 불필요(SecurityConfig에서 permitAll)
 // @RestController: @Controller + @ResponseBody 결합. JSON 응답 자동 직렬화
@@ -38,6 +41,51 @@ public class ChatController {
     public ResponseEntity<ApiResponse<ChatResponse>> chat(@Valid @RequestBody ChatRequest request) {
         ChatResponse response = chatService.chat(request);
         return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    // 채팅 세션 목록 조회. 로그인: JWT로 사용자 전체 세션 반환, 비로그인: X-Session-Key 헤더로 단일 세션 반환
+    @GetMapping("/sessions")
+    public ResponseEntity<ApiResponse<List<ChatSessionSummaryResponse>>> getSessions(
+            Authentication authentication,
+            @RequestHeader(value = "X-Session-Key", required = false) String sessionKey
+    ) {
+        Long userId = extractUserId(authentication);
+        return ResponseEntity.ok(ApiResponse.success(chatService.getSessions(userId, sessionKey)));
+    }
+
+    // 채팅 세션 상세 조회. 세션 정보와 시간순 메시지 목록을 반환. 소유권 검증 실패 시 404
+    @GetMapping("/sessions/{id}")
+    public ResponseEntity<ApiResponse<ChatSessionDetailResponse>> getSessionDetail(
+            @PathVariable Long id,
+            Authentication authentication,
+            @RequestHeader(value = "X-Session-Key", required = false) String sessionKey
+    ) {
+        Long userId = extractUserId(authentication);
+        return ResponseEntity.ok(ApiResponse.success(chatService.getSessionDetail(id, userId, sessionKey)));
+    }
+
+    // 채팅 세션 삭제. 메시지 포함 물리삭제. 소유권 검증 실패 시 404
+    @DeleteMapping("/sessions/{id}")
+    public ResponseEntity<ApiResponse<Void>> deleteSession(
+            @PathVariable Long id,
+            Authentication authentication,
+            @RequestHeader(value = "X-Session-Key", required = false) String sessionKey
+    ) {
+        Long userId = extractUserId(authentication);
+        chatService.deleteSession(id, userId, sessionKey);
+        return ResponseEntity.ok(ApiResponse.success("채팅 세션이 삭제되었습니다."));
+    }
+
+    // AnonymousAuthenticationToken.isAuthenticated()는 true를 반환하므로 instanceof로 로그인 여부를 구분.
+    // 로그인 사용자이면 details에서 userId를 꺼내고, 비로그인이면 null을 반환해 sessionKey 분기로 처리
+    private Long extractUserId(Authentication authentication) {
+        if (authentication == null
+                || authentication instanceof AnonymousAuthenticationToken
+                || !authentication.isAuthenticated()) {
+            return null;
+        }
+        Object details = authentication.getDetails();
+        return details instanceof Long ? (Long) details : null;
     }
 
     // SSE 스트리밍 질의응답. EventSource는 GET만 지원하므로 question을 query param으로 전달

--- a/backend/src/main/java/com/documind/documind/domain/chat/ChatMessageRepository.java
+++ b/backend/src/main/java/com/documind/documind/domain/chat/ChatMessageRepository.java
@@ -8,15 +8,18 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
-// chat_messages 테이블 CRUD를 담당하는 JPA Repository
+/** chat_messages 테이블 CRUD를 담당하는 JPA Repository */
 public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
 
-    // 특정 세션에 속한 메시지를 시간순으로 조회. 세션 상세 조회 시 대화 흐름 재현에 사용
+    /** 특정 세션에 속한 메시지를 시간순으로 조회한다. 세션 상세 조회 시 대화 흐름 재현에 사용한다. */
     List<ChatMessage> findByChatSessionIdOrderByCreatedAtAsc(Long sessionId);
 
-    // 세션 삭제 전 해당 세션의 메시지를 일괄 삭제. derived delete는 N+1 DELETE가 발생하므로 JPQL 사용
-    // @Modifying: DELETE 쿼리 실행을 허용
-    @Modifying
+    /**
+     * 세션의 메시지를 JPQL로 일괄 삭제한다.
+     * derived delete는 SELECT 후 하나씩 remove()를 호출하는 N+1 DELETE가 발생하므로 JPQL을 직접 작성한다.
+     * clearAutomatically: bulk DELETE 후 1차 캐시에 잔류하는 삭제된 엔티티를 제거해 이후 조회가 올바른 결과를 반환하도록 보장한다.
+     */
+    @Modifying(clearAutomatically = true)
     @Transactional
     @Query("DELETE FROM ChatMessage m WHERE m.chatSession.id = :sessionId")
     void deleteByChatSessionId(@Param("sessionId") Long sessionId);

--- a/backend/src/main/java/com/documind/documind/domain/chat/ChatMessageRepository.java
+++ b/backend/src/main/java/com/documind/documind/domain/chat/ChatMessageRepository.java
@@ -1,7 +1,23 @@
 package com.documind.documind.domain.chat;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 // chat_messages 테이블 CRUD를 담당하는 JPA Repository
 public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
+
+    // 특정 세션에 속한 메시지를 시간순으로 조회. 세션 상세 조회 시 대화 흐름 재현에 사용
+    List<ChatMessage> findByChatSessionIdOrderByCreatedAtAsc(Long sessionId);
+
+    // 세션 삭제 전 해당 세션의 메시지를 일괄 삭제. derived delete는 N+1 DELETE가 발생하므로 JPQL 사용
+    // @Modifying: DELETE 쿼리 실행을 허용
+    @Modifying
+    @Transactional
+    @Query("DELETE FROM ChatMessage m WHERE m.chatSession.id = :sessionId")
+    void deleteByChatSessionId(@Param("sessionId") Long sessionId);
 }

--- a/backend/src/main/java/com/documind/documind/domain/chat/ChatMessageResponse.java
+++ b/backend/src/main/java/com/documind/documind/domain/chat/ChatMessageResponse.java
@@ -7,8 +7,10 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 
-// 세션 상세 조회 응답에 포함되는 단일 메시지 DTO
-// @Builder: 서비스 레이어에서 필드를 명시적으로 지정해 객체를 생성
+/**
+ * GET /api/chat/sessions/{id} 상세 조회 응답에 포함되는 단일 메시지 DTO.
+ * sources는 DB의 JSON 문자열을 역직렬화한 결과이며, 역직렬화 실패 시 빈 리스트로 폴백한다.
+ */
 @Getter
 @Builder
 public class ChatMessageResponse {

--- a/backend/src/main/java/com/documind/documind/domain/chat/ChatMessageResponse.java
+++ b/backend/src/main/java/com/documind/documind/domain/chat/ChatMessageResponse.java
@@ -1,0 +1,30 @@
+package com.documind.documind.domain.chat;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+
+// 세션 상세 조회 응답에 포함되는 단일 메시지 DTO
+// @Builder: 서비스 레이어에서 필드를 명시적으로 지정해 객체를 생성
+@Getter
+@Builder
+public class ChatMessageResponse {
+
+    // 메시지 식별자
+    private Long messageId;
+
+    // 사용자 질문
+    private String question;
+
+    // LLM 답변. 스트리밍 중단 시 null일 수 있음
+    private String answer;
+
+    // 답변 근거 문서 목록. DB의 JSON 문자열을 역직렬화한 결과
+    private List<Map<String, Object>> sources;
+
+    // 메시지 생성 시각
+    private LocalDateTime createdAt;
+}

--- a/backend/src/main/java/com/documind/documind/domain/chat/ChatService.java
+++ b/backend/src/main/java/com/documind/documind/domain/chat/ChatService.java
@@ -1,8 +1,11 @@
 package com.documind.documind.domain.chat;
 
+import com.documind.documind.global.exception.CustomException;
+import com.documind.documind.global.exception.ErrorCode;
 import com.documind.documind.global.infra.fastapi.FastApiClient;
 import com.documind.documind.global.infra.fastapi.FastApiQueryResponse;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
@@ -14,6 +17,9 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 import reactor.core.Disposable;
 
 import java.io.IOException;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -53,12 +59,99 @@ public class ChatService {
         // 5. 메시지에 answer와 sourceDocs를 채움. @Transactional dirty checking으로 자동 UPDATE
         message.complete(fastApiResponse.getAnswer(), sourceDocsJson);
 
+        // 6. 세션의 마지막 활동 시각 갱신. 사이드바 목록의 최신 활동 순 정렬에 사용
+        chatSessionRepository.updateUpdatedAt(session.getId(), LocalDateTime.now());
+
         return ChatResponse.builder()
                 .sessionId(session.getId())
                 .messageId(message.getId())
                 .answer(fastApiResponse.getAnswer())
                 .sources(fastApiResponse.getSources())
                 .build();
+    }
+
+    // 세션 목록 조회. 로그인 사용자는 userId 기반 전체 목록, 비로그인은 sessionKey 기반 단일 세션 반환
+    @Transactional(readOnly = true)
+    public List<ChatSessionSummaryResponse> getSessions(Long userId, String sessionKey) {
+        List<ChatSession> sessions;
+        if (userId != null) {
+            sessions = chatSessionRepository.findByUserIdOrderByUpdatedAtDesc(userId);
+        } else if (sessionKey != null) {
+            // 비로그인은 sessionKey가 unique이므로 최대 1개. List 형식으로 통일해 클라이언트 처리 단순화
+            sessions = chatSessionRepository.findBySessionKey(sessionKey)
+                    .map(List::of)
+                    .orElse(List.of());
+        } else {
+            return List.of();
+        }
+        return sessions.stream()
+                .map(s -> ChatSessionSummaryResponse.builder()
+                        .sessionId(s.getId())
+                        .title(s.getTitle())
+                        .createdAt(s.getCreatedAt())
+                        .updatedAt(s.getUpdatedAt())
+                        .build())
+                .toList();
+    }
+
+    // 세션 상세 조회. 세션 정보와 시간순 메시지 목록을 반환. 소유권 검증 실패 시 404 반환
+    @Transactional(readOnly = true)
+    public ChatSessionDetailResponse getSessionDetail(Long sessionId, Long userId, String sessionKey) {
+        ChatSession session = resolveSession(sessionId, userId, sessionKey);
+
+        List<ChatMessageResponse> messageResponses = chatMessageRepository
+                .findByChatSessionIdOrderByCreatedAtAsc(sessionId)
+                .stream()
+                .map(m -> ChatMessageResponse.builder()
+                        .messageId(m.getId())
+                        .question(m.getQuestion())
+                        .answer(m.getAnswer())
+                        .sources(deserializeSources(m.getSourceDocs()))
+                        .createdAt(m.getCreatedAt())
+                        .build())
+                .toList();
+
+        return ChatSessionDetailResponse.builder()
+                .sessionId(session.getId())
+                .title(session.getTitle())
+                .createdAt(session.getCreatedAt())
+                .messages(messageResponses)
+                .build();
+    }
+
+    // 세션 삭제. 메시지 → 세션 순서로 물리삭제. FK 위반 방지를 위해 순서가 중요
+    @Transactional
+    public void deleteSession(Long sessionId, Long userId, String sessionKey) {
+        resolveSession(sessionId, userId, sessionKey);
+        chatMessageRepository.deleteByChatSessionId(sessionId);
+        chatSessionRepository.deleteById(sessionId);
+    }
+
+    // sessionId + (userId 또는 sessionKey)로 소유권을 검증하고 세션을 반환.
+    // 세션 존재 여부 노출을 막기 위해 소유권 불일치도 CHAT_SESSION_NOT_FOUND로 처리한다.
+    private ChatSession resolveSession(Long sessionId, Long userId, String sessionKey) {
+        if (userId != null) {
+            return chatSessionRepository.findByIdAndUserId(sessionId, userId)
+                    .orElseThrow(() -> new CustomException(ErrorCode.CHAT_SESSION_NOT_FOUND));
+        }
+        if (sessionKey != null) {
+            return chatSessionRepository.findByIdAndSessionKey(sessionId, sessionKey)
+                    .orElseThrow(() -> new CustomException(ErrorCode.CHAT_SESSION_NOT_FOUND));
+        }
+        throw new CustomException(ErrorCode.CHAT_SESSION_NOT_FOUND);
+    }
+
+    // sourceDocs JSON 문자열을 역직렬화. null이거나 파싱 실패 시 빈 리스트로 폴백
+    private List<Map<String, Object>> deserializeSources(String sourceDocs) {
+        if (sourceDocs == null || sourceDocs.isBlank()) {
+            return List.of();
+        }
+        try {
+            return objectMapper.readValue(sourceDocs, new TypeReference<>() {});
+        } catch (JsonProcessingException e) {
+            log.error("sourceDocs 역직렬화 실패. 빈 리스트로 폴백합니다.", e);
+            return List.of();
+        }
     }
 
     // sessionKey로 기존 세션을 찾거나, 없으면 새 세션을 생성해 반환.
@@ -109,6 +202,8 @@ public class ChatService {
         ChatMessage message = ChatMessage.create(session, question);
         chatMessageRepository.save(message);
         Long messageId = message.getId();
+        // Reactor 스레드 람다에서 session 객체 전체를 참조하면 LazyInitializationException 위험이 있으므로 id만 캡처
+        Long sessionId = session.getId();
 
         // StringBuffer: onCompletion(서블릿 스레드)과 forwardToken(Reactor 스레드)이 동시 접근 가능
         StringBuffer answerBuffer = new StringBuffer();
@@ -119,7 +214,7 @@ public class ChatService {
                 .subscribe(
                         jsonData -> {
                             try {
-                                forwardToken(jsonData, messageId, answerBuffer, emitter, normallyCompleted);
+                                forwardToken(jsonData, messageId, sessionId, answerBuffer, emitter, normallyCompleted);
                             } catch (Exception e) {
                                 log.error("SSE 토큰 전송 오류", e);
                                 emitter.completeWithError(e);
@@ -148,7 +243,7 @@ public class ChatService {
     }
 
     // SSE data JSON을 파싱해 token이면 emitter에 forwarding, done이면 DB 저장 후 완료
-    private void forwardToken(String jsonData, Long messageId, StringBuffer answerBuffer, SseEmitter emitter, AtomicBoolean normallyCompleted) throws IOException {
+    private void forwardToken(String jsonData, Long messageId, Long sessionId, StringBuffer answerBuffer, SseEmitter emitter, AtomicBoolean normallyCompleted) throws IOException {
         JsonNode node = objectMapper.readTree(jsonData);
 
         if (node.has("token")) {
@@ -170,6 +265,10 @@ public class ChatService {
                 m.complete(finalAnswer, sourcesJson);
                 chatMessageRepository.save(m);
             });
+
+            // 세션의 마지막 활동 시각 갱신. @Transactional이 없는 Reactor 스레드에서 호출되므로
+            // Repository 메서드의 자체 @Transactional로 새 트랜잭션을 시작해 UPDATE 실행
+            chatSessionRepository.updateUpdatedAt(sessionId, LocalDateTime.now());
 
             emitter.send(SseEmitter.event().data(jsonData));
             // DB 저장과 SSE 전송이 모두 성공한 뒤에만 정상 완료로 표시.

--- a/backend/src/main/java/com/documind/documind/domain/chat/ChatSessionDetailResponse.java
+++ b/backend/src/main/java/com/documind/documind/domain/chat/ChatSessionDetailResponse.java
@@ -6,8 +6,10 @@ import lombok.Getter;
 import java.time.LocalDateTime;
 import java.util.List;
 
-// GET /api/chat/sessions/{id} 상세 조회 응답 DTO. 세션 정보와 전체 메시지 목록을 포함
-// @Builder: 서비스 레이어에서 필드를 명시적으로 지정해 객체를 생성
+/**
+ * GET /api/chat/sessions/{id} 상세 조회 응답 DTO.
+ * 세션 정보와 시간순 정렬된 전체 메시지 목록을 포함한다.
+ */
 @Getter
 @Builder
 public class ChatSessionDetailResponse {

--- a/backend/src/main/java/com/documind/documind/domain/chat/ChatSessionDetailResponse.java
+++ b/backend/src/main/java/com/documind/documind/domain/chat/ChatSessionDetailResponse.java
@@ -1,0 +1,26 @@
+package com.documind.documind.domain.chat;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+// GET /api/chat/sessions/{id} 상세 조회 응답 DTO. 세션 정보와 전체 메시지 목록을 포함
+// @Builder: 서비스 레이어에서 필드를 명시적으로 지정해 객체를 생성
+@Getter
+@Builder
+public class ChatSessionDetailResponse {
+
+    // 채팅 세션 식별자
+    private Long sessionId;
+
+    // 첫 질문 앞 50자를 자른 자동 생성 제목
+    private String title;
+
+    // 세션 생성 시각
+    private LocalDateTime createdAt;
+
+    // 해당 세션의 메시지 목록. 시간순 정렬 (오래된 순)으로 대화 흐름을 재현
+    private List<ChatMessageResponse> messages;
+}

--- a/backend/src/main/java/com/documind/documind/domain/chat/ChatSessionRepository.java
+++ b/backend/src/main/java/com/documind/documind/domain/chat/ChatSessionRepository.java
@@ -1,7 +1,13 @@
 package com.documind.documind.domain.chat;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 // chat_sessions 테이블 CRUD를 담당하는 JPA Repository
@@ -9,4 +15,24 @@ public interface ChatSessionRepository extends JpaRepository<ChatSession, Long> 
 
     // 비로그인 사용자의 sessionKey로 기존 세션을 조회
     Optional<ChatSession> findBySessionKey(String sessionKey);
+
+    // 로그인 사용자의 모든 세션을 최신 활동 순으로 조회. 사이드바 목록에 사용
+    @Query("SELECT s FROM ChatSession s WHERE s.user.id = :userId ORDER BY s.updatedAt DESC")
+    List<ChatSession> findByUserIdOrderByUpdatedAtDesc(@Param("userId") Long userId);
+
+    // sessionId + userId로 소유권을 검증하며 세션 조회. 로그인 사용자의 상세 조회·삭제에 사용
+    @Query("SELECT s FROM ChatSession s WHERE s.id = :id AND s.user.id = :userId")
+    Optional<ChatSession> findByIdAndUserId(@Param("id") Long id, @Param("userId") Long userId);
+
+    // sessionId + sessionKey로 소유권을 검증하며 세션 조회. 비로그인 사용자의 상세 조회·삭제에 사용
+    Optional<ChatSession> findByIdAndSessionKey(Long id, String sessionKey);
+
+    // 메시지 저장 시 세션의 마지막 활동 시각을 갱신. 사이드바 정렬 기준으로 사용
+    // @Modifying: UPDATE/DELETE 쿼리 실행을 허용. 없으면 SELECT로 처리돼 실행 안 됨
+    // flushAutomatically: 쿼리 실행 전 영속성 컨텍스트의 미반영 변경사항을 먼저 DB에 반영
+    // clearAutomatically: UPDATE 후 영속성 컨텍스트를 초기화해 이후 조회가 DB에서 최신값을 읽도록 보장
+    @Modifying(flushAutomatically = true, clearAutomatically = true)
+    @Transactional
+    @Query("UPDATE ChatSession s SET s.updatedAt = :now WHERE s.id = :id")
+    void updateUpdatedAt(@Param("id") Long id, @Param("now") LocalDateTime now);
 }

--- a/backend/src/main/java/com/documind/documind/domain/chat/ChatSessionRepository.java
+++ b/backend/src/main/java/com/documind/documind/domain/chat/ChatSessionRepository.java
@@ -10,27 +10,28 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
-// chat_sessions 테이블 CRUD를 담당하는 JPA Repository
+/** chat_sessions 테이블 CRUD를 담당하는 JPA Repository */
 public interface ChatSessionRepository extends JpaRepository<ChatSession, Long> {
 
-    // 비로그인 사용자의 sessionKey로 기존 세션을 조회
+    /** 비로그인 사용자의 sessionKey로 기존 세션을 조회한다. */
     Optional<ChatSession> findBySessionKey(String sessionKey);
 
-    // 로그인 사용자의 모든 세션을 최신 활동 순으로 조회. 사이드바 목록에 사용
+    /** 로그인 사용자의 모든 세션을 최신 활동 순으로 조회한다. 사이드바 목록에 사용한다. */
     @Query("SELECT s FROM ChatSession s WHERE s.user.id = :userId ORDER BY s.updatedAt DESC")
     List<ChatSession> findByUserIdOrderByUpdatedAtDesc(@Param("userId") Long userId);
 
-    // sessionId + userId로 소유권을 검증하며 세션 조회. 로그인 사용자의 상세 조회·삭제에 사용
+    /** sessionId + userId로 소유권을 검증하며 세션을 조회한다. 로그인 사용자의 상세 조회·삭제에 사용한다. */
     @Query("SELECT s FROM ChatSession s WHERE s.id = :id AND s.user.id = :userId")
     Optional<ChatSession> findByIdAndUserId(@Param("id") Long id, @Param("userId") Long userId);
 
-    // sessionId + sessionKey로 소유권을 검증하며 세션 조회. 비로그인 사용자의 상세 조회·삭제에 사용
+    /** sessionId + sessionKey로 소유권을 검증하며 세션을 조회한다. 비로그인 사용자의 상세 조회·삭제에 사용한다. */
     Optional<ChatSession> findByIdAndSessionKey(Long id, String sessionKey);
 
-    // 메시지 저장 시 세션의 마지막 활동 시각을 갱신. 사이드바 정렬 기준으로 사용
-    // @Modifying: UPDATE/DELETE 쿼리 실행을 허용. 없으면 SELECT로 처리돼 실행 안 됨
-    // flushAutomatically: 쿼리 실행 전 영속성 컨텍스트의 미반영 변경사항을 먼저 DB에 반영
-    // clearAutomatically: UPDATE 후 영속성 컨텍스트를 초기화해 이후 조회가 DB에서 최신값을 읽도록 보장
+    /**
+     * 메시지 저장 완료 시 세션의 마지막 활동 시각을 갱신한다. 사이드바 최신 활동 순 정렬 기준으로 사용한다.
+     * flushAutomatically: 쿼리 실행 전 영속성 컨텍스트의 미반영 변경사항을 먼저 DB에 반영한다.
+     * clearAutomatically: UPDATE 후 1차 캐시를 초기화해 이후 조회가 DB에서 최신값을 읽도록 보장한다.
+     */
     @Modifying(flushAutomatically = true, clearAutomatically = true)
     @Transactional
     @Query("UPDATE ChatSession s SET s.updatedAt = :now WHERE s.id = :id")

--- a/backend/src/main/java/com/documind/documind/domain/chat/ChatSessionSummaryResponse.java
+++ b/backend/src/main/java/com/documind/documind/domain/chat/ChatSessionSummaryResponse.java
@@ -5,8 +5,10 @@ import lombok.Getter;
 
 import java.time.LocalDateTime;
 
-// GET /api/chat/sessions 목록 응답 DTO. 세션 기본 정보만 포함해 네트워크 비용을 줄임
-// @Builder: 서비스 레이어에서 필드를 명시적으로 지정해 객체를 생성
+/**
+ * GET /api/chat/sessions 목록 응답 DTO.
+ * 세션 기본 정보만 포함해 메시지 목록을 제외함으로써 네트워크 비용을 줄인다.
+ */
 @Getter
 @Builder
 public class ChatSessionSummaryResponse {

--- a/backend/src/main/java/com/documind/documind/domain/chat/ChatSessionSummaryResponse.java
+++ b/backend/src/main/java/com/documind/documind/domain/chat/ChatSessionSummaryResponse.java
@@ -1,0 +1,25 @@
+package com.documind.documind.domain.chat;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+// GET /api/chat/sessions 목록 응답 DTO. 세션 기본 정보만 포함해 네트워크 비용을 줄임
+// @Builder: 서비스 레이어에서 필드를 명시적으로 지정해 객체를 생성
+@Getter
+@Builder
+public class ChatSessionSummaryResponse {
+
+    // 채팅 세션 식별자
+    private Long sessionId;
+
+    // 첫 질문 앞 50자를 자른 자동 생성 제목. 사이드바 목록 표시에 사용
+    private String title;
+
+    // 세션 생성 시각
+    private LocalDateTime createdAt;
+
+    // 마지막 메시지 저장 시각. 사이드바 정렬 기준 (최신 활동 순)
+    private LocalDateTime updatedAt;
+}

--- a/backend/src/main/java/com/documind/documind/global/auth/JwtAuthenticationDetails.java
+++ b/backend/src/main/java/com/documind/documind/global/auth/JwtAuthenticationDetails.java
@@ -1,0 +1,28 @@
+package com.documind.documind.global.auth;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.security.web.authentication.WebAuthenticationDetails;
+
+/**
+ * JWT 인증에서 추출한 userId와 Spring의 WebAuthenticationDetails(remoteAddress, sessionId)를 함께 보관하는 인증 세부 정보 클래스.
+ * authentication.setDetails(Long)으로 직접 저장하면 WebAuthenticationDetails를 기대하는
+ * Spring Security 내부 컴포넌트에서 ClassCastException이 발생할 수 있으므로 래핑 클래스를 사용한다.
+ */
+public class JwtAuthenticationDetails extends WebAuthenticationDetails {
+
+    private final Long userId;
+
+    /**
+     * @param request HTTP 요청. 부모 클래스가 remoteAddress와 sessionId를 캡처한다.
+     * @param userId  JWT에서 추출한 사용자 PK
+     */
+    public JwtAuthenticationDetails(HttpServletRequest request, Long userId) {
+        super(request);
+        this.userId = userId;
+    }
+
+    /** JWT에서 추출한 사용자 PK를 반환한다. */
+    public Long getUserId() {
+        return userId;
+    }
+}

--- a/backend/src/main/java/com/documind/documind/global/auth/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/documind/documind/global/auth/JwtAuthenticationFilter.java
@@ -31,6 +31,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         if (token != null && jwtProvider.validateToken(token)) {
             String username = jwtProvider.getUsername(token);
             String role = jwtProvider.getRole(token);
+            Long userId = jwtProvider.getUserId(token);
 
             // UsernamePasswordAuthenticationToken: Spring Security의 인증 객체
             UsernamePasswordAuthenticationToken authentication =
@@ -39,6 +40,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                             null,
                             List.of(new SimpleGrantedAuthority("ROLE_" + role))
                     );
+            // details에 userId를 저장해 컨트롤러에서 DB 조회 없이 소유권 검증에 사용
+            authentication.setDetails(userId);
 
             SecurityContextHolder.getContext().setAuthentication(authentication);
         }

--- a/backend/src/main/java/com/documind/documind/global/auth/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/documind/documind/global/auth/JwtAuthenticationFilter.java
@@ -40,8 +40,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                             null,
                             List.of(new SimpleGrantedAuthority("ROLE_" + role))
                     );
-            // details에 userId를 저장해 컨트롤러에서 DB 조회 없이 소유권 검증에 사용
-            authentication.setDetails(userId);
+            // JwtAuthenticationDetails: userId + WebAuthenticationDetails(remoteAddress, sessionId)를 함께 보관
+            // Long을 직접 setDetails하면 WebAuthenticationDetails를 기대하는 Spring 내부에서 ClassCastException 위험
+            authentication.setDetails(new JwtAuthenticationDetails(request, userId));
 
             SecurityContextHolder.getContext().setAuthentication(authentication);
         }

--- a/backend/src/main/java/com/documind/documind/global/auth/JwtProvider.java
+++ b/backend/src/main/java/com/documind/documind/global/auth/JwtProvider.java
@@ -34,12 +34,13 @@ public class JwtProvider {
         this.key = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
     }
 
-    // username과 role을 담아 JWT를 생성
-    public String generateToken(String username, String role) {
+    // username, role, userId를 담아 JWT를 생성. userId는 채팅 세션 소유권 검증에 사용
+    public String generateToken(String username, String role, Long userId) {
         Date now = new Date();
         return Jwts.builder()
                 .subject(username)
                 .claim("role", role)
+                .claim("userId", userId)
                 .issuedAt(now)
                 .expiration(new Date(now.getTime() + expiration))
                 .signWith(key)
@@ -65,6 +66,11 @@ public class JwtProvider {
     // JWT에서 role 클레임을 추출
     public String getRole(String token) {
         return parseClaims(token).get("role", String.class);
+    }
+
+    // JWT에서 userId 클레임을 추출. DB 조회 없이 채팅 세션 소유권 검증에 사용
+    public Long getUserId(String token) {
+        return parseClaims(token).get("userId", Long.class);
     }
 
     // JWT 유효성 검증. 만료되거나 서명이 잘못된 경우 false 반환

--- a/backend/src/main/java/com/documind/documind/global/exception/ErrorCode.java
+++ b/backend/src/main/java/com/documind/documind/global/exception/ErrorCode.java
@@ -26,6 +26,9 @@ public enum ErrorCode {
     DOCUMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "문서를 찾을 수 없습니다."),
     INVALID_FILE_TYPE(HttpStatus.BAD_REQUEST, "지원하지 않는 파일 형식입니다."),
 
+    // 채팅
+    CHAT_SESSION_NOT_FOUND(HttpStatus.NOT_FOUND, "채팅 세션을 찾을 수 없습니다."),
+
     // 서버
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다.");
 

--- a/backend/src/test/java/com/documind/documind/domain/chat/ChatHistoryTest.java
+++ b/backend/src/test/java/com/documind/documind/domain/chat/ChatHistoryTest.java
@@ -1,0 +1,148 @@
+package com.documind.documind.domain.chat;
+
+import com.documind.documind.global.exception.CustomException;
+import com.documind.documind.global.exception.ErrorCode;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+// @SpringBootTest: 전체 애플리케이션 컨텍스트를 로드해 실제 DB(H2 인메모리) 기반으로 검증
+// properties: MySQL 대신 H2를 사용하도록 데이터소스를 오버라이드
+@SpringBootTest(properties = {
+        "spring.datasource.url=jdbc:h2:mem:documind;MODE=MySQL;DB_CLOSE_DELAY=-1",
+        "spring.datasource.username=sa",
+        "spring.datasource.password=",
+        "spring.datasource.driver-class-name=org.h2.Driver",
+        "spring.jpa.hibernate.ddl-auto=create-drop"
+})
+class ChatHistoryTest {
+
+    @Autowired
+    private ChatService chatService;
+
+    @Autowired
+    private ChatSessionRepository chatSessionRepository;
+
+    @Autowired
+    private ChatMessageRepository chatMessageRepository;
+
+    private ChatSession session;
+    private static final String SESSION_KEY = "test-session-uuid-1234";
+
+    // 각 테스트 실행 전 세션과 메시지를 생성해 독립적인 테스트 환경을 보장
+    @BeforeEach
+    void setUp() {
+        session = chatSessionRepository.save(ChatSession.create(null, SESSION_KEY, "테스트 질문"));
+        ChatMessage message = ChatMessage.create(session, "테스트 질문");
+        message.complete("테스트 답변", "[{\"source\":\"test.pdf\"}]");
+        chatMessageRepository.save(message);
+    }
+
+    // 각 테스트 실행 후 생성된 데이터를 정리해 테스트 간 간섭을 방지
+    @AfterEach
+    void tearDown() {
+        chatMessageRepository.deleteByChatSessionId(session.getId());
+        // deleteById는 존재하지 않으면 EmptyResultDataAccessException을 던지므로 존재 확인 후 삭제
+        chatSessionRepository.findById(session.getId()).ifPresent(chatSessionRepository::delete);
+    }
+
+    @Test
+    void getSessions_비로그인_유효한_sessionKey_단일_세션_반환() {
+        List<ChatSessionSummaryResponse> result = chatService.getSessions(null, SESSION_KEY);
+
+        assertEquals(1, result.size());
+        assertEquals(session.getId(), result.get(0).getSessionId());
+        assertEquals("테스트 질문", result.get(0).getTitle());
+    }
+
+    @Test
+    void getSessions_sessionKey_null이면_빈_리스트_반환() {
+        List<ChatSessionSummaryResponse> result = chatService.getSessions(null, null);
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void getSessions_존재하지_않는_sessionKey는_빈_리스트_반환() {
+        List<ChatSessionSummaryResponse> result = chatService.getSessions(null, "없는-키");
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void getSessionDetail_유효한_sessionKey_세션과_메시지_반환() {
+        ChatSessionDetailResponse result = chatService.getSessionDetail(session.getId(), null, SESSION_KEY);
+
+        assertEquals(session.getId(), result.getSessionId());
+        assertEquals("테스트 질문", result.getTitle());
+        assertEquals(1, result.getMessages().size());
+
+        ChatMessageResponse msg = result.getMessages().get(0);
+        assertEquals("테스트 질문", msg.getQuestion());
+        assertEquals("테스트 답변", msg.getAnswer());
+        // H2 JSON 컬럼 타입과 JPA String 매핑의 호환성 차이로 sourceDocs가 null로 읽힐 수 있음.
+        // deserializeSources()가 null 입력 시 빈 리스트로 폴백하는 것을 검증 (NPE 발생 않음)
+        assertNotNull(msg.getSources());
+    }
+
+    @Test
+    void getSessionDetail_잘못된_sessionKey는_404_반환() {
+        CustomException ex = assertThrows(CustomException.class,
+                () -> chatService.getSessionDetail(session.getId(), null, "틀린-키"));
+
+        assertEquals(ErrorCode.CHAT_SESSION_NOT_FOUND, ex.getErrorCode());
+    }
+
+    @Test
+    void getSessionDetail_존재하지_않는_sessionId는_404_반환() {
+        CustomException ex = assertThrows(CustomException.class,
+                () -> chatService.getSessionDetail(99999L, null, SESSION_KEY));
+
+        assertEquals(ErrorCode.CHAT_SESSION_NOT_FOUND, ex.getErrorCode());
+    }
+
+    @Test
+    void getSessionDetail_sessionKey_null이면_404_반환() {
+        CustomException ex = assertThrows(CustomException.class,
+                () -> chatService.getSessionDetail(session.getId(), null, null));
+
+        assertEquals(ErrorCode.CHAT_SESSION_NOT_FOUND, ex.getErrorCode());
+    }
+
+    @Test
+    void deleteSession_유효한_sessionKey_세션과_메시지_삭제() {
+        chatService.deleteSession(session.getId(), null, SESSION_KEY);
+
+        // 세션 삭제 후 재조회 시 404가 반환돼야 함
+        CustomException ex = assertThrows(CustomException.class,
+                () -> chatService.getSessionDetail(session.getId(), null, SESSION_KEY));
+        assertEquals(ErrorCode.CHAT_SESSION_NOT_FOUND, ex.getErrorCode());
+
+        // 메시지도 함께 삭제됐는지 확인
+        assertTrue(chatMessageRepository.findByChatSessionIdOrderByCreatedAtAsc(session.getId()).isEmpty());
+    }
+
+    @Test
+    void deleteSession_잘못된_sessionKey는_404_반환() {
+        CustomException ex = assertThrows(CustomException.class,
+                () -> chatService.deleteSession(session.getId(), null, "틀린-키"));
+
+        assertEquals(ErrorCode.CHAT_SESSION_NOT_FOUND, ex.getErrorCode());
+        // 삭제되지 않았으므로 세션이 여전히 존재해야 함
+        assertTrue(chatSessionRepository.findById(session.getId()).isPresent());
+    }
+
+    @Test
+    void deleteSession_존재하지_않는_sessionId는_404_반환() {
+        CustomException ex = assertThrows(CustomException.class,
+                () -> chatService.deleteSession(99999L, null, SESSION_KEY));
+
+        assertEquals(ErrorCode.CHAT_SESSION_NOT_FOUND, ex.getErrorCode());
+    }
+}

--- a/backend/src/test/java/com/documind/documind/domain/chat/ChatHistoryTest.java
+++ b/backend/src/test/java/com/documind/documind/domain/chat/ChatHistoryTest.java
@@ -1,9 +1,12 @@
 package com.documind.documind.domain.chat;
 
+import com.documind.documind.domain.auth.User;
+import com.documind.documind.domain.auth.UserRepository;
 import com.documind.documind.global.exception.CustomException;
 import com.documind.documind.global.exception.ErrorCode;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -12,8 +15,11 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-// @SpringBootTest: 전체 애플리케이션 컨텍스트를 로드해 실제 DB(H2 인메모리) 기반으로 검증
-// properties: MySQL 대신 H2를 사용하도록 데이터소스를 오버라이드
+/**
+ * 채팅 이력 서비스 통합 테스트.
+ * @SpringBootTest: 전체 애플리케이션 컨텍스트를 로드해 실제 DB(H2 인메모리) 기반으로 검증한다.
+ * properties: MySQL 대신 H2를 사용하도록 데이터소스를 오버라이드한다.
+ */
 @SpringBootTest(properties = {
         "spring.datasource.url=jdbc:h2:mem:documind;MODE=MySQL;DB_CLOSE_DELAY=-1",
         "spring.datasource.username=sa",
@@ -32,16 +38,32 @@ class ChatHistoryTest {
     @Autowired
     private ChatMessageRepository chatMessageRepository;
 
+    @Autowired
+    private UserRepository userRepository;
+
+    // 비로그인 플로우용
     private ChatSession session;
     private static final String SESSION_KEY = "test-session-uuid-1234";
+
+    // 로그인 플로우용
+    private User testUser;
+    private ChatSession userSession;
 
     // 각 테스트 실행 전 세션과 메시지를 생성해 독립적인 테스트 환경을 보장
     @BeforeEach
     void setUp() {
+        // 비로그인 세션 + 메시지
         session = chatSessionRepository.save(ChatSession.create(null, SESSION_KEY, "테스트 질문"));
         ChatMessage message = ChatMessage.create(session, "테스트 질문");
         message.complete("테스트 답변", "[{\"source\":\"test.pdf\"}]");
         chatMessageRepository.save(message);
+
+        // 로그인 사용자 세션 + 메시지. User.create()로 테스트 전용 사용자를 직접 생성한다
+        testUser = userRepository.save(User.create("testadmin", "hashed_password", User.Role.ADMIN));
+        userSession = chatSessionRepository.save(ChatSession.create(testUser, null, "로그인 테스트 질문"));
+        ChatMessage userMessage = ChatMessage.create(userSession, "로그인 테스트 질문");
+        userMessage.complete("로그인 테스트 답변", "[]");
+        chatMessageRepository.save(userMessage);
     }
 
     // 각 테스트 실행 후 생성된 데이터를 정리해 테스트 간 간섭을 방지
@@ -50,10 +72,18 @@ class ChatHistoryTest {
         chatMessageRepository.deleteByChatSessionId(session.getId());
         // deleteById는 존재하지 않으면 EmptyResultDataAccessException을 던지므로 존재 확인 후 삭제
         chatSessionRepository.findById(session.getId()).ifPresent(chatSessionRepository::delete);
+
+        // 로그인 플로우 정리. deleteSession 테스트 실행 후 이미 삭제됐을 수 있으므로 존재 확인 필수
+        chatMessageRepository.deleteByChatSessionId(userSession.getId());
+        chatSessionRepository.findById(userSession.getId()).ifPresent(chatSessionRepository::delete);
+        userRepository.findById(testUser.getId()).ifPresent(userRepository::delete);
     }
 
+    // ── 비로그인(sessionKey 기반) 플로우 ──────────────────────────────────
+
     @Test
-    void getSessions_비로그인_유효한_sessionKey_단일_세션_반환() {
+    @DisplayName("유효한 sessionKey로 목록 조회 시 단일 세션 반환")
+    void getSessions_withValidSessionKey_returnsSingleSession() {
         List<ChatSessionSummaryResponse> result = chatService.getSessions(null, SESSION_KEY);
 
         assertEquals(1, result.size());
@@ -62,21 +92,24 @@ class ChatHistoryTest {
     }
 
     @Test
-    void getSessions_sessionKey_null이면_빈_리스트_반환() {
+    @DisplayName("sessionKey가 null이면 빈 리스트 반환")
+    void getSessions_withNullSessionKey_returnsEmptyList() {
         List<ChatSessionSummaryResponse> result = chatService.getSessions(null, null);
 
         assertTrue(result.isEmpty());
     }
 
     @Test
-    void getSessions_존재하지_않는_sessionKey는_빈_리스트_반환() {
+    @DisplayName("존재하지 않는 sessionKey로 조회 시 빈 리스트 반환")
+    void getSessions_withUnknownSessionKey_returnsEmptyList() {
         List<ChatSessionSummaryResponse> result = chatService.getSessions(null, "없는-키");
 
         assertTrue(result.isEmpty());
     }
 
     @Test
-    void getSessionDetail_유효한_sessionKey_세션과_메시지_반환() {
+    @DisplayName("유효한 sessionKey로 상세 조회 시 세션과 메시지 반환")
+    void getSessionDetail_withValidSessionKey_returnsSessionWithMessages() {
         ChatSessionDetailResponse result = chatService.getSessionDetail(session.getId(), null, SESSION_KEY);
 
         assertEquals(session.getId(), result.getSessionId());
@@ -92,7 +125,8 @@ class ChatHistoryTest {
     }
 
     @Test
-    void getSessionDetail_잘못된_sessionKey는_404_반환() {
+    @DisplayName("잘못된 sessionKey로 상세 조회 시 404 반환")
+    void getSessionDetail_withWrongSessionKey_throwsNotFound() {
         CustomException ex = assertThrows(CustomException.class,
                 () -> chatService.getSessionDetail(session.getId(), null, "틀린-키"));
 
@@ -100,7 +134,8 @@ class ChatHistoryTest {
     }
 
     @Test
-    void getSessionDetail_존재하지_않는_sessionId는_404_반환() {
+    @DisplayName("존재하지 않는 sessionId로 상세 조회 시 404 반환")
+    void getSessionDetail_withNonExistentSessionId_throwsNotFound() {
         CustomException ex = assertThrows(CustomException.class,
                 () -> chatService.getSessionDetail(99999L, null, SESSION_KEY));
 
@@ -108,7 +143,8 @@ class ChatHistoryTest {
     }
 
     @Test
-    void getSessionDetail_sessionKey_null이면_404_반환() {
+    @DisplayName("sessionKey가 null이면 상세 조회 시 404 반환")
+    void getSessionDetail_withNullSessionKey_throwsNotFound() {
         CustomException ex = assertThrows(CustomException.class,
                 () -> chatService.getSessionDetail(session.getId(), null, null));
 
@@ -116,33 +152,75 @@ class ChatHistoryTest {
     }
 
     @Test
-    void deleteSession_유효한_sessionKey_세션과_메시지_삭제() {
+    @DisplayName("유효한 sessionKey로 삭제 시 세션과 메시지가 함께 삭제됨")
+    void deleteSession_withValidSessionKey_deletesSessionAndMessages() {
         chatService.deleteSession(session.getId(), null, SESSION_KEY);
 
-        // 세션 삭제 후 재조회 시 404가 반환돼야 함
         CustomException ex = assertThrows(CustomException.class,
                 () -> chatService.getSessionDetail(session.getId(), null, SESSION_KEY));
         assertEquals(ErrorCode.CHAT_SESSION_NOT_FOUND, ex.getErrorCode());
-
-        // 메시지도 함께 삭제됐는지 확인
         assertTrue(chatMessageRepository.findByChatSessionIdOrderByCreatedAtAsc(session.getId()).isEmpty());
     }
 
     @Test
-    void deleteSession_잘못된_sessionKey는_404_반환() {
+    @DisplayName("잘못된 sessionKey로 삭제 시 404 반환 및 세션 유지")
+    void deleteSession_withWrongSessionKey_throwsNotFoundAndKeepsSession() {
         CustomException ex = assertThrows(CustomException.class,
                 () -> chatService.deleteSession(session.getId(), null, "틀린-키"));
 
         assertEquals(ErrorCode.CHAT_SESSION_NOT_FOUND, ex.getErrorCode());
-        // 삭제되지 않았으므로 세션이 여전히 존재해야 함
         assertTrue(chatSessionRepository.findById(session.getId()).isPresent());
     }
 
     @Test
-    void deleteSession_존재하지_않는_sessionId는_404_반환() {
+    @DisplayName("존재하지 않는 sessionId로 삭제 시 404 반환")
+    void deleteSession_withNonExistentSessionId_throwsNotFound() {
         CustomException ex = assertThrows(CustomException.class,
                 () -> chatService.deleteSession(99999L, null, SESSION_KEY));
 
         assertEquals(ErrorCode.CHAT_SESSION_NOT_FOUND, ex.getErrorCode());
+    }
+
+    // ── 로그인 사용자(userId 기반) 플로우 ──────────────────────────────────
+
+    @Test
+    @DisplayName("로그인 사용자의 userId로 목록 조회 시 전체 세션 반환")
+    void getSessions_withUserId_returnsUserSessions() {
+        List<ChatSessionSummaryResponse> result = chatService.getSessions(testUser.getId(), null);
+
+        assertEquals(1, result.size());
+        assertEquals(userSession.getId(), result.get(0).getSessionId());
+        assertEquals("로그인 테스트 질문", result.get(0).getTitle());
+    }
+
+    @Test
+    @DisplayName("로그인 사용자의 userId로 상세 조회 시 세션과 메시지 반환")
+    void getSessionDetail_withUserId_returnsSessionWithMessages() {
+        ChatSessionDetailResponse result = chatService.getSessionDetail(userSession.getId(), testUser.getId(), null);
+
+        assertEquals(userSession.getId(), result.getSessionId());
+        assertEquals(1, result.getMessages().size());
+        assertEquals("로그인 테스트 질문", result.getMessages().get(0).getQuestion());
+        assertNotNull(result.getMessages().get(0).getSources());
+    }
+
+    @Test
+    @DisplayName("잘못된 userId로 상세 조회 시 404 반환")
+    void getSessionDetail_withWrongUserId_throwsNotFound() {
+        CustomException ex = assertThrows(CustomException.class,
+                () -> chatService.getSessionDetail(userSession.getId(), 99999L, null));
+
+        assertEquals(ErrorCode.CHAT_SESSION_NOT_FOUND, ex.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("로그인 사용자의 userId로 삭제 시 세션과 메시지가 함께 삭제됨")
+    void deleteSession_withUserId_deletesSessionAndMessages() {
+        chatService.deleteSession(userSession.getId(), testUser.getId(), null);
+
+        CustomException ex = assertThrows(CustomException.class,
+                () -> chatService.getSessionDetail(userSession.getId(), testUser.getId(), null));
+        assertEquals(ErrorCode.CHAT_SESSION_NOT_FOUND, ex.getErrorCode());
+        assertTrue(chatMessageRepository.findByChatSessionIdOrderByCreatedAtAsc(userSession.getId()).isEmpty());
     }
 }


### PR DESCRIPTION
  ## 🔗 관련 이슈                                           
  closes #8

  ## 📝 작업 내용

  ### ✨ 채팅 이력 API 구현                                                                                          
  - `GET /api/chat/sessions` — 세션 목록 조회 (로그인: 전체 세션 최신순, 비로그인: 단일 세션)
  - `GET /api/chat/sessions/{id}` — 세션 상세 + 메시지 목록 (시간순) 조회                                            
  - `DELETE /api/chat/sessions/{id}` — 세션 및 메시지 물리삭제                                                       
                                                                                                                     
  ### ✨ JWT userId claim 추가                                                                                       
  - 기존 `username + role` → `username + role + userId` claim 추가                                                   
  - 컨트롤러에서 소유권 검증 시 DB 추가 조회 없이 토큰에서 `userId` 직접 추출
                                                                                                                     
  ### 🐛 버그 수정
  - `AnonymousAuthenticationToken.isAuthenticated()` true 반환 오인식 → `instanceof` 체크로 수정                     
  - N+1 DELETE: 파생 메서드 대신 JPQL `@Modifying @Query`로 교체                                                     
  - `session.updatedAt` 갱신 누락: `updateUpdatedAt()` JPQL 추가 (채팅 및 스트리밍 메시지 저장 완료 시점에 호출)
  - Reactor 스레드 `LazyInitializationException` 위험: 람다 캡처 변수를 `session.getId()`만 추출하도록 수정          
                                                                                                                     
  ### 🧪 테스트                                                                                                      
  - `ChatHistoryTest` 추가 (H2 인메모리, 8개 시나리오)                                                               
    - 유효한 sessionKey 목록/상세 조회, null·존재하지 않는 키 처리, 세션 삭제 및 재조회 404 확인

## 🔄 변경 유형
- [x] ✨ Feature
- [x] 🐛 Bug Fix
- [x] 🧪 Test

## 💡 참고 사항 (선택)
- `X-Session-Key` HTTP 헤더 방식 채택 — query param은 서버·nginx 로그에 UUID가 노출되어 보안 위험
  - 소유권 검증 실패 시 403 대신 404 반환 — 세션 존재 여부 외부 노출 차단                                            
  - 세션 삭제: 논리삭제 대신 물리삭제 — `sessionKey` unique constraint 재사용 시 충돌 방지
  - `./gradlew test` 통과                                                                                            
  - E2E: 데스크탑 WSL2 Docker 환경에서 6개 시나리오 PASS 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 채팅 세션 관리 추가: 세션 목록 조회, 상세 조회, 삭제 기능 제공
  * 비로그인 사용자를 위한 세션 키 기반 접근 지원
  * 인증 토큰에 사용자 식별 정보 포함으로 세션 소유권 검증 강화

* **테스트**
  * 채팅 세션 관리 기능에 대한 통합 테스트 추가

* **오류 처리**
  * 존재하지 않는 채팅 세션에 대한 명확한 404 오류 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->