### PR TITLE
fix(document): 문서 업로드 검수 버그 보완 (#13)

### DIFF
--- a/backend/src/main/java/com/documind/documind/domain/document/Document.java
+++ b/backend/src/main/java/com/documind/documind/domain/document/Document.java
@@ -6,7 +6,9 @@ import jakarta.persistence.*;
 import lombok.*;
 import java.time.LocalDateTime;
 
-// DB의 documents 테이블과 매핑되는 Entity 클래스임을 선언
+/**
+ * 업로드된 문서 메타데이터와 처리 상태를 저장하는 Entity이다.
+ */
 @Entity
 // 매핑할 테이블 이름 지정
 @Table(name = "documents")
@@ -72,13 +74,25 @@ public class Document {
     @Column(nullable = false, updatable = false, columnDefinition = "datetime(6)")
     private LocalDateTime createdAt;
 
-    // DB에 INSERT 되기 직전에 자동 실행되는 메서드
+    /**
+     * DB에 INSERT 되기 직전 생성 시각을 기록한다.
+     */
     @PrePersist
     protected void onCreate() {
         this.createdAt = LocalDateTime.now();
     }
 
-    // 정적 팩토리 메서드. 외부에서 new Document() 대신 이 메서드로 생성
+    /**
+     * 업로드 문서 Entity를 생성한다.
+     *
+     * @param uploadedBy   문서를 업로드한 관리자
+     * @param category     문서 카테고리. 미분류면 null
+     * @param fileName     서버에 저장할 파일명
+     * @param originalName 사용자가 업로드한 원본 파일명
+     * @param fileSize     파일 크기(bytes)
+     * @param mimeType     파일 MIME 타입
+     * @return 초기 처리 상태의 문서 Entity
+     */
     public static Document create(User uploadedBy, Category category,
                                   String fileName, String originalName,
                                   Long fileSize, String mimeType) {

--- a/backend/src/main/java/com/documind/documind/domain/document/DocumentService.java
+++ b/backend/src/main/java/com/documind/documind/domain/document/DocumentService.java
@@ -19,7 +19,9 @@ import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
-// 문서 업로드 비즈니스 로직을 담당
+/**
+ * 문서 업로드, 목록 조회, 청크 조회, 논리 삭제를 담당하는 서비스이다.
+ */
 @Service
 @RequiredArgsConstructor
 public class DocumentService {

--- a/backend/src/main/java/com/documind/documind/domain/document/DocumentUploadResponse.java
+++ b/backend/src/main/java/com/documind/documind/domain/document/DocumentUploadResponse.java
@@ -3,7 +3,9 @@ package com.documind.documind.domain.document;
 import lombok.Builder;
 import lombok.Getter;
 
-// 문서 업로드 성공 시 클라이언트에 반환하는 DTO
+/**
+ * 문서 업로드 성공 시 클라이언트에 반환하는 DTO이다.
+ */
 @Getter
 @Builder
 public class DocumentUploadResponse {

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -2570,6 +2570,12 @@ button:disabled {
   background: #be123c;
 }
 
+.admin-text-button:disabled,
+.admin-danger-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.42;
+}
+
 .document-grid {
   display: grid;
   grid-template-columns: minmax(0, 1.35fr) minmax(280px, 0.65fr);
@@ -2598,7 +2604,20 @@ button:disabled {
   border-radius: 16px;
   color: var(--ink);
   background: #fafafa;
+  cursor: pointer;
   text-align: center;
+  transition: background-color 120ms ease, border-color 120ms ease;
+}
+
+.upload-drop:hover,
+.upload-drop--active {
+  border-color: rgba(31, 63, 147, 0.28);
+  background: #f8fafc;
+}
+
+.upload-drop--disabled {
+  cursor: wait;
+  opacity: 0.72;
 }
 
 .upload-drop input {
@@ -2764,6 +2783,11 @@ button:disabled {
   font-size: 14px;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.admin-modal__hint {
+  color: var(--chat-muted);
+  font-size: 13px;
 }
 
 .admin-modal--error h2,

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -2609,8 +2609,8 @@ button:disabled {
   transition: background-color 120ms ease, border-color 120ms ease;
 }
 
-.upload-drop:hover,
-.upload-drop--active {
+.upload-drop:not(.upload-drop--disabled):hover,
+.upload-drop:not(.upload-drop--disabled).upload-drop--active {
   border-color: rgba(31, 63, 147, 0.28);
   background: #f8fafc;
 }

--- a/frontend/src/features/admin/AdminDashboardPage.jsx
+++ b/frontend/src/features/admin/AdminDashboardPage.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { createCategory, listCategories } from '../../services/categoryApi.js'
 import { deleteDocument, listDocumentChunks, listDocuments, uploadDocument } from '../../services/documentApi.js'
@@ -34,6 +34,7 @@ function formatDuration(durationMs) {
 }
 
 function AdminDashboardPage() {
+  const fileInputRef = useRef(null)
   const [documents, setDocuments] = useState([])
   const [categories, setCategories] = useState([])
   const [selectedCategory, setSelectedCategory] = useState('전체')
@@ -45,6 +46,8 @@ function AdminDashboardPage() {
   const [lastUploadDurationMs, setLastUploadDurationMs] = useState(null)
   const [isLoading, setIsLoading] = useState(true)
   const [isUploading, setIsUploading] = useState(false)
+  const [isUploadDragActive, setIsUploadDragActive] = useState(false)
+  const [isDeleting, setIsDeleting] = useState(false)
   const [isRailCollapsed, setIsRailCollapsed] = useState(false)
   const [activeSection, setActiveSection] = useState('dashboard')
   const [deleteTarget, setDeleteTarget] = useState(null)
@@ -82,6 +85,63 @@ function AdminDashboardPage() {
     loadDashboard()
   }, [])
 
+  const resetSelectedFile = () => {
+    setSelectedFile(null)
+    if (fileInputRef.current) {
+      fileInputRef.current.value = ''
+    }
+  }
+
+  const handleSelectFile = (file) => {
+    if (!file || isUploading) return
+
+    setSelectedFile(file)
+    setMessage('')
+    setErrorMessage('')
+    setLastUploadDurationMs(null)
+  }
+
+  const handleFileInputChange = (event) => {
+    handleSelectFile(event.target.files?.[0] ?? null)
+  }
+
+  const handleUploadDragEnter = (event) => {
+    event.preventDefault()
+    event.stopPropagation()
+    if (!isUploading) {
+      setIsUploadDragActive(true)
+    }
+  }
+
+  const handleUploadDragOver = (event) => {
+    event.preventDefault()
+    event.stopPropagation()
+    if (event.dataTransfer) {
+      event.dataTransfer.dropEffect = isUploading ? 'none' : 'copy'
+    }
+    if (!isUploading) {
+      setIsUploadDragActive(true)
+    }
+  }
+
+  const handleUploadDragLeave = (event) => {
+    event.preventDefault()
+    event.stopPropagation()
+
+    const nextTarget = event.relatedTarget
+    if (nextTarget instanceof Node && event.currentTarget.contains(nextTarget)) return
+    setIsUploadDragActive(false)
+  }
+
+  const handleUploadDrop = (event) => {
+    event.preventDefault()
+    event.stopPropagation()
+    setIsUploadDragActive(false)
+
+    if (isUploading) return
+    handleSelectFile(event.dataTransfer.files?.[0] ?? null)
+  }
+
   const handleUpload = async (event) => {
     event.preventDefault()
     if (!selectedFile || isUploading) return
@@ -93,7 +153,7 @@ function AdminDashboardPage() {
 
     try {
       const uploadResult = await uploadDocument(selectedFile, { categoryId: selectedUploadCategoryId })
-      setSelectedFile(null)
+      resetSelectedFile()
       setLastUploadDurationMs(uploadResult?.processingDurationMs ?? null)
       setMessage('문서를 업로드했습니다.')
       await loadDashboard()
@@ -124,11 +184,12 @@ function AdminDashboardPage() {
   }
 
   const handleConfirmDeleteDocument = async () => {
-    if (!deleteTarget) return
+    if (!deleteTarget || isUploading || isDeleting) return
 
     setMessage('')
     setErrorMessage('')
     setLastUploadDurationMs(null)
+    setIsDeleting(true)
 
     try {
       await deleteDocument(deleteTarget.id)
@@ -137,6 +198,8 @@ function AdminDashboardPage() {
       setDeleteTarget(null)
     } catch (error) {
       setErrorMessage(error.message)
+    } finally {
+      setIsDeleting(false)
     }
   }
 
@@ -258,11 +321,22 @@ function AdminDashboardPage() {
 
             <div className="document-grid">
               <form className="upload-panel" onSubmit={handleUpload}>
-                <label className="upload-drop">
+                <label
+                  className={[
+                    'upload-drop',
+                    isUploadDragActive ? 'upload-drop--active' : '',
+                    isUploading ? 'upload-drop--disabled' : '',
+                  ].filter(Boolean).join(' ')}
+                  onDragEnter={handleUploadDragEnter}
+                  onDragOver={handleUploadDragOver}
+                  onDragLeave={handleUploadDragLeave}
+                  onDrop={handleUploadDrop}
+                >
                   <input
+                    ref={fileInputRef}
                     type="file"
                     accept=".pdf,.docx,.pptx,.xlsx"
-                    onChange={(event) => setSelectedFile(event.target.files?.[0] ?? null)}
+                    onChange={handleFileInputChange}
                     disabled={isUploading}
                   />
                   <span>{selectedFile ? selectedFile.name : 'PDF, DOCX, PPTX, XLSX 업로드'}</span>
@@ -323,7 +397,12 @@ function AdminDashboardPage() {
                       </span>
                     </button>
                     <time>{formatDate(document.createdAt)}</time>
-                    <button type="button" className="admin-text-button" onClick={() => setDeleteTarget(document)}>
+                    <button
+                      type="button"
+                      className="admin-text-button"
+                      onClick={() => setDeleteTarget(document)}
+                      disabled={isUploading || isDeleting}
+                    >
                       삭제
                     </button>
                   </article>
@@ -369,7 +448,7 @@ function AdminDashboardPage() {
           >
             <p>{errorMessage ? '처리할 수 없습니다' : '완료'}</p>
             <h2 id="admin-notice-title">{errorMessage || message}</h2>
-            {!errorMessage && formatDuration(lastUploadDurationMs) && (
+            {!errorMessage && message === '문서를 업로드했습니다.' && formatDuration(lastUploadDurationMs) && (
               <span>처리 시간 {formatDuration(lastUploadDurationMs)}</span>
             )}
             <button type="button" className="admin-primary-button" onClick={handleCloseNotice}>
@@ -390,12 +469,18 @@ function AdminDashboardPage() {
             <p>문서 삭제</p>
             <h2 id="admin-delete-title">정말 삭제할까요?</h2>
             <span>{deleteTarget.originalName}</span>
+            {isUploading && <small className="admin-modal__hint">업로드 중에는 삭제할 수 없습니다.</small>}
             <div className="admin-modal__actions">
               <button type="button" className="admin-ghost-button" onClick={() => setDeleteTarget(null)}>
                 취소
               </button>
-              <button type="button" className="admin-danger-button" onClick={handleConfirmDeleteDocument}>
-                삭제
+              <button
+                type="button"
+                className="admin-danger-button"
+                onClick={handleConfirmDeleteDocument}
+                disabled={isUploading || isDeleting}
+              >
+                {isDeleting ? '삭제 중' : '삭제'}
               </button>
             </div>
           </section>

--- a/frontend/src/features/admin/AdminDashboardPage.jsx
+++ b/frontend/src/features/admin/AdminDashboardPage.jsx
@@ -108,7 +108,7 @@ function AdminDashboardPage() {
   const handleUploadDragEnter = (event) => {
     event.preventDefault()
     event.stopPropagation()
-    if (!isUploading) {
+    if (!isUploading && !isUploadDragActive) {
       setIsUploadDragActive(true)
     }
   }
@@ -119,7 +119,7 @@ function AdminDashboardPage() {
     if (event.dataTransfer) {
       event.dataTransfer.dropEffect = isUploading ? 'none' : 'copy'
     }
-    if (!isUploading) {
+    if (!isUploading && !isUploadDragActive) {
       setIsUploadDragActive(true)
     }
   }


### PR DESCRIPTION
## Summary
- 문서 업로드 영역 drag & drop 시 브라우저가 PDF를 여는 기본 동작을 차단하고 파일 선택 상태로 반영했습니다.
- 업로드 성공 후 file input 값을 초기화해 같은 파일을 다시 선택해도 업로드 버튼이 활성화되도록 했습니다.
- 업로드 중 문서 삭제를 시작하지 못하도록 삭제 버튼과 삭제 확인 버튼을 비활성화했습니다.
- 삭제 완료 모달에는 업로드 처리 시간이 표시되지 않도록 조건을 좁혔습니다.
- CodeRabbit docstring coverage 경고 대응을 위해 문서 도메인 Javadoc을 보강했습니다.

## Validation
- GCP 검수용 브랜치 `fix/#13-document-upload-edge-cases` 배포 후 사용자 브라우저 검수 통과

## Tests
- `cd frontend && npm run lint`
- `cd frontend && npm run build`
- `cd backend && ./gradlew test --tests com.documind.documind.domain.document.DocumentManagementTest`
- `git diff --check`

Related to #13

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 드래그 앤 드롭 문서 업로드 기능 추가

* **스타일**
  * 관리자 대시보드 UI 개선: 비활성화 상태 버튼 스타일, 업로드 영역 상호작용 시각화, 모달 팁 텍스트 스타일 추가

* **문서화**
  * 문서 처리 관련 클래스 및 서비스 자바독 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->