### PR TITLE
fix(frontend): 문서 업로드 크기 제한 보강

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -2,6 +2,8 @@ server {
     listen 80;
     server_name _;
 
+    client_max_body_size 512m;
+
     root /usr/share/nginx/html;
     index index.html;
 

--- a/frontend/src/services/apiClient.js
+++ b/frontend/src/services/apiClient.js
@@ -69,6 +69,9 @@ export async function apiRequest(path, options = {}) {
 
   const payload = await parseResponse(response)
   if (!response.ok || payload?.success === false) {
+    if (response.status === 413) {
+      throw new Error('업로드할 파일이 서버 허용 크기를 초과했습니다.')
+    }
     if (response.status === 502 || response.status === 503 || response.status === 504) {
       throw new Error('백엔드 서버에 연결하지 못했습니다. Spring Boot 서버가 실행 중인지 확인해 주세요.')
     }


### PR DESCRIPTION
## 변경 사항
- frontend nginx client_max_body_size를 512MB로 설정해 대용량 문서 업로드를 허용합니다.
- 413 응답을 일반 오류로 숨기지 않고 파일 크기 제한 메시지로 표시합니다.

## 검증
- cd frontend && npm run lint
- cd frontend && npm run build