### PR TITLE
refactor(security): 보안 응답 계약 및 인가 정책 정리

### DIFF
--- a/backend/src/main/java/com/documind/documind/global/auth/AccessDeniedHandlerImpl.java
+++ b/backend/src/main/java/com/documind/documind/global/auth/AccessDeniedHandlerImpl.java
@@ -1,7 +1,10 @@
 package com.documind.documind.global.auth;
 
+import com.documind.documind.global.common.ApiResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.web.access.AccessDeniedHandler;
@@ -11,17 +14,21 @@ import java.io.IOException;
 
 // 인증은 됐지만 권한이 없는 요청(USER가 /api/admin 접근 등)이 발생할 때 403을 반환
 // AccessDeniedHandler: Spring Security의 권한 부족 핸들러 인터페이스
+// @RequiredArgsConstructor: final 필드(ObjectMapper)를 생성자 주입으로 받는다
 @Component
+@RequiredArgsConstructor
 public class AccessDeniedHandlerImpl implements AccessDeniedHandler {
+
+    private final ObjectMapper objectMapper;
 
     @Override
     public void handle(HttpServletRequest request,
                        HttpServletResponse response,
                        AccessDeniedException accessDeniedException) throws IOException {
-
         response.setStatus(HttpServletResponse.SC_FORBIDDEN);
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
         response.setCharacterEncoding("UTF-8");
-        response.getWriter().write("{\"success\":false,\"data\":null,\"message\":\"접근 권한이 없습니다.\"}");
+        // 수동 JSON 문자열 대신 ApiResponse 객체를 직렬화해 전역 응답 포맷과 일관성을 유지한다
+        objectMapper.writeValue(response.getWriter(), ApiResponse.fail("접근 권한이 없습니다."));
     }
 }

--- a/backend/src/main/java/com/documind/documind/global/auth/AuthEntryPoint.java
+++ b/backend/src/main/java/com/documind/documind/global/auth/AuthEntryPoint.java
@@ -1,7 +1,10 @@
 package com.documind.documind.global.auth;
 
+import com.documind.documind.global.common.ApiResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
@@ -11,17 +14,21 @@ import java.io.IOException;
 
 // 인증되지 않은 요청(토큰 없음 또는 만료)이 보호된 경로에 접근할 때 401을 반환
 // AuthenticationEntryPoint: Spring Security의 인증 실패 진입점 인터페이스
+// @RequiredArgsConstructor: final 필드(ObjectMapper)를 생성자 주입으로 받는다
 @Component
+@RequiredArgsConstructor
 public class AuthEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper;
 
     @Override
     public void commence(HttpServletRequest request,
                          HttpServletResponse response,
                          AuthenticationException authException) throws IOException {
-
         response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
         response.setCharacterEncoding("UTF-8");
-        response.getWriter().write("{\"success\":false,\"data\":null,\"message\":\"인증이 필요합니다.\"}");
+        // 수동 JSON 문자열 대신 ApiResponse 객체를 직렬화해 전역 응답 포맷과 일관성을 유지한다
+        objectMapper.writeValue(response.getWriter(), ApiResponse.fail("인증이 필요합니다."));
     }
 }

--- a/backend/src/main/java/com/documind/documind/global/config/SecurityConfig.java
+++ b/backend/src/main/java/com/documind/documind/global/config/SecurityConfig.java
@@ -66,7 +66,7 @@ public class SecurityConfig {
                     .requestMatchers(HttpMethod.POST, "/api/auth/logout").authenticated()
 
                     // 공개 — USER 비로그인 허용
-                    .requestMatchers("/api/auth/login", "/api/auth/reissue").permitAll()
+                    .requestMatchers(HttpMethod.POST, "/api/auth/login", "/api/auth/reissue").permitAll()
                     .requestMatchers(HttpMethod.GET, "/api/categories").permitAll()
                     .requestMatchers(HttpMethod.POST, "/api/chat").permitAll()
                     .requestMatchers(HttpMethod.GET, "/api/chat/stream").permitAll()

--- a/backend/src/main/java/com/documind/documind/global/config/SecurityConfig.java
+++ b/backend/src/main/java/com/documind/documind/global/config/SecurityConfig.java
@@ -51,24 +51,32 @@ public class SecurityConfig {
             // JWT 사용으로 세션이 필요 없으므로 STATELESS로 설정
             .sessionManagement(session ->
                     session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-            // 경로별 접근 권한 설정
+            // 경로별 접근 권한 설정 — default-deny 정책: 명시하지 않은 경로는 자동 차단
             .authorizeHttpRequests(auth -> auth
-                    // 관리자 전용 경로: ADMIN 권한 필요
+                    // ADMIN 전용
                     .requestMatchers("/api/admin/**").hasRole("ADMIN")
-                    // 문서 업로드·목록·삭제는 ADMIN 전용
                     .requestMatchers(HttpMethod.GET, "/api/documents").hasRole("ADMIN")
                     .requestMatchers(HttpMethod.POST, "/api/documents").hasRole("ADMIN")
                     .requestMatchers(HttpMethod.DELETE, "/api/documents/**").hasRole("ADMIN")
-                    // 카테고리 생성은 ADMIN 전용, 목록 조회는 anyRequest().permitAll()로 허용
                     .requestMatchers(HttpMethod.POST, "/api/categories").hasRole("ADMIN")
-                    // 비밀번호 변경은 ADMIN 전용. 미설정 시 anyRequest().permitAll()에 걸려 비인증 요청이 서비스 레이어까지 도달한다
                     .requestMatchers(HttpMethod.POST, "/api/auth/password").hasRole("ADMIN")
+
+                    // 인증된 사용자 전용
                     // 로그아웃은 DB의 Refresh Token을 제거하므로 인증된 사용자만 호출할 수 있다
                     .requestMatchers(HttpMethod.POST, "/api/auth/logout").authenticated()
-                    // 로그인 엔드포인트: 인증 없이 접근 허용
-                    .requestMatchers("/api/auth/login").permitAll()
-                    // 나머지: USER는 로그인 불필요이므로 전체 허용
-                    .anyRequest().permitAll()
+
+                    // 공개 — USER 비로그인 허용
+                    .requestMatchers("/api/auth/login", "/api/auth/reissue").permitAll()
+                    .requestMatchers(HttpMethod.GET, "/api/categories").permitAll()
+                    .requestMatchers(HttpMethod.POST, "/api/chat").permitAll()
+                    .requestMatchers(HttpMethod.GET, "/api/chat/stream").permitAll()
+                    .requestMatchers(HttpMethod.GET, "/api/chat/sessions").permitAll()
+                    .requestMatchers(HttpMethod.GET, "/api/chat/sessions/**").permitAll()
+                    .requestMatchers(HttpMethod.DELETE, "/api/chat/sessions/**").permitAll()
+                    .requestMatchers("/error", "/actuator/health").permitAll()
+
+                    // 명시되지 않은 모든 요청 차단 — 새 API 추가 시 반드시 위에 명시해야 한다
+                    .anyRequest().denyAll()
             )
             // 인증/권한 예외 처리 핸들러 등록
             .exceptionHandling(ex -> ex

--- a/backend/src/main/java/com/documind/documind/global/exception/ErrorCode.java
+++ b/backend/src/main/java/com/documind/documind/global/exception/ErrorCode.java
@@ -23,6 +23,14 @@ public enum ErrorCode {
     // 권한
     ACCESS_DENIED(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
 
+    // FastAPI 서버 통신 오류 — 클라이언트가 재시도 가능 여부를 판단하도록 HTTP 상태코드로 구분한다
+    // 504: 타임아웃 (잠시 후 재시도 가능)
+    FASTAPI_TIMEOUT(HttpStatus.GATEWAY_TIMEOUT, "AI 서버 응답이 지연되고 있습니다. 잠시 후 다시 시도해주세요."),
+    // 503: AI 서버가 올라와 있지 않거나 과부하 상태
+    FASTAPI_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE, "AI 서버가 일시적으로 사용 불가합니다."),
+    // 502: 네트워크 레벨 연결 실패 (DNS, 연결 거부 등)
+    FASTAPI_CONNECTION_FAILED(HttpStatus.BAD_GATEWAY, "AI 서버에 연결할 수 없습니다."),
+
     // 문서
     FILE_READ_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "파일을 읽는 중 오류가 발생했습니다."),
     FASTAPI_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "AI 서버 문서 처리 중 오류가 발생했습니다."),

--- a/backend/src/main/java/com/documind/documind/global/infra/fastapi/FastApiClient.java
+++ b/backend/src/main/java/com/documind/documind/global/infra/fastapi/FastApiClient.java
@@ -65,6 +65,10 @@ public class FastApiClient {
         } catch (WebClientRequestException e) {
             log.warn("FastAPI /documents 연결 실패. documentId={}", documentId, e);
             throw new CustomException(ErrorCode.FASTAPI_CONNECTION_FAILED);
+        } catch (IllegalStateException e) {
+            // .block(Duration) 타임아웃 시 Reactor가 IllegalStateException을 던진다
+            log.warn("FastAPI /documents 응답 타임아웃. documentId={}", documentId, e);
+            throw new CustomException(ErrorCode.FASTAPI_TIMEOUT);
         } catch (RuntimeException e) {
             log.warn("FastAPI /documents 호출 실패. documentId={}", documentId, e);
             throw new CustomException(ErrorCode.FASTAPI_UPLOAD_FAILED);
@@ -94,6 +98,10 @@ public class FastApiClient {
         } catch (WebClientRequestException e) {
             log.warn("FastAPI /query 연결 실패. topK={}", topK, e);
             throw new CustomException(ErrorCode.FASTAPI_CONNECTION_FAILED);
+        } catch (IllegalStateException e) {
+            // .block(Duration) 타임아웃 시 Reactor가 IllegalStateException을 던진다
+            log.warn("FastAPI /query 응답 타임아웃. topK={}", topK, e);
+            throw new CustomException(ErrorCode.FASTAPI_TIMEOUT);
         } catch (RuntimeException e) {
             log.warn("FastAPI /query 호출 실패. topK={}", topK, e);
             throw new CustomException(ErrorCode.FASTAPI_QUERY_FAILED);
@@ -119,6 +127,10 @@ public class FastApiClient {
         } catch (WebClientRequestException e) {
             log.warn("FastAPI DELETE /documents/{} 연결 실패", documentId, e);
             throw new CustomException(ErrorCode.FASTAPI_CONNECTION_FAILED);
+        } catch (IllegalStateException e) {
+            // .block(Duration) 타임아웃 시 Reactor가 IllegalStateException을 던진다
+            log.warn("FastAPI DELETE /documents/{} 응답 타임아웃", documentId, e);
+            throw new CustomException(ErrorCode.FASTAPI_TIMEOUT);
         } catch (RuntimeException e) {
             log.warn("FastAPI DELETE /documents/{} 호출 실패", documentId, e);
             throw new CustomException(ErrorCode.FASTAPI_DELETE_FAILED);

--- a/backend/src/main/java/com/documind/documind/global/infra/fastapi/FastApiClient.java
+++ b/backend/src/main/java/com/documind/documind/global/infra/fastapi/FastApiClient.java
@@ -13,6 +13,8 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.reactive.function.BodyInserters;
 import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientRequestException;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
 import reactor.core.publisher.Flux;
 
 import java.time.Duration;
@@ -57,6 +59,12 @@ public class FastApiClient {
                     .bodyToMono(FastApiUploadResponse.class)
                     .block(responseTimeout);
             return Objects.requireNonNull(response, "FastAPI /documents 응답이 null입니다.");
+        } catch (WebClientResponseException.ServiceUnavailable e) {
+            log.warn("FastAPI /documents 서비스 불가. documentId={}", documentId, e);
+            throw new CustomException(ErrorCode.FASTAPI_UNAVAILABLE);
+        } catch (WebClientRequestException e) {
+            log.warn("FastAPI /documents 연결 실패. documentId={}", documentId, e);
+            throw new CustomException(ErrorCode.FASTAPI_CONNECTION_FAILED);
         } catch (RuntimeException e) {
             log.warn("FastAPI /documents 호출 실패. documentId={}", documentId, e);
             throw new CustomException(ErrorCode.FASTAPI_UPLOAD_FAILED);
@@ -80,6 +88,12 @@ public class FastApiClient {
                     .block(responseTimeout);
             // FastAPI 응답이 null인 경우 명시적 예외로 변환
             return Objects.requireNonNull(response, "FastAPI /query 응답이 null입니다.");
+        } catch (WebClientResponseException.ServiceUnavailable e) {
+            log.warn("FastAPI /query 서비스 불가. topK={}", topK, e);
+            throw new CustomException(ErrorCode.FASTAPI_UNAVAILABLE);
+        } catch (WebClientRequestException e) {
+            log.warn("FastAPI /query 연결 실패. topK={}", topK, e);
+            throw new CustomException(ErrorCode.FASTAPI_CONNECTION_FAILED);
         } catch (RuntimeException e) {
             log.warn("FastAPI /query 호출 실패. topK={}", topK, e);
             throw new CustomException(ErrorCode.FASTAPI_QUERY_FAILED);
@@ -99,6 +113,12 @@ public class FastApiClient {
                     .retrieve()
                     .bodyToMono(Void.class)
                     .block(responseTimeout);
+        } catch (WebClientResponseException.ServiceUnavailable e) {
+            log.warn("FastAPI DELETE /documents/{} 서비스 불가", documentId, e);
+            throw new CustomException(ErrorCode.FASTAPI_UNAVAILABLE);
+        } catch (WebClientRequestException e) {
+            log.warn("FastAPI DELETE /documents/{} 연결 실패", documentId, e);
+            throw new CustomException(ErrorCode.FASTAPI_CONNECTION_FAILED);
         } catch (RuntimeException e) {
             log.warn("FastAPI DELETE /documents/{} 호출 실패", documentId, e);
             throw new CustomException(ErrorCode.FASTAPI_DELETE_FAILED);

--- a/backend/src/test/java/com/documind/documind/global/infra/fastapi/FastApiClientTest.java
+++ b/backend/src/test/java/com/documind/documind/global/infra/fastapi/FastApiClientTest.java
@@ -131,7 +131,7 @@ class FastApiClientTest {
         CustomException exception = assertThrows(CustomException.class,
                 () -> shortTimeoutClient.uploadDocument(file, 7L));
 
-        assertEquals(ErrorCode.FASTAPI_UPLOAD_FAILED, exception.getErrorCode());
+        assertEquals(ErrorCode.FASTAPI_TIMEOUT, exception.getErrorCode());
     }
 
     @Test
@@ -158,7 +158,7 @@ class FastApiClientTest {
         CustomException exception = assertThrows(CustomException.class,
                 () -> shortTimeoutClient.query("질문", 5));
 
-        assertEquals(ErrorCode.FASTAPI_QUERY_FAILED, exception.getErrorCode());
+        assertEquals(ErrorCode.FASTAPI_TIMEOUT, exception.getErrorCode());
     }
 
     @Test


### PR DESCRIPTION
## 요약

- `SecurityConfig`의 `anyRequest().permitAll()` → 명시적 whitelist + `anyRequest().denyAll()`로 전환
- 공개 경로 6개 명시 추가: `/api/auth/reissue`, `GET /api/categories`, `POST /api/chat`, `GET /api/chat/stream`, `GET /api/chat/sessions/**`, `DELETE /api/chat/sessions/**`
- `AuthEntryPoint`, `AccessDeniedHandlerImpl`의 수동 JSON 문자열 → `ObjectMapper.writeValue()` + `ApiResponse.fail()`로 교체해 401/403 응답을 전역 응답 포맷과 일치시킴
- `ErrorCode`에 FastAPI 통신 오류 3종 추가: `FASTAPI_TIMEOUT`(504), `FASTAPI_UNAVAILABLE`(503), `FASTAPI_CONNECTION_FAILED`(502)
- `FastApiClient` catch 블록을 503/연결실패/RuntimeException 3단계로 세분화

## 검증

- 명시되지 않은 경로(`GET /api/foo`) 호출 시 403 반환 확인
- `/api/auth/login` 익명 호출 200 확인
- `/api/auth/password` 비인증 호출 401, USER 토큰 호출 403, ADMIN 토큰 호출 200 확인
- 401/403 응답 본문이 `{"success":false,"data":null,"message":"..."}` 포맷 일치 확인
- `./gradlew test` 전체 5개 테스트 스위트 통과

closes #42

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * AI 서버 통신 시 발생하는 타임아웃, 서비스 불가, 연결 실패 등 예외 처리를 개선했습니다.
  * 인증 및 접근 권한 관련 오류 응답 처리를 표준화했습니다.

* **New Features**
  * AI 서버 통신 관련 세 가지 새로운 오류 코드를 추가했습니다.

* **Refactor**
  * 보안 정책을 기본 차단 방식으로 변경하고 공개 엔드포인트를 명시적으로 지정했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->