### PR TITLE
chore(ai): 임베딩 모델 설정 외부화

### DIFF
--- a/ai-server/main.py
+++ b/ai-server/main.py
@@ -25,9 +25,11 @@ app = FastAPI(title="DocuMind AI Server", version="1.0.0")
 OLLAMA_BASE_URL = os.getenv("OLLAMA_BASE_URL", "http://localhost:11434")
 # 환경변수로 LLM 모델명 분기. Docker: OLLAMA_LLM_MODEL=exaone3.5:7.8b
 OLLAMA_LLM_MODEL = os.getenv("OLLAMA_LLM_MODEL", "exaone3.5:7.8b")
+# 환경변수로 임베딩 모델명 분기. 배포 서버에서는 qwen3-embedding:8b 사용 가능
+OLLAMA_EMBEDDING_MODEL = os.getenv("OLLAMA_EMBEDDING_MODEL", "qwen3-embedding:4b")
 
 embeddings = OllamaEmbeddings(
-    model="qwen3-embedding:4b",
+    model=OLLAMA_EMBEDDING_MODEL,
     base_url=OLLAMA_BASE_URL
 )
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,6 +56,7 @@ services:
     environment:
       OLLAMA_BASE_URL: http://ollama:11434
       OLLAMA_LLM_MODEL: exaone3.5:7.8b
+      OLLAMA_EMBEDDING_MODEL: ${OLLAMA_EMBEDDING_MODEL:-qwen3-embedding:8b}
       CHROMA_HOST: chromadb
       CHROMA_PORT: 8000
       LANGFUSE_HOST: http://langfuse-web:3000


### PR DESCRIPTION
## 변경 내용
- FastAPI 임베딩 모델을 OLLAMA_EMBEDDING_MODEL 환경변수로 설정 가능하게 변경
- Docker Compose 배포 기본 임베딩 모델을 qwen3-embedding:8b로 설정

## 검증
- python3 -m py_compile ai-server/main.py
- docker compose -f docker-compose.yml -f docker-compose.gpu.yml config --quiet