### PR TITLE
feat(document): 문서 관리 API 구현 (#9)

### DIFF
--- a/ai-server/main.py
+++ b/ai-server/main.py
@@ -298,14 +298,21 @@ async def delete_document(document_id: int):
     ChromaDB에서 document_id에 해당하는 청크를 모두 삭제한다.
     Spring Boot 논리 삭제와 쌍으로 호출되어, RAG 검색에서 해당 문서가 제외되도록 한다.
     """
-    results = collection.get(
-        where={"document_id": str(document_id)},
-        include=[]  # IDs만 필요하므로 documents/embeddings/metadatas 제외
-    )
-    ids_to_delete = results["ids"]
-    if ids_to_delete:
-        collection.delete(ids=ids_to_delete)
-    return {"status": "success", "deleted_chunks": len(ids_to_delete)}
+    def _delete_from_chroma() -> int:
+        results = collection.get(
+            where={"document_id": str(document_id)},
+            include=[]  # IDs만 필요하므로 documents/embeddings/metadatas 제외
+        )
+        ids_to_delete = results["ids"]
+        if ids_to_delete:
+            collection.delete(ids=ids_to_delete)
+        return len(ids_to_delete)
+
+    # collection.get()/delete()는 동기 블로킹 호출이다.
+    # async 핸들러에서 직접 호출하면 이벤트 루프가 점유되어 다른 요청이 대기하므로
+    # /query 핸들러와 동일하게 asyncio.to_thread()로 별도 스레드에서 실행한다.
+    deleted_count = await asyncio.to_thread(_delete_from_chroma)
+    return {"status": "success", "deleted_chunks": deleted_count}
 
 
 @app.post("/query")

--- a/ai-server/main.py
+++ b/ai-server/main.py
@@ -292,6 +292,22 @@ def _prepare_query(question: str, top_k: int) -> tuple[str | None, list]:
     return prompt, sources
 
 
+@app.delete("/documents/{document_id}")
+async def delete_document(document_id: int):
+    """
+    ChromaDB에서 document_id에 해당하는 청크를 모두 삭제한다.
+    Spring Boot 논리 삭제와 쌍으로 호출되어, RAG 검색에서 해당 문서가 제외되도록 한다.
+    """
+    results = collection.get(
+        where={"document_id": str(document_id)},
+        include=[]  # IDs만 필요하므로 documents/embeddings/metadatas 제외
+    )
+    ids_to_delete = results["ids"]
+    if ids_to_delete:
+        collection.delete(ids=ids_to_delete)
+    return {"status": "success", "deleted_chunks": len(ids_to_delete)}
+
+
 @app.post("/query")
 async def query_document(request: QueryRequest):
     """

--- a/backend/src/main/java/com/documind/documind/domain/category/Category.java
+++ b/backend/src/main/java/com/documind/documind/domain/category/Category.java
@@ -33,4 +33,17 @@ public class Category {
     protected void onCreate() {
         this.createdAt = LocalDateTime.now();
     }
+
+    /**
+     * 카테고리를 생성하는 정적 팩토리 메서드.
+     * 외부에서 new Category() 대신 이 메서드를 사용한다.
+     *
+     * @param name 카테고리 이름 (unique 제약 있음)
+     * @return 생성된 Category 인스턴스
+     */
+    public static Category create(String name) {
+        Category category = new Category();
+        category.name = name;
+        return category;
+    }
 }

--- a/backend/src/main/java/com/documind/documind/domain/category/CategoryController.java
+++ b/backend/src/main/java/com/documind/documind/domain/category/CategoryController.java
@@ -1,0 +1,46 @@
+package com.documind.documind.domain.category;
+
+import com.documind.documind.global.common.ApiResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+/**
+ * 카테고리 관련 엔드포인트를 처리하는 컨트롤러.
+ * 생성은 ADMIN 전용, 목록 조회는 전체 허용 (SecurityConfig에서 제어).
+ */
+// @RestController: @Controller + @ResponseBody. JSON 응답을 자동으로 직렬화
+@RestController
+@RequestMapping("/api/categories")
+@RequiredArgsConstructor
+public class CategoryController {
+
+    private final CategoryService categoryService;
+
+    /**
+     * POST /api/categories — 카테고리 생성 (ADMIN 전용).
+     *
+     * @param request 카테고리 이름 요청 DTO
+     * @return 201 Created + 생성된 카테고리
+     */
+    @PostMapping
+    public ResponseEntity<ApiResponse<CategoryResponse>> create(@Valid @RequestBody CategoryCreateRequest request) {
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.success(categoryService.create(request)));
+    }
+
+    /**
+     * GET /api/categories — 카테고리 목록 조회 (전체 허용).
+     * 문서 업로드 폼의 카테고리 드롭다운 등에서 사용한다.
+     *
+     * @return 카테고리 목록 (이름 오름차순)
+     */
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<CategoryResponse>>> list() {
+        return ResponseEntity.ok(ApiResponse.success(categoryService.list()));
+    }
+}

--- a/backend/src/main/java/com/documind/documind/domain/category/CategoryCreateRequest.java
+++ b/backend/src/main/java/com/documind/documind/domain/category/CategoryCreateRequest.java
@@ -1,0 +1,21 @@
+package com.documind.documind.domain.category;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 카테고리 생성 요청 DTO.
+ */
+// @NoArgsConstructor: Jackson 역직렬화에 기본 생성자가 필요하다
+@Getter
+@NoArgsConstructor
+// @AllArgsConstructor: 테스트에서 직접 인스턴스 생성에 사용한다
+@AllArgsConstructor
+public class CategoryCreateRequest {
+
+    // @NotBlank: null, 빈 문자열, 공백 문자열 모두 거부
+    @NotBlank(message = "카테고리 이름은 필수입니다.")
+    private String name;
+}

--- a/backend/src/main/java/com/documind/documind/domain/category/CategoryRepository.java
+++ b/backend/src/main/java/com/documind/documind/domain/category/CategoryRepository.java
@@ -1,0 +1,24 @@
+package com.documind.documind.domain.category;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+// JpaRepository<엔티티, PK타입>를 상속받으면 기본 CRUD 메서드가 자동 생성됨
+public interface CategoryRepository extends JpaRepository<Category, Long> {
+
+    /**
+     * 카테고리 이름 중복 여부를 확인한다.
+     *
+     * @param name 확인할 이름
+     * @return 동일한 이름의 카테고리가 존재하면 true
+     */
+    boolean existsByName(String name);
+
+    /**
+     * 전체 카테고리를 이름 오름차순으로 조회한다.
+     *
+     * @return 카테고리 목록 (이름 오름차순)
+     */
+    List<Category> findAllByOrderByNameAsc();
+}

--- a/backend/src/main/java/com/documind/documind/domain/category/CategoryResponse.java
+++ b/backend/src/main/java/com/documind/documind/domain/category/CategoryResponse.java
@@ -1,0 +1,27 @@
+package com.documind.documind.domain.category;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+/**
+ * 카테고리 조회 응답 DTO.
+ */
+@Getter
+@Builder
+public class CategoryResponse {
+
+    private Long id;
+    private String name;
+    private LocalDateTime createdAt;
+
+    /** Category Entity를 DTO로 변환한다. */
+    public static CategoryResponse from(Category category) {
+        return CategoryResponse.builder()
+                .id(category.getId())
+                .name(category.getName())
+                .createdAt(category.getCreatedAt())
+                .build();
+    }
+}

--- a/backend/src/main/java/com/documind/documind/domain/category/CategoryService.java
+++ b/backend/src/main/java/com/documind/documind/domain/category/CategoryService.java
@@ -1,0 +1,58 @@
+package com.documind.documind.domain.category;
+
+import com.documind.documind.global.exception.CustomException;
+import com.documind.documind.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * 카테고리 생성·조회 비즈니스 로직을 담당한다.
+ */
+// @Service: 스프링 빈으로 등록. 비즈니스 로직 계층임을 명시
+@Service
+@RequiredArgsConstructor
+public class CategoryService {
+
+    private final CategoryRepository categoryRepository;
+
+    /**
+     * 카테고리를 생성한다. 이름 중복 시 CONFLICT 오류를 반환한다.
+     *
+     * @param request 카테고리 이름 요청 DTO
+     * @return 생성된 카테고리 응답 DTO
+     * @throws CustomException 동일한 이름이 이미 존재하는 경우 CATEGORY_ALREADY_EXISTS
+     */
+    @Transactional
+    public CategoryResponse create(CategoryCreateRequest request) {
+        if (categoryRepository.existsByName(request.getName())) {
+            throw new CustomException(ErrorCode.CATEGORY_ALREADY_EXISTS);
+        }
+        // existsByName → save() 사이 동시 요청으로 unique 제약 위반 발생 시 명시적 예외로 변환한다.
+        // ADMIN 전용이라 실제 발생 가능성은 낮지만 DB constraint 위반을 500으로 노출하지 않도록 보호한다.
+        try {
+            Category category = categoryRepository.save(Category.create(request.getName()));
+            return CategoryResponse.from(category);
+        } catch (DataIntegrityViolationException e) {
+            throw new CustomException(ErrorCode.CATEGORY_ALREADY_EXISTS);
+        }
+    }
+
+    /**
+     * 전체 카테고리를 이름 오름차순으로 조회한다.
+     * 문서 업로드 폼의 카테고리 선택 드롭다운 등 공개 API에서 사용한다.
+     *
+     * @return 카테고리 목록 (이름 오름차순)
+     */
+    @Transactional(readOnly = true)
+    public List<CategoryResponse> list() {
+        return categoryRepository.findAllByOrderByNameAsc()
+                .stream()
+                .map(CategoryResponse::from)
+                .collect(Collectors.toList());
+    }
+}

--- a/backend/src/main/java/com/documind/documind/domain/document/Document.java
+++ b/backend/src/main/java/com/documind/documind/domain/document/Document.java
@@ -63,7 +63,9 @@ public class Document {
     private String summary;
 
     // NOT NULL, updatable=false: 최초 저장 후 변경 불가
-    @Column(nullable = false, updatable = false)
+    // columnDefinition="datetime(6)": 마이크로초 정밀도 지정.
+    // 미지정 시 H2(MODE=MySQL)가 DATETIME을 초 단위로만 저장해 createdAt 정렬 테스트가 불안정해진다.
+    @Column(nullable = false, updatable = false, columnDefinition = "datetime(6)")
     private LocalDateTime createdAt;
 
     // DB에 INSERT 되기 직전에 자동 실행되는 메서드

--- a/backend/src/main/java/com/documind/documind/domain/document/Document.java
+++ b/backend/src/main/java/com/documind/documind/domain/document/Document.java
@@ -88,8 +88,20 @@ public class Document {
         return doc;
     }
 
-    // FastAPI 처리 완료 후 청크 수를 업데이트하는 메서드
+    /**
+     * FastAPI 처리 완료 후 청크 수를 업데이트한다.
+     *
+     * @param chunkCount ChromaDB에 저장된 청크 수
+     */
     public void updateChunkCount(int chunkCount) {
         this.chunkCount = chunkCount;
+    }
+
+    /**
+     * 문서를 논리 삭제한다. is_active=false로 설정해 FK 무결성을 보존하면서 비활성화한다.
+     * 채팅 메시지의 출처(sources) JSON이 document_id를 참조하므로 물리 삭제를 사용하지 않는다.
+     */
+    public void deactivate() {
+        this.isActive = false;
     }
 }

--- a/backend/src/main/java/com/documind/documind/domain/document/DocumentController.java
+++ b/backend/src/main/java/com/documind/documind/domain/document/DocumentController.java
@@ -4,13 +4,16 @@ import com.documind.documind.global.common.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
-// 문서 관련 엔드포인트를 처리하는 컨트롤러
+import java.util.List;
+
+/**
+ * 문서 관련 엔드포인트를 처리하는 컨트롤러.
+ * 업로드·목록 조회·삭제는 ADMIN 전용 (SecurityConfig에서 제어).
+ */
+// @RestController: @Controller + @ResponseBody. JSON 응답을 자동으로 직렬화
 @RestController
 @RequestMapping("/api/documents")
 @RequiredArgsConstructor
@@ -18,8 +21,10 @@ public class DocumentController {
 
     private final DocumentService documentService;
 
-    // POST /api/documents - 문서 업로드 (ADMIN 전용)
-    // @RequestParam: multipart/form-data에서 각 파트를 개별 파라미터로 바인딩
+    /**
+     * POST /api/documents — 문서 업로드 (ADMIN 전용).
+     * @RequestParam: multipart/form-data에서 각 파트를 개별 파라미터로 바인딩한다.
+     */
     @PostMapping
     public ResponseEntity<ApiResponse<DocumentUploadResponse>> upload(
             @RequestParam("file") MultipartFile file,
@@ -27,5 +32,27 @@ public class DocumentController {
     ) {
         DocumentUploadResponse response = documentService.upload(file, username);
         return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
+     * GET /api/documents — 활성화된 문서 목록 조회 (ADMIN 전용).
+     *
+     * @return 최신순 문서 목록
+     */
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<DocumentListResponse>>> list() {
+        return ResponseEntity.ok(ApiResponse.success(documentService.list()));
+    }
+
+    /**
+     * DELETE /api/documents/{id} — 문서 논리 삭제 + ChromaDB 청크 제거 (ADMIN 전용).
+     *
+     * @param id 삭제할 문서 PK
+     * @return 204 No Content
+     */
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(@PathVariable Long id) {
+        documentService.delete(id);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/backend/src/main/java/com/documind/documind/domain/document/DocumentListResponse.java
+++ b/backend/src/main/java/com/documind/documind/domain/document/DocumentListResponse.java
@@ -1,0 +1,37 @@
+package com.documind.documind.domain.document;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+/**
+ * 문서 목록 조회 시 각 문서의 요약 정보를 담는 DTO.
+ * summary는 고도화 단계에서 사용하므로 현재는 포함하지 않는다.
+ */
+@Getter
+@Builder
+public class DocumentListResponse {
+
+    private Long id;
+    private String originalName;
+    private String mimeType;
+    private Long fileSize;
+    private int chunkCount;
+    /** 카테고리 미분류 문서는 null */
+    private String categoryName;
+    private LocalDateTime createdAt;
+
+    /** Document Entity를 DTO로 변환한다. */
+    public static DocumentListResponse from(Document document) {
+        return DocumentListResponse.builder()
+                .id(document.getId())
+                .originalName(document.getOriginalName())
+                .mimeType(document.getMimeType())
+                .fileSize(document.getFileSize())
+                .chunkCount(document.getChunkCount())
+                .categoryName(document.getCategory() != null ? document.getCategory().getName() : null)
+                .createdAt(document.getCreatedAt())
+                .build();
+    }
+}

--- a/backend/src/main/java/com/documind/documind/domain/document/DocumentRepository.java
+++ b/backend/src/main/java/com/documind/documind/domain/document/DocumentRepository.java
@@ -1,7 +1,30 @@
 package com.documind.documind.domain.document;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+import java.util.Optional;
 
 // JpaRepository<엔티티, PK타입>를 상속받으면 기본 CRUD 메서드가 자동 생성됨
 public interface DocumentRepository extends JpaRepository<Document, Long> {
+
+    /**
+     * 활성화된 문서 전체를 생성일 내림차순으로 조회한다. 논리 삭제된 문서는 제외한다.
+     *
+     * <p>category는 LAZY 로딩이므로 파생 쿼리 사용 시 문서 N개에 대해 N번 추가 SELECT가 발생한다.
+     * LEFT JOIN FETCH로 category를 한 번에 조회해 N+1을 방지한다.</p>
+     *
+     * @return is_active=true인 문서 목록 (최신순)
+     */
+    @Query("SELECT d FROM Document d LEFT JOIN FETCH d.category WHERE d.isActive = true ORDER BY d.createdAt DESC")
+    List<Document> findAllByIsActiveTrueOrderByCreatedAtDesc();
+
+    /**
+     * 특정 ID의 활성화된 문서를 조회한다. 논리 삭제된 문서는 제외한다.
+     *
+     * @param id 문서 PK
+     * @return is_active=true인 문서. 없으면 empty
+     */
+    Optional<Document> findByIdAndIsActiveTrue(Long id);
 }

--- a/backend/src/main/java/com/documind/documind/domain/document/DocumentService.java
+++ b/backend/src/main/java/com/documind/documind/domain/document/DocumentService.java
@@ -14,6 +14,7 @@ import org.springframework.web.multipart.MultipartFile;
 import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 // 문서 업로드 비즈니스 로직을 담당
 @Service
@@ -32,6 +33,14 @@ public class DocumentService {
             "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" // XLSX
     );
 
+    /**
+     * 문서를 업로드하고 FastAPI를 통해 청킹·임베딩·ChromaDB 저장을 요청한다.
+     *
+     * @param file     업로드할 파일 (PDF/DOCX/PPTX/XLSX)
+     * @param username 업로드한 관리자 계정명
+     * @return 업로드 결과 (document_id, 파일명, 파일 크기, 청크 수)
+     * @throws CustomException 허용하지 않는 파일 형식이거나 사용자를 찾을 수 없는 경우
+     */
     @Transactional
     public DocumentUploadResponse upload(MultipartFile file, String username) {
         // 파일 형식 검증
@@ -71,5 +80,42 @@ public class DocumentService {
                 .fileSize(document.getFileSize())
                 .chunkCount(document.getChunkCount())
                 .build();
+    }
+
+    /**
+     * 활성화된 문서 전체를 최신순으로 조회한다.
+     *
+     * @return is_active=true인 문서 목록 (최신순)
+     */
+    @Transactional(readOnly = true)
+    public List<DocumentListResponse> list() {
+        return documentRepository.findAllByIsActiveTrueOrderByCreatedAtDesc()
+                .stream()
+                .map(DocumentListResponse::from)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * 문서를 논리 삭제하고 ChromaDB에서 청크를 제거한다.
+     *
+     * <p>DB 논리 삭제(is_active=false)와 ChromaDB 청크 삭제를 하나의 트랜잭션으로 처리한다.
+     * FastAPI 호출이 실패하면 {@code CustomException}(RuntimeException)이 발생해
+     * {@code @Transactional}이 롤백되므로 DB도 활성 상태로 유지된다.
+     * 단, FastAPI 호출이 성공한 뒤 트랜잭션 커밋 직전 장애가 발생하면 ChromaDB에서는
+     * 청크가 삭제됐으나 DB는 활성 상태로 남는 불일치가 생길 수 있다.
+     * 이 경우 다음 삭제 요청 시 FastAPI가 이미 없는 청크 삭제를 시도하지만 ChromaDB는
+     * 존재하지 않는 ID 삭제를 무시하므로 재시도하면 정상 처리된다.</p>
+     *
+     * @param documentId 삭제할 문서의 PK
+     * @throws CustomException 문서를 찾을 수 없는 경우 DOCUMENT_NOT_FOUND
+     */
+    @Transactional
+    public void delete(Long documentId) {
+        Document document = documentRepository.findByIdAndIsActiveTrue(documentId)
+                .orElseThrow(() -> new CustomException(ErrorCode.DOCUMENT_NOT_FOUND));
+
+        document.deactivate();
+        // FastAPI 호출 실패 시 @Transactional 롤백으로 document.deactivate()도 되돌아간다
+        fastApiClient.deleteDocument(documentId);
     }
 }

--- a/backend/src/main/java/com/documind/documind/domain/document/DocumentService.java
+++ b/backend/src/main/java/com/documind/documind/domain/document/DocumentService.java
@@ -98,9 +98,15 @@ public class DocumentService {
     /**
      * 문서를 논리 삭제하고 ChromaDB에서 청크를 제거한다.
      *
-     * <p>DB 논리 삭제(is_active=false)와 ChromaDB 청크 삭제를 하나의 트랜잭션으로 처리한다.
-     * FastAPI 호출이 실패하면 {@code CustomException}(RuntimeException)이 발생해
-     * {@code @Transactional}이 롤백되므로 DB도 활성 상태로 유지된다.</p>
+     * <p>FastAPI 호출이 실패하면 {@code CustomException}(RuntimeException)이 발생해
+     * {@code @Transactional}이 롤백되므로 DB도 활성 상태를 유지한다.
+     * HTTP 호출을 {@code @Transactional} 외부로 이동하는 방식({@code @TransactionalEventListener})은
+     * FastAPI 실패 시 DB 롤백이 불가능해 {@code is_active=false}인 문서의 청크가 RAG 검색에
+     * 계속 노출되는 더 심각한 문제가 발생한다. 이 트레이드오프를 고려해 현재 구조를 유지한다.</p>
+     *
+     * <p>알려진 엣지 케이스: FastAPI 삭제 성공 후 DB 커밋 직전 장애가 발생하면 Chroma 청크는
+     * 삭제됐으나 DB는 활성 상태로 남는 불일치가 생길 수 있다. ChromaDB는 존재하지 않는
+     * ID 삭제 요청을 무시하므로, 동일 문서에 대해 삭제를 재시도하면 정상 처리된다.</p>
      *
      * <p>{@code @Transactional} 범위 내에서 HTTP 호출이 발생하므로 FastAPI 응답 지연 시
      * DB 커넥션이 그 시간만큼 점유된다. ADMIN 전용 엔드포인트로 동시 호출 빈도가 낮고,
@@ -109,6 +115,7 @@ public class DocumentService {
      *
      * @param documentId 삭제할 문서의 PK
      * @throws CustomException 문서를 찾을 수 없는 경우 DOCUMENT_NOT_FOUND
+     * @throws CustomException FastAPI 청크 삭제 실패 시 FASTAPI_DELETE_FAILED
      */
     @Transactional
     public void delete(Long documentId) {

--- a/backend/src/main/java/com/documind/documind/domain/document/DocumentService.java
+++ b/backend/src/main/java/com/documind/documind/domain/document/DocumentService.java
@@ -100,11 +100,12 @@ public class DocumentService {
      *
      * <p>DB 논리 삭제(is_active=false)와 ChromaDB 청크 삭제를 하나의 트랜잭션으로 처리한다.
      * FastAPI 호출이 실패하면 {@code CustomException}(RuntimeException)이 발생해
-     * {@code @Transactional}이 롤백되므로 DB도 활성 상태로 유지된다.
-     * 단, FastAPI 호출이 성공한 뒤 트랜잭션 커밋 직전 장애가 발생하면 ChromaDB에서는
-     * 청크가 삭제됐으나 DB는 활성 상태로 남는 불일치가 생길 수 있다.
-     * 이 경우 다음 삭제 요청 시 FastAPI가 이미 없는 청크 삭제를 시도하지만 ChromaDB는
-     * 존재하지 않는 ID 삭제를 무시하므로 재시도하면 정상 처리된다.</p>
+     * {@code @Transactional}이 롤백되므로 DB도 활성 상태로 유지된다.</p>
+     *
+     * <p>{@code @Transactional} 범위 내에서 HTTP 호출이 발생하므로 FastAPI 응답 지연 시
+     * DB 커넥션이 그 시간만큼 점유된다. ADMIN 전용 엔드포인트로 동시 호출 빈도가 낮고,
+     * FastAPI 클라이언트의 최대 대기 시간은 {@code fastapi.response-timeout} 프로퍼티로
+     * 외부화돼 있으므로 무한 점유는 발생하지 않는다.</p>
      *
      * @param documentId 삭제할 문서의 PK
      * @throws CustomException 문서를 찾을 수 없는 경우 DOCUMENT_NOT_FOUND

--- a/backend/src/main/java/com/documind/documind/global/config/SecurityConfig.java
+++ b/backend/src/main/java/com/documind/documind/global/config/SecurityConfig.java
@@ -48,9 +48,12 @@ public class SecurityConfig {
             .authorizeHttpRequests(auth -> auth
                     // 관리자 전용 경로: ADMIN 권한 필요
                     .requestMatchers("/api/admin/**").hasRole("ADMIN")
-                    // 문서 업로드·삭제는 ADMIN 전용
+                    // 문서 업로드·목록·삭제는 ADMIN 전용
+                    .requestMatchers(HttpMethod.GET, "/api/documents").hasRole("ADMIN")
                     .requestMatchers(HttpMethod.POST, "/api/documents").hasRole("ADMIN")
                     .requestMatchers(HttpMethod.DELETE, "/api/documents/**").hasRole("ADMIN")
+                    // 카테고리 생성은 ADMIN 전용, 목록 조회는 anyRequest().permitAll()로 허용
+                    .requestMatchers(HttpMethod.POST, "/api/categories").hasRole("ADMIN")
                     // 로그인 엔드포인트: 인증 없이 접근 허용
                     .requestMatchers("/api/auth/login").permitAll()
                     // 나머지: USER는 로그인 불필요이므로 전체 허용

--- a/backend/src/main/java/com/documind/documind/global/exception/ErrorCode.java
+++ b/backend/src/main/java/com/documind/documind/global/exception/ErrorCode.java
@@ -22,9 +22,14 @@ public enum ErrorCode {
     // 문서
     FILE_READ_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "파일을 읽는 중 오류가 발생했습니다."),
     FASTAPI_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "AI 서버 문서 처리 중 오류가 발생했습니다."),
+    FASTAPI_DELETE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "AI 서버 문서 삭제 중 오류가 발생했습니다."),
     FASTAPI_QUERY_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "AI 서버 질의응답 처리 중 오류가 발생했습니다."),
     DOCUMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "문서를 찾을 수 없습니다."),
     INVALID_FILE_TYPE(HttpStatus.BAD_REQUEST, "지원하지 않는 파일 형식입니다."),
+
+    // 카테고리
+    CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "카테고리를 찾을 수 없습니다."),
+    CATEGORY_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 존재하는 카테고리 이름입니다."),
 
     // 채팅
     CHAT_SESSION_NOT_FOUND(HttpStatus.NOT_FOUND, "채팅 세션을 찾을 수 없습니다."),

--- a/backend/src/main/java/com/documind/documind/global/infra/fastapi/FastApiClient.java
+++ b/backend/src/main/java/com/documind/documind/global/infra/fastapi/FastApiClient.java
@@ -86,6 +86,25 @@ public class FastApiClient {
         }
     }
 
+    /**
+     * ChromaDB에서 해당 document_id의 청크를 삭제하도록 FastAPI에 요청한다.
+     * Spring Boot 논리 삭제와 쌍으로 호출되어 RAG 검색에서 해당 문서가 제외되도록 한다.
+     *
+     * @param documentId 삭제할 문서의 PK
+     */
+    public void deleteDocument(Long documentId) {
+        try {
+            blockingWebClient.delete()
+                    .uri("/documents/{id}", documentId)
+                    .retrieve()
+                    .bodyToMono(Void.class)
+                    .block(responseTimeout);
+        } catch (RuntimeException e) {
+            log.warn("FastAPI DELETE /documents/{} 호출 실패", documentId, e);
+            throw new CustomException(ErrorCode.FASTAPI_DELETE_FAILED);
+        }
+    }
+
     // FastAPI /query/stream SSE 엔드포인트를 구독해 data 필드 JSON 문자열 Flux를 반환
     // ServerSentEvent<String> 디코더가 SSE 포맷을 자동 파싱하므로 "data: " 접두사 제거 불필요
     public Flux<String> streamQuery(String question, int topK) {

--- a/backend/src/main/java/com/documind/documind/global/infra/fastapi/FastApiUploadResponse.java
+++ b/backend/src/main/java/com/documind/documind/global/infra/fastapi/FastApiUploadResponse.java
@@ -1,11 +1,19 @@
 package com.documind.documind.global.infra.fastapi;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
-// FastAPI POST /documents 응답을 역직렬화하는 DTO
-// FastAPI 응답 형식: {"status": "success", "filename": "...", "chunks": 42}
+/**
+ * FastAPI POST /documents 응답을 역직렬화하는 DTO.
+ * FastAPI 응답 형식: {"status": "success", "filename": "...", "chunks": 42}
+ */
 @Getter
+// @NoArgsConstructor: Jackson 역직렬화에 기본 생성자가 필요하다
+@NoArgsConstructor
+// @AllArgsConstructor: 테스트에서 Mock 응답 생성에 사용한다
+@AllArgsConstructor
 public class FastApiUploadResponse {
 
     private String status;

--- a/backend/src/test/java/com/documind/documind/domain/document/DocumentManagementTest.java
+++ b/backend/src/test/java/com/documind/documind/domain/document/DocumentManagementTest.java
@@ -132,6 +132,21 @@ class DocumentManagementTest {
     }
 
     @Test
+    @DisplayName("문서 삭제 - FastAPI 호출 실패 시 트랜잭션이 롤백되어 문서가 활성 상태를 유지한다")
+    void delete_fastApiFailureRollsBackDeactivation() {
+        // FastAPI 호출이 실패하면 @Transactional 롤백으로 document.deactivate()도 되돌아간다
+        doThrow(new RuntimeException("FastAPI unavailable"))
+                .when(fastApiClient).deleteDocument(anyLong());
+
+        assertThrows(RuntimeException.class,
+                () -> documentService.delete(activeDoc.getId()));
+
+        Document doc = documentRepository.findById(activeDoc.getId()).orElseThrow();
+        assertTrue(doc.getIsActive(),
+                "FastAPI 실패 시 @Transactional 롤백으로 isActive가 true를 유지해야 한다");
+    }
+
+    @Test
     @DisplayName("문서 삭제 - 존재하지 않는 ID는 DOCUMENT_NOT_FOUND 예외를 반환한다")
     void delete_notFoundThrowsException() {
         CustomException ex = assertThrows(CustomException.class,

--- a/backend/src/test/java/com/documind/documind/domain/document/DocumentManagementTest.java
+++ b/backend/src/test/java/com/documind/documind/domain/document/DocumentManagementTest.java
@@ -1,0 +1,226 @@
+package com.documind.documind.domain.document;
+
+import com.documind.documind.domain.auth.User;
+import com.documind.documind.domain.auth.User.Role;
+import com.documind.documind.domain.auth.UserRepository;
+import com.documind.documind.domain.category.Category;
+import com.documind.documind.domain.category.CategoryCreateRequest;
+import com.documind.documind.domain.category.CategoryRepository;
+import com.documind.documind.domain.category.CategoryResponse;
+import com.documind.documind.domain.category.CategoryService;
+import com.documind.documind.global.exception.CustomException;
+import com.documind.documind.global.exception.ErrorCode;
+import com.documind.documind.global.infra.fastapi.FastApiClient;
+import com.documind.documind.global.infra.fastapi.FastApiUploadResponse;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.*;
+
+/**
+ * 문서 관리 서비스 통합 테스트.
+ * FastApiClient는 @MockitoBean으로 대체해 외부 HTTP 호출을 격리한다.
+ */
+// @SpringBootTest: 전체 애플리케이션 컨텍스트를 로드해 실제 DB(H2 인메모리) 기반으로 검증한다.
+@SpringBootTest(properties = {
+        "spring.datasource.url=jdbc:h2:mem:documind;MODE=MySQL;DB_CLOSE_DELAY=-1",
+        "spring.datasource.username=sa",
+        "spring.datasource.password=",
+        "spring.datasource.driver-class-name=org.h2.Driver",
+        "spring.jpa.hibernate.ddl-auto=create-drop"
+})
+class DocumentManagementTest {
+
+    @Autowired
+    private DocumentService documentService;
+
+    @Autowired
+    private DocumentRepository documentRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private CategoryService categoryService;
+
+    @Autowired
+    private CategoryRepository categoryRepository;
+
+    // FastApiClient의 실제 HTTP 호출을 Mock으로 대체
+    @MockitoBean
+    private FastApiClient fastApiClient;
+
+    private User admin;
+    private Document activeDoc;
+    private static final String ADMIN_USERNAME = "admin";
+
+    @BeforeEach
+    void setUp() {
+        // 관리자 계정 생성
+        admin = userRepository.save(User.create(ADMIN_USERNAME, "encoded-password", Role.ADMIN));
+
+        // 활성 문서 직접 저장 (업로드 파이프라인 우회)
+        activeDoc = documentRepository.save(
+                Document.create(admin, null, "uuid-file.pdf", "sample.pdf", 1024L, "application/pdf")
+        );
+    }
+
+    @AfterEach
+    void tearDown() {
+        documentRepository.deleteAll();
+        categoryRepository.deleteAll();
+        userRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("문서 목록 조회 - 활성 문서만 반환한다")
+    void list_returnsOnlyActiveDocuments() {
+        // 논리 삭제된 문서 추가
+        Document inactiveDoc = documentRepository.save(
+                Document.create(admin, null, "inactive.pdf", "inactive.pdf", 512L, "application/pdf")
+        );
+        inactiveDoc.deactivate();
+        documentRepository.save(inactiveDoc);
+
+        List<DocumentListResponse> result = documentService.list();
+
+        assertEquals(1, result.size());
+        assertEquals("sample.pdf", result.get(0).getOriginalName());
+    }
+
+    @Test
+    @DisplayName("문서 목록 조회 - 최신순으로 정렬한다")
+    void list_orderedByCreatedAtDesc() throws InterruptedException {
+        // createdAt이 @PrePersist에서 LocalDateTime.now()로 설정되므로
+        // 저장 사이에 최소 1ms 간격을 두어 정렬 순서를 결정론적으로 만든다
+        Thread.sleep(2);
+        documentRepository.save(
+                Document.create(admin, null, "older.pdf", "older.pdf", 512L, "application/pdf")
+        );
+        Thread.sleep(2);
+        documentRepository.save(
+                Document.create(admin, null, "newest.pdf", "newest.pdf", 512L, "application/pdf")
+        );
+
+        List<DocumentListResponse> result = documentService.list();
+
+        // 가장 최근에 저장된 문서가 목록의 첫 번째여야 한다
+        assertEquals("newest.pdf", result.get(0).getOriginalName());
+    }
+
+    @Test
+    @DisplayName("문서 삭제 - is_active=false로 변경하고 FastAPI 청크 삭제를 호출한다")
+    void delete_deactivatesDocumentAndCallsFastApi() {
+        doNothing().when(fastApiClient).deleteDocument(anyLong());
+
+        documentService.delete(activeDoc.getId());
+
+        Document deleted = documentRepository.findById(activeDoc.getId()).orElseThrow();
+        assertFalse(deleted.getIsActive());
+        verify(fastApiClient, times(1)).deleteDocument(activeDoc.getId());
+    }
+
+    @Test
+    @DisplayName("문서 삭제 - 존재하지 않는 ID는 DOCUMENT_NOT_FOUND 예외를 반환한다")
+    void delete_notFoundThrowsException() {
+        CustomException ex = assertThrows(CustomException.class,
+                () -> documentService.delete(99999L));
+        assertEquals(ErrorCode.DOCUMENT_NOT_FOUND, ex.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("문서 삭제 - 이미 논리 삭제된 문서는 DOCUMENT_NOT_FOUND 예외를 반환한다")
+    void delete_alreadyDeactivatedThrowsException() {
+        activeDoc.deactivate();
+        documentRepository.save(activeDoc);
+
+        CustomException ex = assertThrows(CustomException.class,
+                () -> documentService.delete(activeDoc.getId()));
+        assertEquals(ErrorCode.DOCUMENT_NOT_FOUND, ex.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("문서 업로드 - FastAPI 응답 청크 수가 Document에 반영된다")
+    void upload_chunkCountUpdated() {
+        when(fastApiClient.uploadDocument(any(), anyLong()))
+                .thenReturn(new FastApiUploadResponse("success", "report.pdf", 7));
+
+        MockMultipartFile file = new MockMultipartFile(
+                "file", "report.pdf", "application/pdf", new byte[100]
+        );
+
+        DocumentUploadResponse response = documentService.upload(file, ADMIN_USERNAME);
+
+        assertEquals(7, response.getChunkCount());
+        assertEquals("report.pdf", response.getOriginalName());
+    }
+
+    @Test
+    @DisplayName("문서 업로드 - 허용하지 않는 파일 형식은 INVALID_FILE_TYPE 예외를 반환한다")
+    void upload_invalidMimeTypeThrowsException() {
+        MockMultipartFile file = new MockMultipartFile(
+                "file", "image.png", "image/png", new byte[10]
+        );
+
+        CustomException ex = assertThrows(CustomException.class,
+                () -> documentService.upload(file, ADMIN_USERNAME));
+        assertEquals(ErrorCode.INVALID_FILE_TYPE, ex.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("카테고리 생성 - 이름이 저장되고 응답에 반환된다")
+    void categoryCreate_success() {
+        // @AllArgsConstructor를 사용해 리플렉션 없이 직접 생성
+        CategoryCreateRequest req = new CategoryCreateRequest("기술문서");
+
+        CategoryResponse result = categoryService.create(req);
+
+        assertEquals("기술문서", result.getName());
+        assertNotNull(result.getId());
+        assertNotNull(result.getCreatedAt());
+    }
+
+    @Test
+    @DisplayName("카테고리 생성 - 중복 이름은 CATEGORY_ALREADY_EXISTS 예외를 반환한다")
+    void categoryCreate_duplicateNameThrowsException() {
+        categoryRepository.save(Category.create("정책문서"));
+
+        CategoryCreateRequest req = new CategoryCreateRequest("정책문서");
+
+        CustomException ex = assertThrows(CustomException.class,
+                () -> categoryService.create(req));
+        assertEquals(ErrorCode.CATEGORY_ALREADY_EXISTS, ex.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("카테고리 목록 조회 - 이름 오름차순으로 반환한다")
+    void categoryList_orderedByNameAsc() {
+        categoryRepository.save(Category.create("인사문서"));
+        categoryRepository.save(Category.create("기술문서"));
+        categoryRepository.save(Category.create("재무문서"));
+
+        List<CategoryResponse> result = categoryService.list();
+
+        assertEquals("기술문서", result.get(0).getName());
+        assertEquals("인사문서", result.get(1).getName());
+        assertEquals("재무문서", result.get(2).getName());
+    }
+
+    @Test
+    @DisplayName("카테고리 목록 조회 - 카테고리가 없으면 빈 목록을 반환한다")
+    void categoryList_emptyReturnsEmptyList() {
+        List<CategoryResponse> result = categoryService.list();
+        assertTrue(result.isEmpty());
+    }
+}

--- a/backend/src/test/java/com/documind/documind/domain/document/DocumentManagementTest.java
+++ b/backend/src/test/java/com/documind/documind/domain/document/DocumentManagementTest.java
@@ -134,12 +134,13 @@ class DocumentManagementTest {
     @Test
     @DisplayName("문서 삭제 - FastAPI 호출 실패 시 트랜잭션이 롤백되어 문서가 활성 상태를 유지한다")
     void delete_fastApiFailureRollsBackDeactivation() {
-        // FastAPI 호출이 실패하면 @Transactional 롤백으로 document.deactivate()도 되돌아간다
-        doThrow(new RuntimeException("FastAPI unavailable"))
+        // FastApiClient의 계약: 삭제 실패 시 CustomException(FASTAPI_DELETE_FAILED)를 던진다
+        doThrow(new CustomException(ErrorCode.FASTAPI_DELETE_FAILED))
                 .when(fastApiClient).deleteDocument(anyLong());
 
-        assertThrows(RuntimeException.class,
+        CustomException ex = assertThrows(CustomException.class,
                 () -> documentService.delete(activeDoc.getId()));
+        assertEquals(ErrorCode.FASTAPI_DELETE_FAILED, ex.getErrorCode());
 
         Document doc = documentRepository.findById(activeDoc.getId()).orElseThrow();
         assertTrue(doc.getIsActive(),


### PR DESCRIPTION
## 🔗 관련 이슈
closes #9

## 📝 작업 내용
- `GET /api/documents` — 활성 문서 목록 조회 (ADMIN 전용, 최신순)                                                  
- `DELETE /api/documents/{id}` — 논리 삭제 (is_active=false) + ChromaDB 청크 제거 (FastAPI `DELETE /documents/{id}`)                                                                                                  
- `POST /api/categories` — 카테고리 생성 (ADMIN 전용, `@NotBlank` 검증)                                            
- `GET /api/categories` — 카테고리 목록 조회 (전체 허용, 이름 오름차순)                                            
- `DocumentManagementTest` — 11개 시나리오 (H2 인메모리, FastApiClient `@MockitoBean`)                 
                                    
**주요 구현 사항**                                                                                                 
  - N+1 방지: `DocumentRepository`에 `@Query` + `LEFT JOIN FETCH d.category` — 파생 쿼리 사용 시 카테고리 있는 문서  
  N개에 대해 N번 추가 SELECT 발생                                                                                    
  - 트랜잭션 일관성: `DocumentService.delete()`는 FastAPI 실패 시 `@Transactional` 롤백으로 DB도 활성 상태 유지
  - Race condition 보호: `CategoryService.create()`는 `existsByName` → `save()` 사이 동시 요청의 unique 제약 위반을  
  `DataIntegrityViolationException` catch로 409 변환                                                      

## 🔄 변경 유형
- [x] ✨ Feature
- [x] 🧪 Test

## 💡 참고 사항 (선택)
  - `DELETE /api/documents/{id}`는 물리 삭제 없이 `is_active=false`로 논리 삭제 — `chat_messages.sources` JSON의 
  document_id 참조 보존 목적                                                                                         
  - 카테고리 목록(`GET /api/categories`)은 인증 불필요 — 문서 업로드 폼의 카테고리 드롭다운에서 비로그인 환경에서도
  접근 가능해야 하기 때문

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 문서 삭제 기능 강화 — 문서 비활성화 시 관련 외부 저장/색인 데이터도 함께 제거하며 실패 시 변경이 롤백됩니다.
  * 카테고리 관리 추가 — 카테고리 생성 및 이름순 목록 조회 기능 제공.
  * 문서 목록 조회 추가 — 파일명, 크기, 카테고리, 청크 수, 생성일 등 메타데이터 열람 가능.

* **테스트**
  * 문서·카테고리 관련 통합 테스트 추가 (업로드·조회·삭제 및 실패 시 롤백 시나리오 포함)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->