### PR TITLE
feat(auth): RequireAdmin 서버 토큰 검증 추가

### DIFF
--- a/backend/src/main/java/com/documind/documind/domain/auth/AuthController.java
+++ b/backend/src/main/java/com/documind/documind/domain/auth/AuthController.java
@@ -54,6 +54,16 @@ public class AuthController {
     }
 
     /**
+     * GET /api/auth/verify — Access Token 유효성 검증 (ADMIN 전용).
+     * JwtAuthenticationFilter가 JWT 서명·만료를 검증하므로 여기까지 도달하면 토큰이 유효하다.
+     * 프론트엔드 RequireAdmin이 마운트 시 이 API를 호출해 토큰의 서버 수준 유효성을 확인한다.
+     */
+    @GetMapping("/verify")
+    public ResponseEntity<ApiResponse<Void>> verify() {
+        return ResponseEntity.ok(ApiResponse.success(null));
+    }
+
+    /**
      * POST /api/auth/password — 비밀번호 변경 (ADMIN 전용).
      * currentPassword 재확인으로 세션 탈취 공격자가 비밀번호를 교체하는 것을 방지한다.
      */

--- a/backend/src/main/java/com/documind/documind/global/config/SecurityConfig.java
+++ b/backend/src/main/java/com/documind/documind/global/config/SecurityConfig.java
@@ -55,6 +55,7 @@ public class SecurityConfig {
             .authorizeHttpRequests(auth -> auth
                     // ADMIN 전용
                     .requestMatchers("/api/admin/**").hasRole("ADMIN")
+                    .requestMatchers(HttpMethod.GET, "/api/auth/verify").hasRole("ADMIN")
                     .requestMatchers(HttpMethod.GET, "/api/documents").hasRole("ADMIN")
                     .requestMatchers(HttpMethod.POST, "/api/documents").hasRole("ADMIN")
                     .requestMatchers(HttpMethod.DELETE, "/api/documents/**").hasRole("ADMIN")

--- a/backend/src/test/java/com/documind/documind/domain/auth/AuthApiTest.java
+++ b/backend/src/test/java/com/documind/documind/domain/auth/AuthApiTest.java
@@ -22,6 +22,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -223,6 +224,34 @@ class AuthApiTest {
                 () -> authService.changePassword(ADMIN_USERNAME, "wrongCurrent", "newPassword123"));
 
         assertEquals(ErrorCode.WRONG_PASSWORD, ex.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("토큰 검증 API - ADMIN 토큰으로 요청하면 200을 반환한다")
+    void verifyApi_adminToken_returns200() throws Exception {
+        User admin = userRepository.findByUsername(ADMIN_USERNAME).orElseThrow();
+        String adminToken = jwtProvider.generateToken(admin.getUsername(), admin.getRole().name(), admin.getId());
+
+        mockMvc.perform(get("/api/auth/verify")
+                        .header("Authorization", bearer(adminToken)))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("토큰 검증 API - 토큰 없이 요청하면 401을 반환한다")
+    void verifyApi_noToken_returns401() throws Exception {
+        mockMvc.perform(get("/api/auth/verify"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("토큰 검증 API - USER 토큰으로 요청하면 403을 반환한다")
+    void verifyApi_userToken_returns403() throws Exception {
+        String userToken = jwtProvider.generateToken("user", User.Role.USER.name(), 999L);
+
+        mockMvc.perform(get("/api/auth/verify")
+                        .header("Authorization", bearer(userToken)))
+                .andExpect(status().isForbidden());
     }
 
     // Authorization 헤더에 사용할 Bearer Token 값을 생성한다

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,17 +1,45 @@
+import { useEffect, useState } from 'react'
 import { Navigate, Route, Routes } from 'react-router-dom'
 import AppLayout from './components/layout/AppLayout.jsx'
 import AdminDashboardPage from './features/admin/AdminDashboardPage.jsx'
 import LoginPage from './features/admin/LoginPage.jsx'
 import ChatPage from './features/chat/ChatPage.jsx'
 import NotFoundPage from './features/not-found/NotFoundPage.jsx'
-import { hasAccessToken } from './services/authStorage.js'
+import { verifyAccessToken } from './services/authApi.js'
+import { clearTokens, hasAccessToken } from './services/authStorage.js'
 import './App.css'
 
+/**
+ * 관리자 전용 라우트 보호 컴포넌트.
+ * 마운트 시 서버에 JWT 유효성을 검증하고, 만료·위조·권한 없음이면 로그인 화면으로 리다이렉트한다.
+ * localStorage 단독 검사와 달리 서버 서명과 만료 시간까지 확인한다.
+ */
 function RequireAdmin({ children }) {
-  if (!hasAccessToken()) {
-    return <Navigate to="/admin/login" replace />
-  }
+  // lazy initializer로 렌더 전에 토큰 존재 여부를 확인한다.
+  // 토큰이 없으면 effect 없이 바로 redirect 처리한다.
+  const [status, setStatus] = useState(() =>
+    hasAccessToken() ? 'pending' : 'redirect'
+  )
 
+  useEffect(() => {
+    // status가 pending이 아니면 이미 처리 완료 (no-op 반환)
+    if (status !== 'pending') return
+
+    let cancelled = false
+
+    verifyAccessToken()
+      .then(() => { if (!cancelled) setStatus('ok') })
+      .catch(() => {
+        if (cancelled) return
+        clearTokens()
+        setStatus('redirect')
+      })
+
+    return () => { cancelled = true }
+  }, [status])
+
+  if (status === 'pending') return null
+  if (status === 'redirect') return <Navigate to="/admin/login" replace />
   return children
 }
 

--- a/frontend/src/services/authApi.js
+++ b/frontend/src/services/authApi.js
@@ -22,6 +22,11 @@ export async function logout() {
   }
 }
 
+export async function verifyAccessToken() {
+  // 서버가 JWT 서명·만료·권한을 검증한다. 실패 시 apiRequest가 예외를 던진다.
+  await apiRequest('/auth/verify', { method: 'GET', auth: true })
+}
+
 export async function reissueAccessToken() {
   const refreshToken = getRefreshToken()
   if (!refreshToken) {


### PR DESCRIPTION
## 작업 내용
- ADMIN 전용 GET /api/auth/verify 엔드포인트 추가
- SecurityConfig에 verify API ADMIN 권한 정책 추가
- RequireAdmin이 localStorage 존재 여부만 보지 않고 서버 JWT 검증을 수행하도록 변경
- ADMIN/USER/비인증 토큰 검증 API 테스트 추가

## 검증
- ./gradlew test
- npm run lint
- npm run build
- npm audit --omit=dev

closes #50