### PR TITLE
feat(document): 문서 업로드 처리 시간 표시 추가 (#13)

### DIFF
--- a/backend/src/main/java/com/documind/documind/domain/document/Document.java
+++ b/backend/src/main/java/com/documind/documind/domain/document/Document.java
@@ -54,6 +54,10 @@ public class Document {
     @Column(nullable = false)
     private Integer chunkCount = 0;
 
+    // 업로드 요청에서 FastAPI 청킹·임베딩·ChromaDB 저장 완료까지 걸린 시간(ms). 처리 전에는 null
+    @Column
+    private Long processingDurationMs;
+
     // 논리삭제 플래그. 물리삭제 대신 is_active=false로 비활성화해 FK 무결성 보존
     @Column(nullable = false)
     private Boolean isActive = true;
@@ -91,12 +95,14 @@ public class Document {
     }
 
     /**
-     * FastAPI 처리 완료 후 청크 수를 업데이트한다.
+     * FastAPI 처리 완료 후 청크 수와 처리 시간을 업데이트한다.
      *
-     * @param chunkCount ChromaDB에 저장된 청크 수
+     * @param chunkCount           ChromaDB에 저장된 청크 수
+     * @param processingDurationMs 업로드 처리에 걸린 시간(ms)
      */
-    public void updateChunkCount(int chunkCount) {
+    public void completeProcessing(int chunkCount, long processingDurationMs) {
         this.chunkCount = chunkCount;
+        this.processingDurationMs = processingDurationMs;
     }
 
     /**

--- a/backend/src/main/java/com/documind/documind/domain/document/DocumentListResponse.java
+++ b/backend/src/main/java/com/documind/documind/domain/document/DocumentListResponse.java
@@ -22,6 +22,8 @@ public class DocumentListResponse {
     private Long categoryId;
     /** 카테고리 미분류 문서는 null */
     private String categoryName;
+    /** 문서 처리 완료까지 걸린 시간(ms). 기존 데이터나 처리 전 문서는 null */
+    private Long processingDurationMs;
     private LocalDateTime createdAt;
 
     /** Document Entity를 DTO로 변환한다. */
@@ -34,6 +36,7 @@ public class DocumentListResponse {
                 .chunkCount(document.getChunkCount())
                 .categoryId(document.getCategory() != null ? document.getCategory().getId() : null)
                 .categoryName(document.getCategory() != null ? document.getCategory().getName() : null)
+                .processingDurationMs(document.getProcessingDurationMs())
                 .createdAt(document.getCreatedAt())
                 .build();
     }

--- a/backend/src/main/java/com/documind/documind/domain/document/DocumentService.java
+++ b/backend/src/main/java/com/documind/documind/domain/document/DocumentService.java
@@ -16,6 +16,7 @@ import org.springframework.web.multipart.MultipartFile;
 import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 // 문서 업로드 비즈니스 로직을 담당
@@ -60,6 +61,8 @@ public class DocumentService {
      */
     @Transactional
     public DocumentUploadResponse upload(MultipartFile file, Long categoryId, String username) {
+        long processingStartNanos = System.nanoTime();
+
         // 파일 형식 검증
         String mimeType = file.getContentType();
         if (mimeType == null || !ALLOWED_MIME_TYPES.contains(mimeType)) {
@@ -94,14 +97,17 @@ public class DocumentService {
         // FastAPI에 파일 전송 → 청킹·임베딩·ChromaDB 저장 요청
         FastApiUploadResponse fastApiResponse = fastApiClient.uploadDocument(file, document.getId());
 
-        // FastAPI 처리 완료 후 청크 수 업데이트
-        document.updateChunkCount(fastApiResponse.getChunks());
+        long processingDurationMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - processingStartNanos);
+
+        // FastAPI 처리 완료 후 청크 수와 처리 시간을 업데이트
+        document.completeProcessing(fastApiResponse.getChunks(), processingDurationMs);
 
         return DocumentUploadResponse.builder()
                 .documentId(document.getId())
                 .originalName(document.getOriginalName())
                 .fileSize(document.getFileSize())
                 .chunkCount(document.getChunkCount())
+                .processingDurationMs(document.getProcessingDurationMs())
                 .build();
     }
 

--- a/backend/src/main/java/com/documind/documind/domain/document/DocumentUploadResponse.java
+++ b/backend/src/main/java/com/documind/documind/domain/document/DocumentUploadResponse.java
@@ -12,4 +12,5 @@ public class DocumentUploadResponse {
     private String originalName;
     private Long fileSize;
     private int chunkCount;
+    private Long processingDurationMs;
 }

--- a/backend/src/main/resources/db/migration/V2__add_document_processing_duration.sql
+++ b/backend/src/main/resources/db/migration/V2__add_document_processing_duration.sql
@@ -1,0 +1,2 @@
+ALTER TABLE documents
+  ADD COLUMN processing_duration_ms BIGINT DEFAULT NULL;

--- a/backend/src/test/java/com/documind/documind/domain/document/DocumentManagementTest.java
+++ b/backend/src/test/java/com/documind/documind/domain/document/DocumentManagementTest.java
@@ -177,6 +177,12 @@ class DocumentManagementTest {
 
         assertEquals(7, response.getChunkCount());
         assertEquals("report.pdf", response.getOriginalName());
+        assertNotNull(response.getProcessingDurationMs());
+        assertTrue(response.getProcessingDurationMs() >= 0);
+
+        Document uploaded = documentRepository.findById(response.getDocumentId()).orElseThrow();
+        assertEquals(7, uploaded.getChunkCount());
+        assertNotNull(uploaded.getProcessingDurationMs());
     }
 
     @Test

--- a/frontend/src/features/admin/AdminDashboardPage.jsx
+++ b/frontend/src/features/admin/AdminDashboardPage.jsx
@@ -21,6 +21,18 @@ function formatDate(value) {
   }).format(date)
 }
 
+function formatDuration(durationMs) {
+  if (!Number.isFinite(durationMs) || durationMs < 0) return null
+  if (durationMs < 1000) return `${durationMs}ms`
+
+  const totalSeconds = durationMs / 1000
+  if (totalSeconds < 60) return `${totalSeconds.toFixed(1)}초`
+
+  const minutes = Math.floor(totalSeconds / 60)
+  const seconds = Math.round(totalSeconds % 60).toString().padStart(2, '0')
+  return `${minutes}분 ${seconds}초`
+}
+
 function AdminDashboardPage() {
   const [documents, setDocuments] = useState([])
   const [categories, setCategories] = useState([])
@@ -30,6 +42,7 @@ function AdminDashboardPage() {
   const [categoryName, setCategoryName] = useState('')
   const [message, setMessage] = useState('')
   const [errorMessage, setErrorMessage] = useState('')
+  const [lastUploadDurationMs, setLastUploadDurationMs] = useState(null)
   const [isLoading, setIsLoading] = useState(true)
   const [isUploading, setIsUploading] = useState(false)
   const [isRailCollapsed, setIsRailCollapsed] = useState(false)
@@ -76,10 +89,12 @@ function AdminDashboardPage() {
     setIsUploading(true)
     setMessage('')
     setErrorMessage('')
+    setLastUploadDurationMs(null)
 
     try {
-      await uploadDocument(selectedFile, { categoryId: selectedUploadCategoryId })
+      const uploadResult = await uploadDocument(selectedFile, { categoryId: selectedUploadCategoryId })
       setSelectedFile(null)
+      setLastUploadDurationMs(uploadResult?.processingDurationMs ?? null)
       setMessage('문서를 업로드했습니다.')
       await loadDashboard()
     } catch (error) {
@@ -96,6 +111,7 @@ function AdminDashboardPage() {
 
     setMessage('')
     setErrorMessage('')
+    setLastUploadDurationMs(null)
 
     try {
       await createCategory(trimmedName)
@@ -112,6 +128,7 @@ function AdminDashboardPage() {
 
     setMessage('')
     setErrorMessage('')
+    setLastUploadDurationMs(null)
 
     try {
       await deleteDocument(deleteTarget.id)
@@ -142,6 +159,7 @@ function AdminDashboardPage() {
   const handleCloseNotice = () => {
     setMessage('')
     setErrorMessage('')
+    setLastUploadDurationMs(null)
   }
 
   return (
@@ -300,6 +318,7 @@ function AdminDashboardPage() {
                         <strong>{document.originalName}</strong>
                         <small>
                           {document.categoryName || '미분류'} · {formatFileSize(document.fileSize)} · {document.chunkCount} chunks
+                          {formatDuration(document.processingDurationMs) && ` · 처리 ${formatDuration(document.processingDurationMs)}`}
                         </small>
                       </span>
                     </button>
@@ -350,6 +369,9 @@ function AdminDashboardPage() {
           >
             <p>{errorMessage ? '처리할 수 없습니다' : '완료'}</p>
             <h2 id="admin-notice-title">{errorMessage || message}</h2>
+            {!errorMessage && formatDuration(lastUploadDurationMs) && (
+              <span>처리 시간 {formatDuration(lastUploadDurationMs)}</span>
+            )}
             <button type="button" className="admin-primary-button" onClick={handleCloseNotice}>
               확인
             </button>


### PR DESCRIPTION
## Summary

- 문서 업로드 처리 시간을 Spring Boot 기준으로 측정해 `documents.processing_duration_ms`에 저장했습니다.
- 업로드 성공 응답과 문서 목록 응답에 `processingDurationMs`를 포함했습니다.
- 관리자 문서 화면의 업로드 완료 모달과 문서 목록에 처리 시간을 표시했습니다.
- Flyway V2 migration으로 기존 DB에 처리 시간 컬럼을 추가했습니다.

## Changes

- `Document`에 `processingDurationMs` 필드를 추가했습니다.
- 문서 업로드 요청 시작부터 FastAPI 문서 처리 완료까지의 시간을 `System.nanoTime()` 기준으로 측정합니다.
- `DocumentUploadResponse`, `DocumentListResponse`에 처리 시간을 포함했습니다.
- 관리자 문서 UI에서 `ms`, `초`, `분 초` 단위로 처리 시간을 보기 좋게 표시합니다.
- 문서 관리 테스트에 처리 시간 저장/응답 검증을 추가했습니다.

## Tests

- `cd backend && ./gradlew test`
- `cd backend && ./gradlew test --tests com.documind.documind.domain.document.DocumentManagementTest`
- `cd frontend && npm run lint`
- `cd frontend && npm run build`
- `git diff --check`

## Notes

- 기존 문서는 과거 처리 시간이 없으므로 `processingDurationMs`가 `null`일 수 있습니다.
- 이미 적용된 Flyway V1은 수정하지 않고, V2 migration으로 컬럼을 추가했습니다.
- 이 PR은 #13 문서 업로드 UI의 처리 시간 표시 보강입니다. #13 전체 완료 여부는 남은 UI 범위를 확인한 뒤 결정합니다.

Related to #13

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 문서 처리 시간 추적 및 표시 기능 추가
  * 관리자 대시보드에서 각 문서의 처리 소요 시간을 한글 형식(초/분)으로 확인 가능
  * 업로드 완료 알림에서 마지막 업로드의 처리 시간 표시

* **Tests**
  * 처리 시간 추적 기능에 대한 테스트 검증 강화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->