### PR TITLE
refactor(chat): SSE 스트리밍 저장 책임 분리

### DIFF
--- a/backend/src/main/java/com/documind/documind/domain/chat/ChatService.java
+++ b/backend/src/main/java/com/documind/documind/domain/chat/ChatService.java
@@ -208,12 +208,16 @@ public class ChatService {
                 chatStreamPersistenceService
         );
 
-        Disposable subscription = fastApiClient.streamQuery(question, resolvedTopK)
-                .subscribe(context::onToken, context::onUpstreamError);
-        context.attachSubscription(subscription);
-
         emitter.onCompletion(context::onClientDisconnect);
         emitter.onTimeout(context::onTimeout);
         emitter.onError(context::onEmitterError);
+
+        try {
+            Disposable subscription = fastApiClient.streamQuery(question, resolvedTopK)
+                    .subscribe(context::onToken, context::onUpstreamError);
+            context.attachSubscription(subscription);
+        } catch (Exception e) {
+            context.onUpstreamError(e);
+        }
     }
 }

--- a/backend/src/main/java/com/documind/documind/domain/chat/ChatService.java
+++ b/backend/src/main/java/com/documind/documind/domain/chat/ChatService.java
@@ -6,7 +6,6 @@ import com.documind.documind.global.infra.fastapi.FastApiClient;
 import com.documind.documind.global.infra.fastapi.FastApiQueryResponse;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -16,12 +15,10 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 import reactor.core.Disposable;
 
-import java.io.IOException;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 // 질의응답 비즈니스 로직. 세션 관리 → FastAPI 호출 → 메시지 저장을 담당
 // @RequiredArgsConstructor: final 필드를 인자로 받는 생성자를 자동 생성 (Lombok)
@@ -32,6 +29,7 @@ public class ChatService {
 
     private final ChatSessionRepository chatSessionRepository;
     private final ChatMessageRepository chatMessageRepository;
+    private final ChatStreamPersistenceService chatStreamPersistenceService;
     private final FastApiClient fastApiClient;
     // Spring Boot가 자동 설정한 ObjectMapper 빈을 주입해 Jackson 전역 설정을 공유
     private final ObjectMapper objectMapper;
@@ -187,98 +185,35 @@ public class ChatService {
         }
     }
 
-    // SSE 스트리밍 질의응답.
-    // 1) 세션 생성·조회 → 메시지(question만) DB 저장
-    // 2) FastAPI /query/stream 구독 → 토큰마다 SseEmitter로 forwarding
-    // 3) done 이벤트 수신 시 answer + sources를 DB에 저장 후 emitter 완료
-    // 4) 클라이언트 연결 종료(EventSource.close()) 시 onCompletion 콜백으로 구독 취소
+    /**
+     * SSE 스트리밍 질의응답을 시작한다.
+     *
+     * @param question 사용자 질문
+     * @param sessionKey 비로그인 사용자 세션 추적 키
+     * @param topK 검색에 사용할 문서 청크 개수
+     * @param emitter 브라우저로 SSE 이벤트를 전송할 Spring MVC emitter
+     */
     public void streamChat(String question, String sessionKey, Integer topK, SseEmitter emitter) {
         int resolvedTopK = topK != null ? topK : DEFAULT_TOP_K;
 
-        // 세션 조회 또는 생성
         ChatSession session = getOrCreateSession(question, sessionKey);
-
-        // question만 먼저 저장. answer는 스트리밍 완료 후 채움
         ChatMessage message = ChatMessage.create(session, question);
         chatMessageRepository.save(message);
-        Long messageId = message.getId();
-        // Reactor 스레드 람다에서 session 객체 전체를 참조하면 LazyInitializationException 위험이 있으므로 id만 캡처
-        Long sessionId = session.getId();
 
-        // StringBuffer: onCompletion(서블릿 스레드)과 forwardToken(Reactor 스레드)이 동시 접근 가능
-        StringBuffer answerBuffer = new StringBuffer();
-        // done 이벤트 수신 여부로 정상 완료와 중단을 구분. onCompletion은 두 케이스 모두에서 호출됨
-        AtomicBoolean normallyCompleted = new AtomicBoolean(false);
+        SseStreamingContext context = new SseStreamingContext(
+                emitter,
+                message.getId(),
+                session.getId(),
+                objectMapper,
+                chatStreamPersistenceService
+        );
 
         Disposable subscription = fastApiClient.streamQuery(question, resolvedTopK)
-                .subscribe(
-                        jsonData -> {
-                            try {
-                                forwardToken(jsonData, messageId, sessionId, answerBuffer, emitter, normallyCompleted);
-                            } catch (Exception e) {
-                                log.error("SSE 토큰 전송 오류", e);
-                                emitter.completeWithError(e);
-                            }
-                        },
-                        error -> {
-                            log.error("FastAPI 스트리밍 오류", error);
-                            emitter.completeWithError(error);
-                        }
-                );
+                .subscribe(context::onToken, context::onUpstreamError);
+        context.attachSubscription(subscription);
 
-        // 클라이언트 연결 종료·타임아웃 시:
-        // 1) FastAPI 구독 취소 (GPU 연산 중단)
-        // 2) 정상 완료가 아닌 경우에만 answerBuffer의 부분 답변을 DB에 저장
-        emitter.onCompletion(() -> {
-            subscription.dispose();
-            if (!normallyCompleted.get() && answerBuffer.length() > 0) {
-                chatMessageRepository.findById(messageId).ifPresent(m -> {
-                    m.complete(answerBuffer.toString(), "[]");
-                    chatMessageRepository.save(m);
-                });
-            }
-        });
-        emitter.onTimeout(subscription::dispose);
-        emitter.onError(t -> subscription.dispose());
-    }
-
-    // SSE data JSON을 파싱해 token이면 emitter에 forwarding, done이면 DB 저장 후 완료
-    private void forwardToken(String jsonData, Long messageId, Long sessionId, StringBuffer answerBuffer, SseEmitter emitter, AtomicBoolean normallyCompleted) throws IOException {
-        JsonNode node = objectMapper.readTree(jsonData);
-
-        if (node.has("token")) {
-            answerBuffer.append(node.get("token").asText());
-            // 원본 JSON을 그대로 전달해 React에서 추가 파싱 없이 사용 가능하도록 함
-            emitter.send(SseEmitter.event().data(jsonData));
-        } else if (node.has("done") && node.get("done").asBoolean()) {
-            String sourcesJson = node.has("sources")
-                    ? objectMapper.writeValueAsString(node.get("sources"))
-                    : "[]";
-
-            // done 이벤트에 answer가 직접 포함된 경우(빈 문서) answerBuffer 대신 사용
-            String finalAnswer = node.has("answer")
-                    ? node.get("answer").asText()
-                    : answerBuffer.toString();
-
-            // DB에 완성된 answer + sources 저장
-            chatMessageRepository.findById(messageId).ifPresent(m -> {
-                m.complete(finalAnswer, sourcesJson);
-                chatMessageRepository.save(m);
-            });
-
-            // 세션의 마지막 활동 시각 갱신. @Transactional이 없는 Reactor 스레드에서 호출되므로
-            // Repository 메서드의 자체 @Transactional로 새 트랜잭션을 시작해 UPDATE 실행
-            chatSessionRepository.updateUpdatedAt(sessionId, LocalDateTime.now());
-
-            emitter.send(SseEmitter.event().data(jsonData));
-            // DB 저장과 SSE 전송이 모두 성공한 뒤에만 정상 완료로 표시.
-            // 이전에 이 플래그를 먼저 올리면 그 사이 예외 발생 시 onCompletion 폴백이 건너뛰어진다.
-            normallyCompleted.set(true);
-            emitter.complete();
-        } else if (node.has("error")) {
-            log.error("FastAPI 오류 이벤트: {}", node.get("error").asText());
-            emitter.send(SseEmitter.event().data(jsonData));
-            emitter.complete();
-        }
+        emitter.onCompletion(context::onClientDisconnect);
+        emitter.onTimeout(context::onTimeout);
+        emitter.onError(context::onEmitterError);
     }
 }

--- a/backend/src/main/java/com/documind/documind/domain/chat/ChatStreamPersistenceService.java
+++ b/backend/src/main/java/com/documind/documind/domain/chat/ChatStreamPersistenceService.java
@@ -1,0 +1,45 @@
+package com.documind.documind.domain.chat;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+/**
+ * SSE 스트리밍 콜백에서 발생하는 채팅 메시지 저장을 명시적 트랜잭션으로 처리한다.
+ */
+@Service
+@RequiredArgsConstructor
+public class ChatStreamPersistenceService {
+
+    private final ChatMessageRepository chatMessageRepository;
+    private final ChatSessionRepository chatSessionRepository;
+
+    /**
+     * 스트리밍 정상 완료 시 답변과 출처를 저장하고 세션의 마지막 활동 시각을 갱신한다.
+     *
+     * @param messageId 저장할 메시지 ID
+     * @param sessionId 마지막 활동 시각을 갱신할 세션 ID
+     * @param answer 완성된 LLM 답변
+     * @param sourcesJson 답변 출처 JSON 문자열
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void completeMessage(Long messageId, Long sessionId, String answer, String sourcesJson) {
+        chatMessageRepository.findById(messageId).ifPresent(message -> message.complete(answer, sourcesJson));
+        chatSessionRepository.updateUpdatedAt(sessionId, LocalDateTime.now());
+    }
+
+    /**
+     * 스트리밍이 비정상 종료됐을 때 현재까지 누적된 부분 답변을 저장한다.
+     *
+     * @param messageId 저장할 메시지 ID
+     * @param partialAnswer 클라이언트 중단 전까지 수신한 답변 조각
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void savePartialAnswer(Long messageId, String partialAnswer) {
+        chatMessageRepository.findById(messageId)
+                .ifPresent(message -> message.complete(partialAnswer, "[]"));
+    }
+}

--- a/backend/src/main/java/com/documind/documind/domain/chat/SseStreamingContext.java
+++ b/backend/src/main/java/com/documind/documind/domain/chat/SseStreamingContext.java
@@ -1,5 +1,6 @@
 package com.documind.documind.domain.chat;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
@@ -60,8 +61,16 @@ class SseStreamingContext {
      * @param jsonData FastAPI가 보낸 SSE data JSON 문자열
      */
     void onToken(String jsonData) {
+        JsonNode node;
         try {
-            JsonNode node = objectMapper.readTree(jsonData);
+            node = objectMapper.readTree(jsonData);
+        } catch (JsonProcessingException e) {
+            log.error("SSE 토큰 JSON 파싱 오류", e);
+            sendSafeErrorAndComplete(STREAM_ERROR_CODE, STREAM_ERROR_MESSAGE);
+            return;
+        }
+
+        try {
             if (node.has("token")) {
                 handleTokenEvent(jsonData, node);
             } else if (node.has("done") && node.get("done").asBoolean()) {
@@ -69,6 +78,11 @@ class SseStreamingContext {
             } else if (node.has("error")) {
                 handleErrorEvent(jsonData, node);
             }
+        } catch (JsonProcessingException e) {
+            log.error("SSE 토큰 JSON 직렬화 오류", e);
+            sendSafeErrorAndComplete(STREAM_ERROR_CODE, STREAM_ERROR_MESSAGE);
+        } catch (IOException e) {
+            handleEmitterSendFailure(e);
         } catch (Exception e) {
             log.error("SSE 토큰 처리 오류", e);
             sendSafeErrorAndComplete(STREAM_ERROR_CODE, STREAM_ERROR_MESSAGE);
@@ -143,6 +157,12 @@ class SseStreamingContext {
     private void handleErrorEvent(String jsonData, JsonNode node) {
         log.error("FastAPI 오류 이벤트: {}", node.get("error").asText());
         sendSafeErrorAndComplete(UPSTREAM_ERROR_CODE, UPSTREAM_ERROR_MESSAGE);
+    }
+
+    private void handleEmitterSendFailure(IOException error) {
+        log.warn("SSE 이벤트 전송 실패. 클라이언트 연결 종료로 보고 부분 답변 저장을 시도합니다.", error);
+        onClientDisconnect();
+        emitter.complete();
     }
 
     private void sendSafeErrorAndComplete(String code, String message) {

--- a/backend/src/main/java/com/documind/documind/domain/chat/SseStreamingContext.java
+++ b/backend/src/main/java/com/documind/documind/domain/chat/SseStreamingContext.java
@@ -1,0 +1,135 @@
+package com.documind.documind.domain.chat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+import reactor.core.Disposable;
+
+import java.io.IOException;
+
+/**
+ * 단일 SSE 스트림의 상태와 FastAPI 이벤트 처리 로직을 캡슐화한다.
+ */
+@Slf4j
+class SseStreamingContext {
+
+    private final SseEmitter emitter;
+    private final Long messageId;
+    private final Long sessionId;
+    private final ObjectMapper objectMapper;
+    private final ChatStreamPersistenceService persistenceService;
+    private final StringBuffer answerBuffer = new StringBuffer();
+    private final Object persistenceLock = new Object();
+    private boolean normallyCompleted;
+    private boolean answerStored;
+    private volatile Disposable subscription;
+
+    SseStreamingContext(
+            SseEmitter emitter,
+            Long messageId,
+            Long sessionId,
+            ObjectMapper objectMapper,
+            ChatStreamPersistenceService persistenceService
+    ) {
+        this.emitter = emitter;
+        this.messageId = messageId;
+        this.sessionId = sessionId;
+        this.objectMapper = objectMapper;
+        this.persistenceService = persistenceService;
+    }
+
+    // subscribe() 이후 반환되는 Disposable을 지연 주입해 클라이언트 중단 시 upstream 구독을 취소한다.
+    void attachSubscription(Disposable subscription) {
+        this.subscription = subscription;
+    }
+
+    // FastAPI SSE data JSON 한 건을 파싱해 token/done/error 이벤트별로 처리한다.
+    void onToken(String jsonData) {
+        try {
+            JsonNode node = objectMapper.readTree(jsonData);
+            if (node.has("token")) {
+                handleTokenEvent(jsonData, node);
+            } else if (node.has("done") && node.get("done").asBoolean()) {
+                handleDoneEvent(jsonData, node);
+            } else if (node.has("error")) {
+                handleErrorEvent(jsonData, node);
+            }
+        } catch (Exception e) {
+            log.error("SSE 토큰 처리 오류", e);
+            emitter.completeWithError(e);
+        }
+    }
+
+    // 클라이언트 연결 종료 시 FastAPI 구독을 취소하고 정상 완료 전이면 부분 답변을 저장한다.
+    void onClientDisconnect() {
+        disposeSubscription();
+        synchronized (persistenceLock) {
+            String partialAnswer = currentAnswer();
+            if (!normallyCompleted && !answerStored && !partialAnswer.isEmpty()) {
+                persistenceService.savePartialAnswer(messageId, partialAnswer);
+                answerStored = true;
+            }
+        }
+    }
+
+    // Spring MVC SseEmitter timeout 시 FastAPI 구독을 취소한다.
+    void onTimeout() {
+        disposeSubscription();
+    }
+
+    // Spring MVC SseEmitter error 시 FastAPI 구독을 취소한다.
+    void onEmitterError(Throwable error) {
+        disposeSubscription();
+    }
+
+    // FastAPI 스트림 자체에서 오류가 발생하면 브라우저 SSE 연결도 오류로 종료한다.
+    void onUpstreamError(Throwable error) {
+        log.error("FastAPI 스트리밍 오류", error);
+        emitter.completeWithError(error);
+    }
+
+    private void handleTokenEvent(String jsonData, JsonNode node) throws IOException {
+        answerBuffer.append(node.get("token").asText());
+        emitter.send(SseEmitter.event().data(jsonData));
+    }
+
+    private void handleDoneEvent(String jsonData, JsonNode node) throws IOException {
+        String sourcesJson = node.has("sources")
+                ? objectMapper.writeValueAsString(node.get("sources"))
+                : "[]";
+        String finalAnswer = node.has("answer")
+                ? node.get("answer").asText()
+                : currentAnswer();
+
+        synchronized (persistenceLock) {
+            if (answerStored) {
+                return;
+            }
+            persistenceService.completeMessage(messageId, sessionId, finalAnswer, sourcesJson);
+            answerStored = true;
+            normallyCompleted = true;
+        }
+        emitter.send(SseEmitter.event().data(jsonData));
+        emitter.complete();
+    }
+
+    private void handleErrorEvent(String jsonData, JsonNode node) throws IOException {
+        log.error("FastAPI 오류 이벤트: {}", node.get("error").asText());
+        emitter.send(SseEmitter.event().data(jsonData));
+        emitter.complete();
+    }
+
+    private void disposeSubscription() {
+        Disposable currentSubscription = subscription;
+        if (currentSubscription != null && !currentSubscription.isDisposed()) {
+            currentSubscription.dispose();
+        }
+    }
+
+    private String currentAnswer() {
+        synchronized (answerBuffer) {
+            return answerBuffer.toString();
+        }
+    }
+}

--- a/backend/src/main/java/com/documind/documind/domain/chat/SseStreamingContext.java
+++ b/backend/src/main/java/com/documind/documind/domain/chat/SseStreamingContext.java
@@ -7,12 +7,18 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 import reactor.core.Disposable;
 
 import java.io.IOException;
+import java.util.Map;
 
 /**
  * 단일 SSE 스트림의 상태와 FastAPI 이벤트 처리 로직을 캡슐화한다.
  */
 @Slf4j
 class SseStreamingContext {
+
+    static final String STREAM_ERROR_CODE = "STREAM_ERROR";
+    static final String STREAM_ERROR_MESSAGE = "스트리밍 처리 중 오류가 발생했습니다.";
+    static final String UPSTREAM_ERROR_CODE = "UPSTREAM_ERROR";
+    static final String UPSTREAM_ERROR_MESSAGE = "요청 처리 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요.";
 
     private final SseEmitter emitter;
     private final Long messageId;
@@ -39,12 +45,20 @@ class SseStreamingContext {
         this.persistenceService = persistenceService;
     }
 
-    // subscribe() 이후 반환되는 Disposable을 지연 주입해 클라이언트 중단 시 upstream 구독을 취소한다.
+    /**
+     * subscribe() 이후 반환되는 Disposable을 지연 주입해 클라이언트 중단 시 upstream 구독을 취소한다.
+     *
+     * @param subscription FastAPI SSE 스트림 구독 핸들
+     */
     void attachSubscription(Disposable subscription) {
         this.subscription = subscription;
     }
 
-    // FastAPI SSE data JSON 한 건을 파싱해 token/done/error 이벤트별로 처리한다.
+    /**
+     * FastAPI SSE data JSON 한 건을 파싱해 token/done/error 이벤트별로 처리한다.
+     *
+     * @param jsonData FastAPI가 보낸 SSE data JSON 문자열
+     */
     void onToken(String jsonData) {
         try {
             JsonNode node = objectMapper.readTree(jsonData);
@@ -57,11 +71,13 @@ class SseStreamingContext {
             }
         } catch (Exception e) {
             log.error("SSE 토큰 처리 오류", e);
-            emitter.completeWithError(e);
+            sendSafeErrorAndComplete(STREAM_ERROR_CODE, STREAM_ERROR_MESSAGE);
         }
     }
 
-    // 클라이언트 연결 종료 시 FastAPI 구독을 취소하고 정상 완료 전이면 부분 답변을 저장한다.
+    /**
+     * 클라이언트 연결 종료 시 FastAPI 구독을 취소하고 정상 완료 전이면 부분 답변을 저장한다.
+     */
     void onClientDisconnect() {
         disposeSubscription();
         synchronized (persistenceLock) {
@@ -73,20 +89,30 @@ class SseStreamingContext {
         }
     }
 
-    // Spring MVC SseEmitter timeout 시 FastAPI 구독을 취소한다.
+    /**
+     * Spring MVC SseEmitter timeout 시 FastAPI 구독을 취소한다.
+     */
     void onTimeout() {
         disposeSubscription();
     }
 
-    // Spring MVC SseEmitter error 시 FastAPI 구독을 취소한다.
+    /**
+     * Spring MVC SseEmitter error 시 FastAPI 구독을 취소한다.
+     *
+     * @param error emitter에서 발생한 오류
+     */
     void onEmitterError(Throwable error) {
         disposeSubscription();
     }
 
-    // FastAPI 스트림 자체에서 오류가 발생하면 브라우저 SSE 연결도 오류로 종료한다.
+    /**
+     * FastAPI 스트림 자체에서 오류가 발생하면 안전한 오류 이벤트를 전송하고 스트림을 종료한다.
+     *
+     * @param error upstream 스트림 오류
+     */
     void onUpstreamError(Throwable error) {
         log.error("FastAPI 스트리밍 오류", error);
-        emitter.completeWithError(error);
+        sendSafeErrorAndComplete(UPSTREAM_ERROR_CODE, UPSTREAM_ERROR_MESSAGE);
     }
 
     private void handleTokenEvent(String jsonData, JsonNode node) throws IOException {
@@ -114,10 +140,36 @@ class SseStreamingContext {
         emitter.complete();
     }
 
-    private void handleErrorEvent(String jsonData, JsonNode node) throws IOException {
+    private void handleErrorEvent(String jsonData, JsonNode node) {
         log.error("FastAPI 오류 이벤트: {}", node.get("error").asText());
-        emitter.send(SseEmitter.event().data(jsonData));
-        emitter.complete();
+        sendSafeErrorAndComplete(UPSTREAM_ERROR_CODE, UPSTREAM_ERROR_MESSAGE);
+    }
+
+    private void sendSafeErrorAndComplete(String code, String message) {
+        disposeSubscription();
+        persistSafeErrorAnswer(message);
+        try {
+            String payload = objectMapper.writeValueAsString(Map.of(
+                    "type", "error",
+                    "error", message,
+                    "code", code,
+                    "message", message
+            ));
+            emitter.send(SseEmitter.event().data(payload));
+        } catch (Exception sendError) {
+            log.error("SSE 안전 오류 이벤트 전송 실패", sendError);
+        } finally {
+            emitter.complete();
+        }
+    }
+
+    private void persistSafeErrorAnswer(String message) {
+        synchronized (persistenceLock) {
+            if (!answerStored) {
+                persistenceService.completeMessage(messageId, sessionId, message, "[]");
+                answerStored = true;
+            }
+        }
     }
 
     private void disposeSubscription() {

--- a/backend/src/test/java/com/documind/documind/domain/chat/SseStreamingContextTest.java
+++ b/backend/src/test/java/com/documind/documind/domain/chat/SseStreamingContextTest.java
@@ -1,0 +1,85 @@
+package com.documind.documind.domain.chat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+import reactor.core.Disposable;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+/**
+ * SSE 스트림 상태 객체의 완료·중단 저장 흐름을 검증하는 단위 테스트.
+ */
+class SseStreamingContextTest {
+
+    private static final Long MESSAGE_ID = 1L;
+    private static final Long SESSION_ID = 10L;
+
+    private final SseEmitter emitter = mock(SseEmitter.class);
+    private final ChatStreamPersistenceService persistenceService = mock(ChatStreamPersistenceService.class);
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    @DisplayName("done 이벤트 수신 시 완성 답변을 저장하고 이후 연결 종료에서는 부분 답변을 저장하지 않음")
+    void onToken_withDoneEvent_savesFinalAnswerOnly() {
+        SseStreamingContext context = createContext();
+
+        context.onToken("{\"token\":\"안녕\"}");
+        context.onToken("{\"token\":\"하세요\"}");
+        context.onToken("{\"done\":true,\"sources\":[{\"source\":\"guide.pdf\"}]}");
+        context.onClientDisconnect();
+
+        verify(persistenceService).completeMessage(
+                eq(MESSAGE_ID),
+                eq(SESSION_ID),
+                eq("안녕하세요"),
+                eq("[{\"source\":\"guide.pdf\"}]")
+        );
+        verify(persistenceService, never()).savePartialAnswer(any(), any());
+    }
+
+    @Test
+    @DisplayName("클라이언트 연결 종료 시 FastAPI 구독을 취소하고 누적된 부분 답변을 저장함")
+    void onClientDisconnect_savesPartialAnswerAndDisposesSubscription() {
+        Disposable subscription = mock(Disposable.class);
+        SseStreamingContext context = createContext();
+        context.attachSubscription(subscription);
+
+        context.onToken("{\"token\":\"부분\"}");
+        context.onToken("{\"token\":\"답변\"}");
+        context.onClientDisconnect();
+
+        verify(subscription).dispose();
+        verify(persistenceService).savePartialAnswer(MESSAGE_ID, "부분답변");
+        verify(persistenceService, never()).completeMessage(any(), any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("done 이벤트에 answer가 포함되면 누적 버퍼보다 answer 값을 우선 저장함")
+    void onToken_withDoneAnswer_usesAnswerField() {
+        SseStreamingContext context = createContext();
+
+        context.onToken("{\"token\":\"검색\"}");
+        context.onToken("{\"done\":true,\"answer\":\"검색 결과가 없습니다.\",\"sources\":[]}");
+
+        verify(persistenceService).completeMessage(
+                MESSAGE_ID,
+                SESSION_ID,
+                "검색 결과가 없습니다.",
+                "[]"
+        );
+    }
+
+    private SseStreamingContext createContext() {
+        return new SseStreamingContext(
+                emitter,
+                MESSAGE_ID,
+                SESSION_ID,
+                objectMapper,
+                persistenceService
+        );
+    }
+}

--- a/backend/src/test/java/com/documind/documind/domain/chat/SseStreamingContextTest.java
+++ b/backend/src/test/java/com/documind/documind/domain/chat/SseStreamingContextTest.java
@@ -73,6 +73,48 @@ class SseStreamingContextTest {
         );
     }
 
+    @Test
+    @DisplayName("upstream 오류 발생 시 안전 오류 답변을 저장하고 스트림을 종료함")
+    void onUpstreamError_savesSafeErrorAnswerAndDisposesSubscription() throws Exception {
+        Disposable subscription = mock(Disposable.class);
+        SseStreamingContext context = createContext();
+        context.attachSubscription(subscription);
+
+        context.onUpstreamError(new RuntimeException("boom"));
+
+        verify(subscription).dispose();
+        verify(persistenceService).completeMessage(
+                MESSAGE_ID,
+                SESSION_ID,
+                SseStreamingContext.UPSTREAM_ERROR_MESSAGE,
+                "[]"
+        );
+        verify(persistenceService, never()).savePartialAnswer(any(), any());
+        verify(emitter).send(any(SseEmitter.SseEventBuilder.class));
+        verify(emitter).complete();
+    }
+
+    @Test
+    @DisplayName("깨진 JSON 수신 시 안전 오류 답변을 저장하고 스트림을 종료함")
+    void onToken_withMalformedJson_savesSafeErrorAnswerAndDisposesSubscription() throws Exception {
+        Disposable subscription = mock(Disposable.class);
+        SseStreamingContext context = createContext();
+        context.attachSubscription(subscription);
+
+        context.onToken("{bad json");
+
+        verify(subscription).dispose();
+        verify(persistenceService).completeMessage(
+                MESSAGE_ID,
+                SESSION_ID,
+                SseStreamingContext.STREAM_ERROR_MESSAGE,
+                "[]"
+        );
+        verify(persistenceService, never()).savePartialAnswer(any(), any());
+        verify(emitter).send(any(SseEmitter.SseEventBuilder.class));
+        verify(emitter).complete();
+    }
+
     private SseStreamingContext createContext() {
         return new SseStreamingContext(
                 emitter,

--- a/backend/src/test/java/com/documind/documind/domain/chat/SseStreamingContextTest.java
+++ b/backend/src/test/java/com/documind/documind/domain/chat/SseStreamingContextTest.java
@@ -6,6 +6,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 import reactor.core.Disposable;
 
+import java.io.IOException;
+
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
@@ -55,6 +57,24 @@ class SseStreamingContextTest {
         verify(subscription).dispose();
         verify(persistenceService).savePartialAnswer(MESSAGE_ID, "부분답변");
         verify(persistenceService, never()).completeMessage(any(), any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("토큰 전송 실패 시 안전 오류 답변 대신 누적된 부분 답변을 저장함")
+    void onToken_withSendFailure_savesPartialAnswer() throws Exception {
+        Disposable subscription = mock(Disposable.class);
+        SseStreamingContext context = createContext();
+        context.attachSubscription(subscription);
+        doThrow(new IOException("broken pipe"))
+                .when(emitter)
+                .send(any(SseEmitter.SseEventBuilder.class));
+
+        context.onToken("{\"token\":\"부분\"}");
+
+        verify(subscription).dispose();
+        verify(persistenceService).savePartialAnswer(MESSAGE_ID, "부분");
+        verify(persistenceService, never()).completeMessage(any(), any(), any(), any());
+        verify(emitter).complete();
     }
 
     @Test


### PR DESCRIPTION
closes #43

## 변경 사항
- SSE 저장 책임을 ChatStreamPersistenceService로 분리하고 REQUIRES_NEW 트랜잭션으로 명시
- 단일 스트림 상태와 token/done/error 처리를 SseStreamingContext로 캡슐화
- ChatService.streamChat()을 세션/메시지 준비와 구독 연결 orchestration 중심으로 축소
- SseStreamingContext 단위 테스트로 정상 완료, 부분 답변 저장, done.answer 우선 저장 검증

## 검증
- cd backend && ./gradlew test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved chat streaming architecture to better handle message persistence, client disconnections, and timeout scenarios, ensuring more reliable delivery of streamed responses.

* **Tests**
  * Added comprehensive test coverage for streaming behavior validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->