### PR TITLE
fix(security): CORS 허용 origin 외부화

### DIFF
--- a/backend/src/main/java/com/documind/documind/global/config/SecurityConfig.java
+++ b/backend/src/main/java/com/documind/documind/global/config/SecurityConfig.java
@@ -5,6 +5,7 @@ import com.documind.documind.global.auth.AuthEntryPoint;
 import com.documind.documind.global.auth.JwtAuthenticationFilter;
 import com.documind.documind.global.auth.JwtProvider;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
@@ -36,6 +37,9 @@ public class SecurityConfig {
     private final JwtProvider jwtProvider;
     private final AuthEntryPoint authEntryPoint;
     private final AccessDeniedHandlerImpl accessDeniedHandler;
+
+    @Value("${app.cors.allowed-origins}")
+    private List<String> allowedOrigins;
 
     /**
      * HTTP 보안 필터 체인을 구성한다.
@@ -99,14 +103,7 @@ public class SecurityConfig {
     @Bean
     CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration config = new CorsConfiguration();
-        config.setAllowedOrigins(List.of(
-                "http://localhost:5173",
-                "http://127.0.0.1:5173",
-                "http://localhost:5174",
-                "http://127.0.0.1:5174",
-                "http://localhost",
-                "http://192.168.35.168"  // 운영 서버 — HttpOnly cookie 및 SSE credentials 요청 허용
-        ));
+        config.setAllowedOrigins(allowedOrigins);
         config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
         config.setAllowedHeaders(List.of("*"));
         // HttpOnly cookie(refresh-token)와 SSE EventSource credentials 전송을 위해 true로 설정

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -48,6 +48,11 @@ auth:
   # HTTPS 배포 시 true로 설정하면 refresh-token 쿠키에 Secure 속성을 추가한다.
   refresh-cookie-secure: ${AUTH_REFRESH_COOKIE_SECURE:false}
 
+app:
+  cors:
+    # 브라우저 Origin 허용 목록. Docker/nginx reverse proxy 환경에서도 POST 요청은 Origin 검증을 받으므로 배포 주소를 포함한다.
+    allowed-origins: ${APP_CORS_ALLOWED_ORIGINS:http://localhost:5173,http://127.0.0.1:5173,http://localhost:5174,http://127.0.0.1:5174,http://localhost,http://192.168.35.168,http://mojuk.kr:19580}
+
 documind:
   admin:
     bootstrap:


### PR DESCRIPTION
## 변경 내용
- 브라우저 배포 Origin을 환경변수로 설정할 수 있도록 CORS 허용 목록 외부화
- 기본 허용 목록에 학교 서버 테스트 주소 http://mojuk.kr:19580 추가

## 검증
- cd backend && ./gradlew test
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **기타**
  * CORS 허용 출처가 이제 환경 설정 속성을 통해 동적으로 구성 가능해졌습니다. APP_CORS_ALLOWED_ORIGINS 환경 변수로 허용된 출처 목록을 관리할 수 있으며, 기본값으로 로컬호스트 및 프로덕션 주소가 포함됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->