### PR TITLE
feat(auth): 관리자 인증 API 구현 (#10)

### DIFF
--- a/backend/src/main/java/com/documind/documind/domain/auth/AuthController.java
+++ b/backend/src/main/java/com/documind/documind/domain/auth/AuthController.java
@@ -8,7 +8,10 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 
 import org.springframework.web.bind.annotation.*;
 
-// 인증 관련 엔드포인트를 처리하는 컨트롤러
+/**
+ * 인증 관련 엔드포인트를 처리하는 컨트롤러.
+ * 로그인·로그아웃·토큰 재발급·비밀번호 변경을 담당한다.
+ */
 // @RestController: @Controller + @ResponseBody. JSON 응답을 기본으로 반환
 // @RequestMapping: 공통 URL 접두사를 지정
 @RestController
@@ -18,7 +21,10 @@ public class AuthController {
 
     private final AuthService authService;
 
-    // POST /api/auth/login - 로그인
+    /**
+     * POST /api/auth/login — 로그인.
+     * @return Access Token과 Refresh Token을 포함한 응답
+     */
     // @Valid: @NotBlank 등 DTO 유효성 검사를 활성화
     @PostMapping("/login")
     public ResponseEntity<ApiResponse<LoginResponse>> login(@Valid @RequestBody LoginRequest request) {
@@ -26,7 +32,10 @@ public class AuthController {
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
-    // POST /api/auth/logout - 로그아웃
+    /**
+     * POST /api/auth/logout — 로그아웃.
+     * DB의 Refresh Token을 NULL로 초기화해 재사용을 차단한다.
+     */
     // @AuthenticationPrincipal: SecurityContext에 저장된 principal을 주입. 필터에서 String(username)으로 저장했으므로 String으로 받는다
     @PostMapping("/logout")
     public ResponseEntity<ApiResponse<Void>> logout(@AuthenticationPrincipal String username) {
@@ -34,10 +43,25 @@ public class AuthController {
         return ResponseEntity.ok(ApiResponse.success("로그아웃 되었습니다."));
     }
 
-    // POST /api/auth/reissue - Access Token 재발급
+    /**
+     * POST /api/auth/reissue — Access Token 재발급.
+     * Refresh-Token 헤더로 유효한 Refresh Token을 전달해야 한다.
+     */
     @PostMapping("/reissue")
     public ResponseEntity<ApiResponse<String>> reissue(@RequestHeader("Refresh-Token") String refreshToken) {
         String newAccessToken = authService.reissue(refreshToken);
         return ResponseEntity.ok(ApiResponse.success(newAccessToken));
+    }
+
+    /**
+     * POST /api/auth/password — 비밀번호 변경 (ADMIN 전용).
+     * currentPassword 재확인으로 세션 탈취 공격자가 비밀번호를 교체하는 것을 방지한다.
+     */
+    @PostMapping("/password")
+    public ResponseEntity<ApiResponse<Void>> changePassword(
+            @AuthenticationPrincipal String username,
+            @Valid @RequestBody PasswordChangeRequest request) {
+        authService.changePassword(username, request.getCurrentPassword(), request.getNewPassword());
+        return ResponseEntity.ok(ApiResponse.success("비밀번호가 변경되었습니다."));
     }
 }

--- a/backend/src/main/java/com/documind/documind/domain/auth/AuthService.java
+++ b/backend/src/main/java/com/documind/documind/domain/auth/AuthService.java
@@ -51,6 +51,25 @@ public class AuthService {
         user.logout();
     }
 
+    /**
+     * 비밀번호를 변경한다.
+     * currentPassword를 재확인하는 이유: Access Token이 유효해도 세션 탈취 공격자가
+     * 비밀번호를 바꿔버리는 것을 막기 위해 본인 의사 확인이 필요하다.
+     * @throws CustomException WRONG_PASSWORD — 현재 비밀번호 불일치
+     * @throws CustomException USER_NOT_FOUND — 사용자 미존재 (정상 흐름에서는 발생하지 않음)
+     */
+    @Transactional
+    public void changePassword(String username, String currentPassword, String newPassword) {
+        User user = userRepository.findByUsername(username)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        if (!passwordEncoder.matches(currentPassword, user.getPassword())) {
+            throw new CustomException(ErrorCode.WRONG_PASSWORD);
+        }
+
+        user.changePassword(passwordEncoder.encode(newPassword));
+    }
+
     // Access Token 재발급: Refresh Token 유효성 검증 후 새로운 Access Token 발급
     @Transactional
     public String reissue(String refreshToken) {

--- a/backend/src/main/java/com/documind/documind/domain/auth/AuthService.java
+++ b/backend/src/main/java/com/documind/documind/domain/auth/AuthService.java
@@ -8,7 +8,9 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-// 로그인, 로그아웃, 토큰 재발급 비즈니스 로직을 담당
+/**
+ * 로그인, 로그아웃, 토큰 재발급, 비밀번호 변경 비즈니스 로직을 담당한다.
+ */
 // @Service: 스프링 빈으로 등록
 // @RequiredArgsConstructor: final 필드를 인자로 받는 생성자를 자동 생성 (Lombok)
 @Service
@@ -19,7 +21,11 @@ public class AuthService {
     private final PasswordEncoder passwordEncoder;
     private final JwtProvider jwtProvider;
 
-    // 로그인: username/password 검증 후 Access Token과 Refresh Token을 발급
+    /**
+     * username/password 검증 후 Access Token과 Refresh Token을 발급한다.
+     * @return 발급된 Access Token과 Refresh Token
+     * @throws CustomException INVALID_CREDENTIALS — 사용자명 또는 비밀번호 불일치
+     */
     // @Transactional: 메서드 실행 전 트랜잭션을 시작하고, 정상 종료 시 커밋, 예외 발생 시 롤백
     @Transactional
     public LoginResponse login(String username, String password) {
@@ -43,7 +49,10 @@ public class AuthService {
                 .build();
     }
 
-    // 로그아웃: DB의 Refresh Token을 NULL로 초기화하여 재사용 차단
+    /**
+     * DB의 Refresh Token을 NULL로 초기화해 재사용을 차단한다.
+     * @throws CustomException USER_NOT_FOUND — 사용자 미존재
+     */
     @Transactional
     public void logout(String username) {
         User user = userRepository.findByUsername(username)
@@ -68,9 +77,14 @@ public class AuthService {
         }
 
         user.changePassword(passwordEncoder.encode(newPassword));
+        user.logout();
     }
 
-    // Access Token 재발급: Refresh Token 유효성 검증 후 새로운 Access Token 발급
+    /**
+     * Refresh Token 유효성 검증 후 새로운 Access Token을 발급한다.
+     * @return 새로 발급된 Access Token
+     * @throws CustomException INVALID_TOKEN — Refresh Token 만료, 위조, 미저장 상태
+     */
     @Transactional
     public String reissue(String refreshToken) {
         if (!jwtProvider.validateToken(refreshToken)) {

--- a/backend/src/main/java/com/documind/documind/domain/auth/PasswordChangeRequest.java
+++ b/backend/src/main/java/com/documind/documind/domain/auth/PasswordChangeRequest.java
@@ -1,0 +1,23 @@
+package com.documind.documind.domain.auth;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * 비밀번호 변경 요청 바디를 받는 DTO.
+ * currentPassword는 본인 의사 확인용이다. Access Token이 유효하더라도 현재 비밀번호를 재확인해
+ * 세션 탈취 공격자가 비밀번호를 교체하는 것을 막는다.
+ */
+// @AllArgsConstructor: 테스트에서 리플렉션 없이 직접 생성할 수 있도록 추가
+@Getter
+@AllArgsConstructor
+public class PasswordChangeRequest {
+
+    // @NotBlank: null, 빈 문자열, 공백 문자열 모두 거부
+    @NotBlank
+    private String currentPassword;
+
+    @NotBlank
+    private String newPassword;
+}

--- a/backend/src/main/java/com/documind/documind/domain/auth/PasswordChangeRequest.java
+++ b/backend/src/main/java/com/documind/documind/domain/auth/PasswordChangeRequest.java
@@ -1,6 +1,7 @@
 package com.documind.documind.domain.auth;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -18,6 +19,8 @@ public class PasswordChangeRequest {
     @NotBlank
     private String currentPassword;
 
+    // @Size: 새 비밀번호 최소 길이 정책 검증
     @NotBlank
+    @Size(min = 8, message = "새 비밀번호는 최소 8자 이상이어야 합니다.")
     private String newPassword;
 }

--- a/backend/src/main/java/com/documind/documind/domain/auth/User.java
+++ b/backend/src/main/java/com/documind/documind/domain/auth/User.java
@@ -4,7 +4,11 @@ import jakarta.persistence.*;
 import lombok.*;
 import java.time.LocalDateTime;
 
-// DB의 users 테이블과 매핑되는 Entity 클래스임을 선언
+/**
+ * users 테이블과 매핑되는 사용자 엔티티.
+ * 관리자 인증과 Refresh Token 저장 상태를 관리한다.
+ */
+// @Entity: DB의 users 테이블과 매핑되는 Entity 클래스임을 선언
 @Entity
 // 매핑할 테이블 이름 지정 (생략하면 클래스명 그대로 사용)
 @Table(name = "users")
@@ -46,13 +50,17 @@ public class User {
     @Column(nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
-    // 로그인 시 Refresh Token 저장 및 마지막 로그인 시각 갱신
+    /**
+     * 로그인 시 Refresh Token을 저장하고 마지막 로그인 시각을 갱신한다.
+     */
     public void login(String refreshToken) {
         this.refreshToken = refreshToken;
         this.lastLoginAt = LocalDateTime.now();
     }
 
-    // 로그아웃 시 Refresh Token을 NULL로 초기화하여 재사용 차단
+    /**
+     * 로그아웃 시 Refresh Token을 NULL로 초기화하여 재사용을 차단한다.
+     */
     public void logout() {
         this.refreshToken = null;
     }
@@ -84,7 +92,9 @@ public class User {
         return user;
     }
 
-    // User 클래스 안에 Role Enum 정의
+    /**
+     * 사용자 권한.
+     */
     public enum Role {
         ADMIN, USER
     }

--- a/backend/src/main/java/com/documind/documind/domain/auth/User.java
+++ b/backend/src/main/java/com/documind/documind/domain/auth/User.java
@@ -57,6 +57,14 @@ public class User {
         this.refreshToken = null;
     }
 
+    /**
+     * 비밀번호를 변경한다.
+     * @param encodedNewPassword BCrypt 등으로 인코딩된 새 비밀번호. 호출 전 서비스 레이어에서 인코딩해야 한다.
+     */
+    public void changePassword(String encodedNewPassword) {
+        this.password = encodedNewPassword;
+    }
+
     // DB에 INSERT 되기 직전에 자동 실행되는 메서드
     @PrePersist
     protected void onCreate() {

--- a/backend/src/main/java/com/documind/documind/global/config/SecurityConfig.java
+++ b/backend/src/main/java/com/documind/documind/global/config/SecurityConfig.java
@@ -54,6 +54,8 @@ public class SecurityConfig {
                     .requestMatchers(HttpMethod.DELETE, "/api/documents/**").hasRole("ADMIN")
                     // 카테고리 생성은 ADMIN 전용, 목록 조회는 anyRequest().permitAll()로 허용
                     .requestMatchers(HttpMethod.POST, "/api/categories").hasRole("ADMIN")
+                    // 비밀번호 변경은 ADMIN 전용. 미설정 시 anyRequest().permitAll()에 걸려 비인증 요청이 서비스 레이어까지 도달한다
+                    .requestMatchers(HttpMethod.POST, "/api/auth/password").hasRole("ADMIN")
                     // 로그인 엔드포인트: 인증 없이 접근 허용
                     .requestMatchers("/api/auth/login").permitAll()
                     // 나머지: USER는 로그인 불필요이므로 전체 허용

--- a/backend/src/main/java/com/documind/documind/global/config/SecurityConfig.java
+++ b/backend/src/main/java/com/documind/documind/global/config/SecurityConfig.java
@@ -22,7 +22,10 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 import java.util.List;
 
-// Spring Security 전역 설정 클래스
+/**
+ * Spring Security 전역 설정 클래스.
+ * JWT 기반 stateless 인증, CORS, 경로별 인가 정책을 정의한다.
+ */
 // @Configuration: 스프링 설정 클래스임을 선언
 // @EnableWebSecurity: Spring Security 활성화
 @Configuration
@@ -34,6 +37,10 @@ public class SecurityConfig {
     private final AuthEntryPoint authEntryPoint;
     private final AccessDeniedHandlerImpl accessDeniedHandler;
 
+    /**
+     * HTTP 보안 필터 체인을 구성한다.
+     * 관리자 전용 API는 ADMIN 권한을 요구하고, 사용자 채팅 API는 비로그인 접근을 허용한다.
+     */
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
@@ -56,6 +63,8 @@ public class SecurityConfig {
                     .requestMatchers(HttpMethod.POST, "/api/categories").hasRole("ADMIN")
                     // 비밀번호 변경은 ADMIN 전용. 미설정 시 anyRequest().permitAll()에 걸려 비인증 요청이 서비스 레이어까지 도달한다
                     .requestMatchers(HttpMethod.POST, "/api/auth/password").hasRole("ADMIN")
+                    // 로그아웃은 DB의 Refresh Token을 제거하므로 인증된 사용자만 호출할 수 있다
+                    .requestMatchers(HttpMethod.POST, "/api/auth/logout").authenticated()
                     // 로그인 엔드포인트: 인증 없이 접근 허용
                     .requestMatchers("/api/auth/login").permitAll()
                     // 나머지: USER는 로그인 불필요이므로 전체 허용
@@ -89,7 +98,9 @@ public class SecurityConfig {
         return source;
     }
 
-    // BCrypt 해시 알고리즘으로 비밀번호를 암호화. 스프링 빈으로 등록해 어디서든 주입 가능
+    /**
+     * BCrypt 해시 알고리즘으로 비밀번호를 암호화하는 PasswordEncoder Bean을 등록한다.
+     */
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();

--- a/backend/src/main/java/com/documind/documind/global/exception/ErrorCode.java
+++ b/backend/src/main/java/com/documind/documind/global/exception/ErrorCode.java
@@ -15,6 +15,7 @@ public enum ErrorCode {
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
     EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 토큰입니다."),
     USER_NOT_FOUND(HttpStatus.UNAUTHORIZED, "사용자를 찾을 수 없습니다."),
+    WRONG_PASSWORD(HttpStatus.UNAUTHORIZED, "현재 비밀번호가 올바르지 않습니다."),
 
     // 권한
     ACCESS_DENIED(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),

--- a/backend/src/main/java/com/documind/documind/global/exception/ErrorCode.java
+++ b/backend/src/main/java/com/documind/documind/global/exception/ErrorCode.java
@@ -4,7 +4,10 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 
-// 서비스 전체에서 사용하는 에러 코드 목록. HTTP 상태코드와 메시지를 한 곳에서 관리
+/**
+ * 서비스 전체에서 사용하는 에러 코드 목록.
+ * HTTP 상태코드와 클라이언트 응답 메시지를 한 곳에서 관리한다.
+ */
 // @RequiredArgsConstructor: final 필드를 인자로 받는 생성자를 자동 생성 (Lombok)
 @Getter
 @RequiredArgsConstructor

--- a/backend/src/test/java/com/documind/documind/domain/auth/AuthApiTest.java
+++ b/backend/src/test/java/com/documind/documind/domain/auth/AuthApiTest.java
@@ -4,6 +4,8 @@ import com.documind.documind.global.auth.JwtProvider;
 import com.documind.documind.global.exception.CustomException;
 import com.documind.documind.global.exception.ErrorCode;
 import com.documind.documind.global.infra.fastapi.FastApiClient;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validator;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -12,6 +14,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -40,6 +44,9 @@ class AuthApiTest {
 
     @Autowired
     private JwtProvider jwtProvider;
+
+    @Autowired
+    private Validator validator;
 
     // FastApiClient Bean이 컨텍스트에 등록되어 있어 Mock으로 대체해야 컨텍스트 로딩이 성공한다
     @MockitoBean
@@ -126,15 +133,40 @@ class AuthApiTest {
     }
 
     @Test
-    @DisplayName("비밀번호 변경 - 현재 비밀번호 일치 시 변경되고 새 비밀번호로 로그인에 성공한다")
+    @DisplayName("비밀번호 변경 - 현재 비밀번호 일치 시 변경되고 기존 토큰과 비밀번호가 무효화된다")
     void changePassword_success() {
         String newPassword = "newPassword123";
+        LoginResponse oldLoginResponse = authService.login(ADMIN_USERNAME, RAW_PASSWORD);
 
         authService.changePassword(ADMIN_USERNAME, RAW_PASSWORD, newPassword);
+
+        // 비밀번호 변경 직후 기존 Refresh Token을 DB에서 제거해 재발급을 차단한다
+        User afterChange = userRepository.findByUsername(ADMIN_USERNAME).orElseThrow();
+        assertNull(afterChange.getRefreshToken());
+
+        CustomException reissueEx = assertThrows(CustomException.class,
+                () -> authService.reissue(oldLoginResponse.getRefreshToken()));
+        assertEquals(ErrorCode.INVALID_TOKEN, reissueEx.getErrorCode());
+
+        // 이전 비밀번호로 로그인 실패 검증
+        CustomException loginEx = assertThrows(CustomException.class,
+                () -> authService.login(ADMIN_USERNAME, RAW_PASSWORD));
+        assertEquals(ErrorCode.INVALID_CREDENTIALS, loginEx.getErrorCode());
 
         // 새 비밀번호로 로그인 성공 여부로 실제 변경을 검증
         LoginResponse response = authService.login(ADMIN_USERNAME, newPassword);
         assertNotNull(response.getAccessToken());
+    }
+
+    @Test
+    @DisplayName("비밀번호 변경 요청 - 새 비밀번호가 8자 미만이면 검증 실패한다")
+    void changePasswordRequest_shortNewPassword() {
+        PasswordChangeRequest request = new PasswordChangeRequest(RAW_PASSWORD, "short");
+
+        Set<ConstraintViolation<PasswordChangeRequest>> violations = validator.validate(request);
+
+        assertTrue(violations.stream()
+                .anyMatch(v -> "새 비밀번호는 최소 8자 이상이어야 합니다.".equals(v.getMessage())));
     }
 
     @Test

--- a/backend/src/test/java/com/documind/documind/domain/auth/AuthApiTest.java
+++ b/backend/src/test/java/com/documind/documind/domain/auth/AuthApiTest.java
@@ -12,18 +12,24 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 /**
  * 인증 API 서비스 레이어 통합 테스트.
  * FastApiClient는 @MockitoBean으로 대체해 외부 HTTP 호출을 격리한다.
  */
 // @SpringBootTest: 전체 애플리케이션 컨텍스트를 로드해 실제 DB(H2 인메모리) 기반으로 검증한다.
+// @AutoConfigureMockMvc: Spring Security 필터 체인을 포함한 MVC 요청 테스트를 활성화한다.
 @SpringBootTest(properties = {
         "spring.datasource.url=jdbc:h2:mem:documind;MODE=MySQL;DB_CLOSE_DELAY=-1",
         "spring.datasource.username=sa",
@@ -31,10 +37,14 @@ import static org.junit.jupiter.api.Assertions.*;
         "spring.datasource.driver-class-name=org.h2.Driver",
         "spring.jpa.hibernate.ddl-auto=create-drop"
 })
+@AutoConfigureMockMvc
 class AuthApiTest {
 
     @Autowired
     private AuthService authService;
+
+    @Autowired
+    private MockMvc mockMvc;
 
     @Autowired
     private UserRepository userRepository;
@@ -56,6 +66,12 @@ class AuthApiTest {
     // BCrypt 검증이 실제로 동작하므로 passwordEncoder.encode()로 저장해야 한다
     private static final String RAW_PASSWORD = "admin1234";
     private static final String ADMIN_USERNAME = "admin";
+    private static final String PASSWORD_CHANGE_JSON = """
+            {
+              "currentPassword": "admin1234",
+              "newPassword": "newPassword123"
+            }
+            """;
 
     @BeforeEach
     void setUp() {
@@ -159,6 +175,40 @@ class AuthApiTest {
     }
 
     @Test
+    @DisplayName("비밀번호 변경 API - 비인증 요청은 401을 반환한다")
+    void changePasswordApi_unauthenticated_returns401() throws Exception {
+        mockMvc.perform(post("/api/auth/password")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(PASSWORD_CHANGE_JSON))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("비밀번호 변경 API - USER 권한 요청은 403을 반환한다")
+    void changePasswordApi_userRole_returns403() throws Exception {
+        String userToken = jwtProvider.generateToken("user", User.Role.USER.name(), 999L);
+
+        mockMvc.perform(post("/api/auth/password")
+                        .header("Authorization", bearer(userToken))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(PASSWORD_CHANGE_JSON))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("비밀번호 변경 API - ADMIN 권한 요청은 200을 반환한다")
+    void changePasswordApi_adminRole_returns200() throws Exception {
+        User admin = userRepository.findByUsername(ADMIN_USERNAME).orElseThrow();
+        String adminToken = jwtProvider.generateToken(admin.getUsername(), admin.getRole().name(), admin.getId());
+
+        mockMvc.perform(post("/api/auth/password")
+                        .header("Authorization", bearer(adminToken))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(PASSWORD_CHANGE_JSON))
+                .andExpect(status().isOk());
+    }
+
+    @Test
     @DisplayName("비밀번호 변경 요청 - 새 비밀번호가 8자 미만이면 검증 실패한다")
     void changePasswordRequest_shortNewPassword() {
         PasswordChangeRequest request = new PasswordChangeRequest(RAW_PASSWORD, "short");
@@ -176,5 +226,10 @@ class AuthApiTest {
                 () -> authService.changePassword(ADMIN_USERNAME, "wrongCurrent", "newPassword123"));
 
         assertEquals(ErrorCode.WRONG_PASSWORD, ex.getErrorCode());
+    }
+
+    // Authorization 헤더에 사용할 Bearer Token 값을 생성한다
+    private String bearer(String token) {
+        return "Bearer " + token;
     }
 }

--- a/backend/src/test/java/com/documind/documind/domain/auth/AuthApiTest.java
+++ b/backend/src/test/java/com/documind/documind/domain/auth/AuthApiTest.java
@@ -1,0 +1,148 @@
+package com.documind.documind.domain.auth;
+
+import com.documind.documind.global.auth.JwtProvider;
+import com.documind.documind.global.exception.CustomException;
+import com.documind.documind.global.exception.ErrorCode;
+import com.documind.documind.global.infra.fastapi.FastApiClient;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * 인증 API 서비스 레이어 통합 테스트.
+ * FastApiClient는 @MockitoBean으로 대체해 외부 HTTP 호출을 격리한다.
+ */
+// @SpringBootTest: 전체 애플리케이션 컨텍스트를 로드해 실제 DB(H2 인메모리) 기반으로 검증한다.
+@SpringBootTest(properties = {
+        "spring.datasource.url=jdbc:h2:mem:documind;MODE=MySQL;DB_CLOSE_DELAY=-1",
+        "spring.datasource.username=sa",
+        "spring.datasource.password=",
+        "spring.datasource.driver-class-name=org.h2.Driver",
+        "spring.jpa.hibernate.ddl-auto=create-drop"
+})
+class AuthApiTest {
+
+    @Autowired
+    private AuthService authService;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @Autowired
+    private JwtProvider jwtProvider;
+
+    // FastApiClient Bean이 컨텍스트에 등록되어 있어 Mock으로 대체해야 컨텍스트 로딩이 성공한다
+    @MockitoBean
+    private FastApiClient fastApiClient;
+
+    // 테스트에서 공통으로 사용할 실제 비밀번호 (평문)
+    // BCrypt 검증이 실제로 동작하므로 passwordEncoder.encode()로 저장해야 한다
+    private static final String RAW_PASSWORD = "admin1234";
+    private static final String ADMIN_USERNAME = "admin";
+
+    @BeforeEach
+    void setUp() {
+        String encoded = passwordEncoder.encode(RAW_PASSWORD);
+        userRepository.save(User.create(ADMIN_USERNAME, encoded, User.Role.ADMIN));
+    }
+
+    @AfterEach
+    void tearDown() {
+        userRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("로그인 - 올바른 자격증명으로 Access Token과 Refresh Token을 반환한다")
+    void login_success() {
+        LoginResponse response = authService.login(ADMIN_USERNAME, RAW_PASSWORD);
+
+        assertNotNull(response.getAccessToken());
+        assertNotNull(response.getRefreshToken());
+
+        // DB에 Refresh Token이 저장됐는지 확인
+        User saved = userRepository.findByUsername(ADMIN_USERNAME).orElseThrow();
+        assertEquals(response.getRefreshToken(), saved.getRefreshToken());
+        assertNotNull(saved.getLastLoginAt());
+    }
+
+    @Test
+    @DisplayName("로그인 - 잘못된 비밀번호는 INVALID_CREDENTIALS 예외를 반환한다")
+    void login_wrongPassword() {
+        CustomException ex = assertThrows(CustomException.class,
+                () -> authService.login(ADMIN_USERNAME, "wrong-password"));
+
+        assertEquals(ErrorCode.INVALID_CREDENTIALS, ex.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("로그인 - 존재하지 않는 사용자명은 INVALID_CREDENTIALS 예외를 반환한다")
+    void login_wrongUsername() {
+        CustomException ex = assertThrows(CustomException.class,
+                () -> authService.login("nobody", RAW_PASSWORD));
+
+        assertEquals(ErrorCode.INVALID_CREDENTIALS, ex.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("로그아웃 - DB의 Refresh Token이 null로 초기화된다")
+    void logout_clearsRefreshToken() {
+        // 로그인으로 Refresh Token을 DB에 저장한 뒤 로그아웃
+        authService.login(ADMIN_USERNAME, RAW_PASSWORD);
+        authService.logout(ADMIN_USERNAME);
+
+        User saved = userRepository.findByUsername(ADMIN_USERNAME).orElseThrow();
+        assertNull(saved.getRefreshToken());
+    }
+
+    @Test
+    @DisplayName("토큰 재발급 - 유효한 Refresh Token으로 새 Access Token을 반환한다")
+    void reissue_success() {
+        LoginResponse loginResponse = authService.login(ADMIN_USERNAME, RAW_PASSWORD);
+
+        String newAccessToken = authService.reissue(loginResponse.getRefreshToken());
+
+        assertNotNull(newAccessToken);
+        assertTrue(jwtProvider.validateToken(newAccessToken));
+        assertEquals(ADMIN_USERNAME, jwtProvider.getUsername(newAccessToken));
+    }
+
+    @Test
+    @DisplayName("토큰 재발급 - 유효하지 않은 Refresh Token은 INVALID_TOKEN 예외를 반환한다")
+    void reissue_invalidToken() {
+        CustomException ex = assertThrows(CustomException.class,
+                () -> authService.reissue("invalid.token.value"));
+
+        assertEquals(ErrorCode.INVALID_TOKEN, ex.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("비밀번호 변경 - 현재 비밀번호 일치 시 변경되고 새 비밀번호로 로그인에 성공한다")
+    void changePassword_success() {
+        String newPassword = "newPassword123";
+
+        authService.changePassword(ADMIN_USERNAME, RAW_PASSWORD, newPassword);
+
+        // 새 비밀번호로 로그인 성공 여부로 실제 변경을 검증
+        LoginResponse response = authService.login(ADMIN_USERNAME, newPassword);
+        assertNotNull(response.getAccessToken());
+    }
+
+    @Test
+    @DisplayName("비밀번호 변경 - 현재 비밀번호 불일치 시 WRONG_PASSWORD 예외를 반환한다")
+    void changePassword_wrongCurrentPassword() {
+        CustomException ex = assertThrows(CustomException.class,
+                () -> authService.changePassword(ADMIN_USERNAME, "wrongCurrent", "newPassword123"));
+
+        assertEquals(ErrorCode.WRONG_PASSWORD, ex.getErrorCode());
+    }
+}


### PR DESCRIPTION
closes #10

비밀번호 변경 API(`POST /api/auth/password`) 추가.
`WRONG_PASSWORD`를 `INVALID_CREDENTIALS`와 별도 에러코드로 분리 — 로그인 실패와 비밀번호 변경 실패를 서버 로그에서 구분하기 위함.
`currentPassword` 재확인은 세션 탈취 공격자가 비밀번호를 교체하는 것을 방지하는 보안 의도.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 인증된 사용자가 비밀번호를 변경할 수 있는 POST 엔드포인트 추가(관리자 권한 필요)
  * 비밀번호 변경 시 기존 세션/토큰이 무효화되어 재로그인이 필요

* **Documentation**
  * 인증 관련 엔드포인트 및 동작에 대한 주석/설명 추가

* **Tests**
  * 로그인·로그아웃·토큰 재발급·비밀번호 변경 통합 테스트 추가(비밀번호 길이 검증 및 현재 비밀번호 불일치 경우 검증 포함)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->