### PR TITLE
refactor(auth): Refresh Token을 HttpOnly 쿠키로 이전

### DIFF
--- a/backend/src/main/java/com/documind/documind/domain/auth/AuthController.java
+++ b/backend/src/main/java/com/documind/documind/domain/auth/AuthController.java
@@ -8,6 +8,8 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -54,13 +56,21 @@ public class AuthController {
     /**
      * POST /api/auth/logout — 로그아웃.
      * DB의 Refresh Token을 NULL로 초기화하고, 브라우저의 refresh-token 쿠키를 만료시킨다.
+     * Access Token이 만료된 경우에도 HttpOnly 쿠키는 클라이언트가 직접 삭제할 수 없으므로 refresh-token 쿠키만으로도 로그아웃을 허용한다.
      */
-    // @AuthenticationPrincipal: SecurityContext에 저장된 principal을 주입. 필터에서 String(username)으로 저장했으므로 String으로 받는다
+    // Authentication: 익명 인증 객체와 실제 JWT 인증 객체를 구분하기 위해 직접 받는다.
+    // @CookieValue(required = false): Access Token 없이도 refresh-token 쿠키 기반 로그아웃을 처리한다.
     @PostMapping("/logout")
     public ResponseEntity<ApiResponse<Void>> logout(
-            @AuthenticationPrincipal String username,
+            Authentication authentication,
+            @CookieValue(name = REFRESH_COOKIE_NAME, required = false) String refreshToken,
             HttpServletResponse response) {
-        authService.logout(username);
+        String username = extractAuthenticatedUsername(authentication);
+        if (username != null) {
+            authService.logout(username);
+        } else {
+            authService.logoutByRefreshToken(refreshToken);
+        }
         expireRefreshTokenCookie(response);
         return ResponseEntity.ok(ApiResponse.successMessage("로그아웃 되었습니다."));
     }
@@ -115,5 +125,16 @@ public class AuthController {
                 .maxAge(0)
                 .build();
         response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+    }
+
+    // 익명 요청이면 null을 반환하고, JWT 인증 요청이면 username principal을 반환한다
+    private String extractAuthenticatedUsername(Authentication authentication) {
+        if (authentication == null
+                || authentication instanceof AnonymousAuthenticationToken
+                || !authentication.isAuthenticated()
+                || !(authentication.getPrincipal() instanceof String username)) {
+            return null;
+        }
+        return username;
     }
 }

--- a/backend/src/main/java/com/documind/documind/domain/auth/AuthController.java
+++ b/backend/src/main/java/com/documind/documind/domain/auth/AuthController.java
@@ -30,6 +30,10 @@ public class AuthController {
     @Value("${jwt.refresh-token-expiration}")
     private Duration refreshTokenExpiration;
 
+    // 운영 환경에서 HTTPS를 적용하면 true로 전환해 Secure 쿠키로 발급한다
+    @Value("${auth.refresh-cookie-secure:false}")
+    private boolean refreshCookieSecure;
+
     // 쿠키 이름을 한 곳에서 관리해 오타 위험을 제거한다
     private static final String REFRESH_COOKIE_NAME = "refresh-token";
 
@@ -88,12 +92,12 @@ public class AuthController {
 
     /**
      * refresh-token HttpOnly 쿠키를 Set-Cookie 헤더에 추가한다.
-     * Secure 속성은 HTTPS 도입 이후 true로 변경해야 한다.
+     * Secure 속성은 환경변수로 제어해 HTTP 로컬 개발과 HTTPS 운영 배포를 분리한다.
      */
     private void setRefreshTokenCookie(HttpServletResponse response, String refreshToken) {
         ResponseCookie cookie = ResponseCookie.from(REFRESH_COOKIE_NAME, refreshToken)
                 .httpOnly(true)
-                .secure(false) // HTTPS 환경으로 전환 시 true로 변경
+                .secure(refreshCookieSecure)
                 .sameSite("Strict")
                 .path("/api/auth")
                 .maxAge(refreshTokenExpiration)
@@ -105,7 +109,7 @@ public class AuthController {
     private void expireRefreshTokenCookie(HttpServletResponse response) {
         ResponseCookie cookie = ResponseCookie.from(REFRESH_COOKIE_NAME, "")
                 .httpOnly(true)
-                .secure(false)
+                .secure(refreshCookieSecure)
                 .sameSite("Strict")
                 .path("/api/auth")
                 .maxAge(0)

--- a/backend/src/main/java/com/documind/documind/domain/auth/AuthController.java
+++ b/backend/src/main/java/com/documind/documind/domain/auth/AuthController.java
@@ -1,12 +1,17 @@
 package com.documind.documind.domain.auth;
 
 import com.documind.documind.global.common.ApiResponse;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-
 import org.springframework.web.bind.annotation.*;
+
+import java.time.Duration;
 
 /**
  * 인증 관련 엔드포인트를 처리하는 컨트롤러.
@@ -21,34 +26,50 @@ public class AuthController {
 
     private final AuthService authService;
 
+    // jwt.refresh-token-expiration 값으로 쿠키 Max-Age를 동기화한다
+    @Value("${jwt.refresh-token-expiration}")
+    private Duration refreshTokenExpiration;
+
+    // 쿠키 이름을 한 곳에서 관리해 오타 위험을 제거한다
+    private static final String REFRESH_COOKIE_NAME = "refresh-token";
+
     /**
      * POST /api/auth/login — 로그인.
-     * @return Access Token과 Refresh Token을 포함한 응답
+     * Access Token은 응답 body에, Refresh Token은 HttpOnly 쿠키에 담아 반환한다.
      */
     // @Valid: @NotBlank 등 DTO 유효성 검사를 활성화
     @PostMapping("/login")
-    public ResponseEntity<ApiResponse<LoginResponse>> login(@Valid @RequestBody LoginRequest request) {
-        LoginResponse response = authService.login(request.getUsername(), request.getPassword());
-        return ResponseEntity.ok(ApiResponse.success(response));
+    public ResponseEntity<ApiResponse<LoginResponse>> login(
+            @Valid @RequestBody LoginRequest request,
+            HttpServletResponse response) {
+        LoginResponse tokens = authService.login(request.getUsername(), request.getPassword());
+        setRefreshTokenCookie(response, tokens.getRefreshToken());
+        return ResponseEntity.ok(ApiResponse.success(tokens));
     }
 
     /**
      * POST /api/auth/logout — 로그아웃.
-     * DB의 Refresh Token을 NULL로 초기화해 재사용을 차단한다.
+     * DB의 Refresh Token을 NULL로 초기화하고, 브라우저의 refresh-token 쿠키를 만료시킨다.
      */
     // @AuthenticationPrincipal: SecurityContext에 저장된 principal을 주입. 필터에서 String(username)으로 저장했으므로 String으로 받는다
     @PostMapping("/logout")
-    public ResponseEntity<ApiResponse<Void>> logout(@AuthenticationPrincipal String username) {
+    public ResponseEntity<ApiResponse<Void>> logout(
+            @AuthenticationPrincipal String username,
+            HttpServletResponse response) {
         authService.logout(username);
-        return ResponseEntity.ok(ApiResponse.success("로그아웃 되었습니다."));
+        expireRefreshTokenCookie(response);
+        return ResponseEntity.ok(ApiResponse.successMessage("로그아웃 되었습니다."));
     }
 
     /**
      * POST /api/auth/reissue — Access Token 재발급.
-     * Refresh-Token 헤더로 유효한 Refresh Token을 전달해야 한다.
+     * Refresh Token은 HttpOnly 쿠키에서 자동으로 읽는다. 쿠키가 없거나 만료된 경우 401을 반환한다.
      */
+    // @CookieValue(required = false): 쿠키가 없으면 null을 주입한다.
+    //   null이 전달되면 AuthService.reissue()가 INVALID_TOKEN 예외를 던져 GlobalExceptionHandler가 401을 반환한다.
     @PostMapping("/reissue")
-    public ResponseEntity<ApiResponse<String>> reissue(@RequestHeader("Refresh-Token") String refreshToken) {
+    public ResponseEntity<ApiResponse<String>> reissue(
+            @CookieValue(name = REFRESH_COOKIE_NAME, required = false) String refreshToken) {
         String newAccessToken = authService.reissue(refreshToken);
         return ResponseEntity.ok(ApiResponse.success(newAccessToken));
     }
@@ -62,6 +83,33 @@ public class AuthController {
             @AuthenticationPrincipal String username,
             @Valid @RequestBody PasswordChangeRequest request) {
         authService.changePassword(username, request.getCurrentPassword(), request.getNewPassword());
-        return ResponseEntity.ok(ApiResponse.success("비밀번호가 변경되었습니다."));
+        return ResponseEntity.ok(ApiResponse.successMessage("비밀번호가 변경되었습니다."));
+    }
+
+    /**
+     * refresh-token HttpOnly 쿠키를 Set-Cookie 헤더에 추가한다.
+     * Secure 속성은 HTTPS 도입 이후 true로 변경해야 한다.
+     */
+    private void setRefreshTokenCookie(HttpServletResponse response, String refreshToken) {
+        ResponseCookie cookie = ResponseCookie.from(REFRESH_COOKIE_NAME, refreshToken)
+                .httpOnly(true)
+                .secure(false) // HTTPS 환경으로 전환 시 true로 변경
+                .sameSite("Strict")
+                .path("/api/auth")
+                .maxAge(refreshTokenExpiration)
+                .build();
+        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+    }
+
+    /** refresh-token 쿠키를 Max-Age=0으로 즉시 만료시킨다. */
+    private void expireRefreshTokenCookie(HttpServletResponse response) {
+        ResponseCookie cookie = ResponseCookie.from(REFRESH_COOKIE_NAME, "")
+                .httpOnly(true)
+                .secure(false)
+                .sameSite("Strict")
+                .path("/api/auth")
+                .maxAge(0)
+                .build();
+        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
     }
 }

--- a/backend/src/main/java/com/documind/documind/domain/auth/AuthService.java
+++ b/backend/src/main/java/com/documind/documind/domain/auth/AuthService.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 
 /**
  * 로그인, 로그아웃, 토큰 재발급, 비밀번호 변경 비즈니스 로직을 담당한다.
@@ -58,6 +59,19 @@ public class AuthService {
         User user = userRepository.findByUsername(username)
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
         user.logout();
+    }
+
+    /**
+     * Refresh Token 문자열로 사용자를 찾아 로그아웃한다.
+     * Access Token이 만료된 사용자가 HttpOnly 쿠키를 서버에 맡겨 제거할 때 사용한다.
+     */
+    @Transactional
+    public void logoutByRefreshToken(String refreshToken) {
+        if (!StringUtils.hasText(refreshToken)) {
+            return;
+        }
+        userRepository.findByRefreshToken(refreshToken)
+                .ifPresent(User::logout);
     }
 
     /**

--- a/backend/src/main/java/com/documind/documind/domain/auth/LoginResponse.java
+++ b/backend/src/main/java/com/documind/documind/domain/auth/LoginResponse.java
@@ -1,14 +1,21 @@
 package com.documind.documind.domain.auth;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.Builder;
 import lombok.Getter;
 
-// 로그인 성공 시 프론트엔드에 전달하는 DTO
+/**
+ * 로그인 성공 시 HTTP 응답 body에 담기는 DTO.
+ * refreshToken은 HttpOnly 쿠키로 전달하므로 JSON 직렬화에서 제외한다.
+ */
 // @Builder: 빌더 패턴으로 객체를 생성할 수 있도록 지원 (Lombok)
 @Getter
 @Builder
 public class LoginResponse {
 
     private String accessToken;
+
+    // HTTP 응답 body에 노출하지 않는다 — AuthController에서 HttpOnly 쿠키로 전송
+    @JsonIgnore
     private String refreshToken;
 }

--- a/backend/src/main/java/com/documind/documind/domain/chat/ChatController.java
+++ b/backend/src/main/java/com/documind/documind/domain/chat/ChatController.java
@@ -84,7 +84,7 @@ public class ChatController {
     ) {
         Long userId = extractUserId(authentication);
         chatService.deleteSession(id, userId, sessionKey);
-        return ResponseEntity.ok(ApiResponse.success("채팅 세션이 삭제되었습니다."));
+        return ResponseEntity.ok(ApiResponse.successMessage("채팅 세션이 삭제되었습니다."));
     }
 
     /**

--- a/backend/src/main/java/com/documind/documind/global/common/ApiResponse.java
+++ b/backend/src/main/java/com/documind/documind/global/common/ApiResponse.java
@@ -2,7 +2,10 @@ package com.documind.documind.global.common;
 
 import lombok.Getter;
 
-// 모든 API 응답을 감싸는 공통 응답 형식. 프론트엔드가 success 필드로 성공/실패를 판단
+/**
+ * 모든 API 응답을 감싸는 공통 응답 형식.
+ * 프론트엔드가 success 필드로 성공/실패를 판단한다.
+ */
 // @Getter: 모든 필드의 getter 메서드 자동 생성 (Lombok)
 @Getter
 public class ApiResponse<T> {
@@ -17,17 +20,21 @@ public class ApiResponse<T> {
         this.message = message;
     }
 
-    // 성공 응답 (data 포함)
+    /** 성공 응답 — data 포함. String을 data로 반환할 때도 이 메서드를 사용한다. */
     public static <T> ApiResponse<T> success(T data) {
         return new ApiResponse<>(true, data, null);
     }
 
-    // 성공 응답 (data 없이 메시지만)
-    public static <T> ApiResponse<T> success(String message) {
+    /**
+     * 성공 응답 — data 없이 사용자 안내 메시지만 반환.
+     * 삭제·변경처럼 반환할 data가 없는 작업에 사용한다.
+     * success(T data)와 String 인수 충돌을 막기 위해 메서드명을 구분한다.
+     */
+    public static <T> ApiResponse<T> successMessage(String message) {
         return new ApiResponse<>(true, null, message);
     }
 
-    // 실패 응답
+    /** 실패 응답 — 오류 메시지 포함. */
     public static <T> ApiResponse<T> fail(String message) {
         return new ApiResponse<>(false, null, message);
     }

--- a/backend/src/main/java/com/documind/documind/global/config/SecurityConfig.java
+++ b/backend/src/main/java/com/documind/documind/global/config/SecurityConfig.java
@@ -61,12 +61,10 @@ public class SecurityConfig {
                     .requestMatchers(HttpMethod.POST, "/api/categories").hasRole("ADMIN")
                     .requestMatchers(HttpMethod.POST, "/api/auth/password").hasRole("ADMIN")
 
-                    // 인증된 사용자 전용
-                    // 로그아웃은 DB의 Refresh Token을 제거하므로 인증된 사용자만 호출할 수 있다
-                    .requestMatchers(HttpMethod.POST, "/api/auth/logout").authenticated()
-
                     // 공개 — USER 비로그인 허용
+                    // logout은 Access Token이 만료된 경우에도 HttpOnly refresh-token 쿠키 만료를 위해 허용한다
                     .requestMatchers(HttpMethod.POST, "/api/auth/login", "/api/auth/reissue").permitAll()
+                    .requestMatchers(HttpMethod.POST, "/api/auth/logout").permitAll()
                     .requestMatchers(HttpMethod.GET, "/api/categories").permitAll()
                     .requestMatchers(HttpMethod.POST, "/api/chat").permitAll()
                     .requestMatchers(HttpMethod.GET, "/api/chat/stream").permitAll()

--- a/backend/src/main/java/com/documind/documind/global/config/SecurityConfig.java
+++ b/backend/src/main/java/com/documind/documind/global/config/SecurityConfig.java
@@ -92,14 +92,19 @@ public class SecurityConfig {
         return http.build();
     }
 
-    // Vite dev server(5173), Docker nginx(80), nginx 기본 포트(80)에서의 브라우저 요청 허용
+    // Vite dev server(5173), Docker nginx(80), 운영 서버(192.168.35.168)에서의 브라우저 요청 허용
+    // allowCredentials(true)와 allowedOrigins("*") 조합은 Spring CORS에서 예외 발생 — origin 명시 필수
     @Bean
     CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration config = new CorsConfiguration();
-        config.setAllowedOrigins(List.of("http://localhost:5173", "http://localhost:80", "http://localhost"));
+        config.setAllowedOrigins(List.of(
+                "http://localhost:5173",
+                "http://localhost",
+                "http://192.168.35.168"  // 운영 서버 — HttpOnly cookie 및 SSE credentials 요청 허용
+        ));
         config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
         config.setAllowedHeaders(List.of("*"));
-        // EventSource(SSE) 쿠키 기반 세션 추적을 위해 credentials 허용
+        // HttpOnly cookie(refresh-token)와 SSE EventSource credentials 전송을 위해 true로 설정
         config.setAllowCredentials(true);
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", config);

--- a/backend/src/main/java/com/documind/documind/global/config/SecurityConfig.java
+++ b/backend/src/main/java/com/documind/documind/global/config/SecurityConfig.java
@@ -99,6 +99,7 @@ public class SecurityConfig {
         CorsConfiguration config = new CorsConfiguration();
         config.setAllowedOrigins(List.of(
                 "http://localhost:5173",
+                "http://127.0.0.1:5173",
                 "http://localhost",
                 "http://192.168.35.168"  // 운영 서버 — HttpOnly cookie 및 SSE credentials 요청 허용
         ));

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -39,3 +39,7 @@ jwt:
   access-token-expiration: ${JWT_ACCESS_TOKEN_EXPIRATION:24h}
   # Refresh Token 만료 시간. 운영에서는 환경변수 JWT_REFRESH_TOKEN_EXPIRATION으로 조정한다.
   refresh-token-expiration: ${JWT_REFRESH_TOKEN_EXPIRATION:7d}
+
+auth:
+  # HTTPS 배포 시 true로 설정하면 refresh-token 쿠키에 Secure 속성을 추가한다.
+  refresh-cookie-secure: ${AUTH_REFRESH_COOKIE_SECURE:false}

--- a/backend/src/test/java/com/documind/documind/domain/auth/AuthApiTest.java
+++ b/backend/src/test/java/com/documind/documind/domain/auth/AuthApiTest.java
@@ -167,6 +167,31 @@ class AuthApiTest {
     }
 
     @Test
+    @DisplayName("로그아웃 API - Access Token 없이 refresh-token 쿠키만 있어도 DB 토큰 제거와 쿠키 만료를 수행한다")
+    void logoutApi_withRefreshCookieOnly_clearsRefreshTokenAndExpiresCookie() throws Exception {
+        LoginResponse loginResponse = authService.login(ADMIN_USERNAME, RAW_PASSWORD);
+
+        mockMvc.perform(post("/api/auth/logout")
+                        .cookie(new Cookie("refresh-token", loginResponse.getRefreshToken())))
+                .andExpect(status().isOk())
+                .andExpect(header().string("Set-Cookie", containsString("refresh-token=")))
+                .andExpect(header().string("Set-Cookie", containsString("Max-Age=0")))
+                .andExpect(header().string("Set-Cookie", containsString("Path=/api/auth")));
+
+        User saved = userRepository.findByUsername(ADMIN_USERNAME).orElseThrow();
+        assertNull(saved.getRefreshToken());
+    }
+
+    @Test
+    @DisplayName("로그아웃 API - 토큰이 없어도 HttpOnly 쿠키 만료 응답은 반환한다")
+    void logoutApi_withoutTokens_returnsCookieExpiration() throws Exception {
+        mockMvc.perform(post("/api/auth/logout"))
+                .andExpect(status().isOk())
+                .andExpect(header().string("Set-Cookie", containsString("refresh-token=")))
+                .andExpect(header().string("Set-Cookie", containsString("Max-Age=0")));
+    }
+
+    @Test
     @DisplayName("토큰 재발급 - 유효한 Refresh Token으로 새 Access Token을 반환한다")
     void reissue_success() {
         LoginResponse loginResponse = authService.login(ADMIN_USERNAME, RAW_PASSWORD);

--- a/backend/src/test/java/com/documind/documind/domain/auth/AuthApiTest.java
+++ b/backend/src/test/java/com/documind/documind/domain/auth/AuthApiTest.java
@@ -21,9 +21,12 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.Set;
 
+import jakarta.servlet.http.Cookie;
+
 import static org.junit.jupiter.api.Assertions.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.hamcrest.Matchers.containsString;
 
 /**
  * 인증 API 서비스 레이어 통합 테스트.
@@ -82,17 +85,54 @@ class AuthApiTest {
     }
 
     @Test
-    @DisplayName("로그인 - 올바른 자격증명으로 Access Token과 Refresh Token을 반환한다")
+    @DisplayName("로그인 - Access Token을 발급하고 Refresh Token은 DB와 HttpOnly 쿠키로 관리한다")
     void login_success() {
         LoginResponse response = authService.login(ADMIN_USERNAME, RAW_PASSWORD);
 
         assertNotNull(response.getAccessToken());
+        // refreshToken은 JSON 직렬화 대상이 아니지만 서비스 레이어에서는 정상 생성된다
         assertNotNull(response.getRefreshToken());
 
         // DB에 Refresh Token이 저장됐는지 확인
         User saved = userRepository.findByUsername(ADMIN_USERNAME).orElseThrow();
         assertEquals(response.getRefreshToken(), saved.getRefreshToken());
         assertNotNull(saved.getLastLoginAt());
+    }
+
+    @Test
+    @DisplayName("로그인 API - 응답 body에 accessToken이 있고 Set-Cookie에 refresh-token이 존재한다")
+    void loginApi_setsRefreshTokenCookie() throws Exception {
+        String loginJson = String.format("""
+                { "username": "%s", "password": "%s" }
+                """, ADMIN_USERNAME, RAW_PASSWORD);
+
+        mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(loginJson))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.accessToken").isNotEmpty())
+                // refreshToken은 body에 노출되지 않아야 한다
+                .andExpect(jsonPath("$.data.refreshToken").doesNotExist())
+                .andExpect(header().string("Set-Cookie", containsString("refresh-token=")))
+                .andExpect(header().string("Set-Cookie", containsString("HttpOnly")));
+    }
+
+    @Test
+    @DisplayName("토큰 재발급 API - refresh-token 쿠키로 새 Access Token을 발급한다")
+    void reissueApi_withCookie_returnsNewAccessToken() throws Exception {
+        LoginResponse loginResponse = authService.login(ADMIN_USERNAME, RAW_PASSWORD);
+
+        mockMvc.perform(post("/api/auth/reissue")
+                        .cookie(new Cookie("refresh-token", loginResponse.getRefreshToken())))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data").isNotEmpty());
+    }
+
+    @Test
+    @DisplayName("토큰 재발급 API - refresh-token 쿠키 없이 요청하면 401을 반환한다")
+    void reissueApi_withoutCookie_returns401() throws Exception {
+        mockMvc.perform(post("/api/auth/reissue"))
+                .andExpect(status().isUnauthorized());
     }
 
     @Test

--- a/backend/src/test/java/com/documind/documind/domain/auth/AuthApiTest.java
+++ b/backend/src/test/java/com/documind/documind/domain/auth/AuthApiTest.java
@@ -114,7 +114,9 @@ class AuthApiTest {
                 // refreshToken은 body에 노출되지 않아야 한다
                 .andExpect(jsonPath("$.data.refreshToken").doesNotExist())
                 .andExpect(header().string("Set-Cookie", containsString("refresh-token=")))
-                .andExpect(header().string("Set-Cookie", containsString("HttpOnly")));
+                .andExpect(header().string("Set-Cookie", containsString("HttpOnly")))
+                .andExpect(header().string("Set-Cookie", containsString("SameSite=Strict")))
+                .andExpect(header().string("Set-Cookie", containsString("Path=/api/auth")));
     }
 
     @Test

--- a/frontend/src/services/apiClient.js
+++ b/frontend/src/services/apiClient.js
@@ -1,6 +1,8 @@
 import { env } from '../config/env.js'
 import { getAccessToken } from './authStorage.js'
 
+const DEFAULT_TIMEOUT_MS = 30000
+
 function createUrl(path) {
   const normalizedBase = env.apiBaseUrl.replace(/\/$/, '')
   const normalizedPath = path.startsWith('/') ? path : `/${path}`
@@ -13,11 +15,15 @@ async function parseResponse(response) {
     return null
   }
 
-  return response.json()
+  try {
+    return await response.json()
+  } catch {
+    return null
+  }
 }
 
 export async function apiRequest(path, options = {}) {
-  const { body, headers = {}, auth = false, ...fetchOptions } = options
+  const { body, headers = {}, auth = false, timeoutMs = DEFAULT_TIMEOUT_MS, ...fetchOptions } = options
   const requestHeaders = {
     ...headers,
   }
@@ -34,13 +40,32 @@ export async function apiRequest(path, options = {}) {
     }
   }
 
-  const response = await fetch(createUrl(path), {
-    ...fetchOptions,
-    headers: requestHeaders,
-    // HttpOnly 쿠키(refresh-token)를 cross-origin 요청에도 전송하기 위해 credentials 포함
-    credentials: 'include',
-    body: body === undefined ? undefined : body instanceof FormData ? body : JSON.stringify(body),
-  })
+  const controller = new AbortController()
+  const shouldApplyTimeout = !fetchOptions.signal && Number.isFinite(timeoutMs) && timeoutMs > 0
+  const timeoutId = shouldApplyTimeout
+    ? window.setTimeout(() => controller.abort(), timeoutMs)
+    : null
+
+  let response
+  try {
+    response = await fetch(createUrl(path), {
+      ...fetchOptions,
+      headers: requestHeaders,
+      // HttpOnly 쿠키(refresh-token)를 cross-origin 요청에도 전송하기 위해 credentials 포함
+      credentials: 'include',
+      signal: fetchOptions.signal ?? controller.signal,
+      body: body === undefined ? undefined : body instanceof FormData ? body : JSON.stringify(body),
+    })
+  } catch (error) {
+    if (error instanceof DOMException && error.name === 'AbortError') {
+      throw new Error('요청 시간이 초과되었습니다.')
+    }
+    throw new Error('서버와 통신하지 못했습니다.')
+  } finally {
+    if (timeoutId) {
+      window.clearTimeout(timeoutId)
+    }
+  }
 
   const payload = await parseResponse(response)
   if (!response.ok || payload?.success === false) {

--- a/frontend/src/services/apiClient.js
+++ b/frontend/src/services/apiClient.js
@@ -37,6 +37,8 @@ export async function apiRequest(path, options = {}) {
   const response = await fetch(createUrl(path), {
     ...fetchOptions,
     headers: requestHeaders,
+    // HttpOnly 쿠키(refresh-token)를 cross-origin 요청에도 전송하기 위해 credentials 포함
+    credentials: 'include',
     body: body === undefined ? undefined : body instanceof FormData ? body : JSON.stringify(body),
   })
 

--- a/frontend/src/services/authApi.js
+++ b/frontend/src/services/authApi.js
@@ -24,8 +24,14 @@ export async function logout() {
 }
 
 export async function reissueAccessToken() {
-  // refresh token은 HttpOnly 쿠키로 자동 전송된다 — 헤더에 직접 포함하지 않는다
-  const accessToken = await apiRequest('/auth/reissue', { method: 'POST' })
+  let accessToken
+  try {
+    // refresh token은 HttpOnly 쿠키로 자동 전송된다 — 헤더에 직접 포함하지 않는다
+    accessToken = await apiRequest('/auth/reissue', { method: 'POST' })
+  } catch (error) {
+    clearTokens()
+    throw error
+  }
 
   if (typeof accessToken !== 'string' || !accessToken) {
     clearTokens()

--- a/frontend/src/services/authApi.js
+++ b/frontend/src/services/authApi.js
@@ -1,14 +1,14 @@
 import { apiRequest } from './apiClient.js'
-import { clearTokens, getRefreshToken, saveTokens } from './authStorage.js'
+import { clearTokens, saveTokens } from './authStorage.js'
 
 export async function login({ username, password }) {
-  const tokens = await apiRequest('/auth/login', {
+  const data = await apiRequest('/auth/login', {
     method: 'POST',
     body: { username, password },
   })
-
-  saveTokens(tokens)
-  return tokens
+  // 응답 body에는 accessToken만 있다. refreshToken은 서버가 HttpOnly 쿠키로 설정한다
+  saveTokens({ accessToken: data.accessToken })
+  return data
 }
 
 export async function logout() {
@@ -18,24 +18,20 @@ export async function logout() {
       auth: true,
     })
   } finally {
+    // 서버가 refresh-token 쿠키를 만료시키고, 클라이언트는 access token만 제거한다
     clearTokens()
   }
 }
 
 export async function reissueAccessToken() {
-  const refreshToken = getRefreshToken()
-  if (!refreshToken) {
+  // refresh token은 HttpOnly 쿠키로 자동 전송된다 — 헤더에 직접 포함하지 않는다
+  const accessToken = await apiRequest('/auth/reissue', { method: 'POST' })
+
+  if (typeof accessToken !== 'string' || !accessToken) {
     clearTokens()
     throw new Error('세션이 만료되었습니다. 다시 로그인해 주세요.')
   }
 
-  const accessToken = await apiRequest('/auth/reissue', {
-    method: 'POST',
-    headers: {
-      'Refresh-Token': refreshToken,
-    },
-  })
-
-  saveTokens({ accessToken, refreshToken })
+  saveTokens({ accessToken })
   return accessToken
 }

--- a/frontend/src/services/authStorage.js
+++ b/frontend/src/services/authStorage.js
@@ -1,5 +1,4 @@
 const ACCESS_TOKEN_KEY = 'documind-access-token'
-const REFRESH_TOKEN_KEY = 'documind-refresh-token'
 
 function normalizeToken(token) {
   if (typeof token !== 'string') return null
@@ -14,31 +13,19 @@ export function getAccessToken() {
   return normalizeToken(localStorage.getItem(ACCESS_TOKEN_KEY))
 }
 
-export function getRefreshToken() {
-  return normalizeToken(localStorage.getItem(REFRESH_TOKEN_KEY))
-}
-
 export function hasAccessToken() {
   return Boolean(getAccessToken())
 }
 
-export function saveTokens({ accessToken, refreshToken } = {}) {
+export function saveTokens({ accessToken } = {}) {
   const normalizedAccessToken = normalizeToken(accessToken)
   if (normalizedAccessToken) {
     localStorage.setItem(ACCESS_TOKEN_KEY, normalizedAccessToken)
   } else {
     localStorage.removeItem(ACCESS_TOKEN_KEY)
   }
-
-  const normalizedRefreshToken = normalizeToken(refreshToken)
-  if (normalizedRefreshToken) {
-    localStorage.setItem(REFRESH_TOKEN_KEY, normalizedRefreshToken)
-  } else {
-    localStorage.removeItem(REFRESH_TOKEN_KEY)
-  }
 }
 
 export function clearTokens() {
   localStorage.removeItem(ACCESS_TOKEN_KEY)
-  localStorage.removeItem(REFRESH_TOKEN_KEY)
 }


### PR DESCRIPTION
## 작업 내용
- Refresh Token을 응답 body/localStorage에서 제거하고 HttpOnly 쿠키로 이전
- 재발급 API가 refresh-token 쿠키를 읽도록 변경하고 로그아웃 시 쿠키 만료 처리
- Access Token만 localStorage에 보관하도록 프론트 인증 저장소 정리
- CORS credentials 허용과 refresh-token Secure 속성 환경변수화
- API 요청 timeout/JSON 파싱 실패 처리 및 재발급 실패 시 토큰 정리 보강

## 검증
- ./gradlew test
- npm run lint
- npm run build
- npm audit --omit=dev

closes #52