### PR TITLE
feat(chat): 답변 출처 표시 UI 보강 (#15)

### DIFF
--- a/ai-server/main.py
+++ b/ai-server/main.py
@@ -345,6 +345,7 @@ def _prepare_query(question: str, top_k: int) -> tuple[str | None, list]:
 
     docs = results["documents"][0] if results["documents"] else []
     metadatas = results["metadatas"][0] if results["metadatas"] else []
+    ids = results["ids"][0] if results["ids"] else []
 
     if not docs:
         return None, []
@@ -364,14 +365,14 @@ def _prepare_query(question: str, top_k: int) -> tuple[str | None, list]:
 
     # 출처 목록 구성: document_id, source(파일명), 페이지, 청크 미리보기, 헤더 메타데이터 포함
     sources = []
-    for doc, meta in zip(docs, metadatas):
+    for doc, meta, chunk_id in zip(docs, metadatas, ids):
         source: dict = {
             "document_id": meta.get("document_id", ""),
             "source": meta.get("source", ""),
             "page": meta.get("page"),
             "page_start": meta.get("page_start"),
             "page_end": meta.get("page_end"),
-            "chunk_index": meta.get("chunk_index"),
+            "chunk_index": meta.get("chunk_index", _parse_chunk_index(chunk_id)),
             # 청크 전체를 반환하면 응답이 너무 커지므로 200자 미리보기만 포함
             "content": doc[:200]
         }
@@ -382,6 +383,15 @@ def _prepare_query(question: str, top_k: int) -> tuple[str | None, list]:
         sources.append(source)
 
     return prompt, sources
+
+
+def _parse_chunk_index(chunk_id: str) -> int | None:
+    """
+    ChromaDB id({document_id}_{chunk_index})에서 청크 순번을 복원한다.
+    기존 업로드 문서처럼 chunk_index metadata가 없는 경우 출처 UI에 최소 위치 정보를 제공한다.
+    """
+    suffix = str(chunk_id).rsplit("_", 1)[-1]
+    return int(suffix) if suffix.isdigit() else None
 
 
 @app.delete("/documents/{document_id}")

--- a/ai-server/main.py
+++ b/ai-server/main.py
@@ -115,6 +115,85 @@ def _normalize_text(text: str) -> str:
     return text
 
 
+def _compact_for_page_match(text: str) -> str:
+    """
+    페이지 추정을 위해 공백을 제거한 비교용 문자열을 만든다.
+    청킹 과정에서 개행과 공백이 정규화되어도 원본 페이지와 매칭할 수 있게 한다.
+    """
+    return re.sub(r'\s+', '', text)
+
+
+def _build_page_lookup(raw_docs: list[Document]) -> list[dict]:
+    """
+    원본 로더가 제공한 페이지 metadata를 검색 가능한 형태로 보존한다.
+    PDF는 OpenDataLoader가 page metadata를 제공하고, DOCX/PPTX/XLSX는 페이지 개념이 없으므로 제외된다.
+    """
+    page_lookup: list[dict] = []
+    for doc in raw_docs:
+        page = doc.metadata.get("page")
+        if page is None:
+            continue
+
+        try:
+            page_number = int(page)
+        except (TypeError, ValueError):
+            continue
+
+        normalized_content = _compact_for_page_match(_normalize_text(doc.page_content))
+        if normalized_content:
+            page_lookup.append({
+                "page": page_number,
+                "content": normalized_content,
+            })
+
+    return page_lookup
+
+
+def _sample_page_match_snippets(text: str) -> list[str]:
+    """
+    청크의 앞/중간/뒤 일부를 뽑아 원본 페이지와 비교한다.
+    수동 overlap 때문에 앞부분이 이전 페이지에 걸칠 수 있어 여러 구간을 함께 사용한다.
+    """
+    compacted = _compact_for_page_match(text)
+    if not compacted:
+        return []
+
+    snippet_size = min(120, len(compacted))
+    starts = {0, max(0, (len(compacted) - snippet_size) // 2), max(0, len(compacted) - snippet_size)}
+
+    snippets: list[str] = []
+    for start in sorted(starts):
+        snippet = compacted[start:start + snippet_size]
+        if len(snippet) >= 8:
+            snippets.append(snippet)
+
+    return snippets
+
+
+def _resolve_page_range(content: str, page_lookup: list[dict]) -> tuple[int | None, int | None]:
+    """
+    청크 내용이 어느 원본 페이지에 포함되는지 추정한다.
+    여러 페이지에 걸친 overlap 청크는 page_start/page_end 범위로 반환한다.
+    """
+    if not page_lookup:
+        return None, None
+
+    snippets = _sample_page_match_snippets(content)
+    if not snippets:
+        return None, None
+
+    matched_pages = set()
+    for page in page_lookup:
+        page_content = page["content"]
+        if any(snippet in page_content for snippet in snippets):
+            matched_pages.add(page["page"])
+
+    if not matched_pages:
+        return None, None
+
+    return min(matched_pages), max(matched_pages)
+
+
 def _two_pass_split(full_text: str) -> list[Document]:
     """
     Two-Pass 청킹: MarkdownHeaderTextSplitter → RecursiveCharacterTextSplitter.
@@ -162,6 +241,7 @@ async def _run_upload_pipeline(tmp_path: str, filename: str, document_id: int) -
     async def _execute() -> int:
         # 파서 분기: 확장자에 따라 PDF 또는 Docling 로더 사용
         raw_docs = _load_documents(tmp_path, filename)
+        page_lookup = _build_page_lookup(raw_docs)
 
         # 전체 텍스트 병합 후 정규화
         full_text = "\n".join([doc.page_content for doc in raw_docs])
@@ -180,7 +260,13 @@ async def _run_upload_pipeline(tmp_path: str, filename: str, document_id: int) -
             metadata: dict = {
                 "document_id": str(document_id),
                 "source": filename,
+                "chunk_index": i,
             }
+            page_start, page_end = _resolve_page_range(doc.page_content, page_lookup)
+            if page_start is not None:
+                metadata["page"] = page_start
+                metadata["page_start"] = page_start
+                metadata["page_end"] = page_end if page_end is not None else page_start
             for k, v in doc.metadata.items():
                 if isinstance(v, (str, int, float, bool)):
                     metadata[k] = v
@@ -276,12 +362,16 @@ def _prepare_query(question: str, top_k: int) -> tuple[str | None, list]:
 [답변]
 """
 
-    # 출처 목록 구성: document_id, source(파일명), 청크 미리보기, 헤더 메타데이터 포함
+    # 출처 목록 구성: document_id, source(파일명), 페이지, 청크 미리보기, 헤더 메타데이터 포함
     sources = []
     for doc, meta in zip(docs, metadatas):
         source: dict = {
             "document_id": meta.get("document_id", ""),
             "source": meta.get("source", ""),
+            "page": meta.get("page"),
+            "page_start": meta.get("page_start"),
+            "page_end": meta.get("page_end"),
+            "chunk_index": meta.get("chunk_index"),
             # 청크 전체를 반환하면 응답이 너무 커지므로 200자 미리보기만 포함
             "content": doc[:200]
         }

--- a/backend/src/main/java/com/documind/documind/domain/chat/ChatService.java
+++ b/backend/src/main/java/com/documind/documind/domain/chat/ChatService.java
@@ -37,6 +37,7 @@ public class ChatService {
     private final ChatSessionRepository chatSessionRepository;
     private final ChatMessageRepository chatMessageRepository;
     private final ChatStreamPersistenceService chatStreamPersistenceService;
+    private final SourceDocumentMetadataEnricher sourceDocumentMetadataEnricher;
     private final FastApiClient fastApiClient;
     private final EntityManager entityManager;
     // Spring Boot가 자동 설정한 ObjectMapper 빈을 주입해 Jackson 전역 설정을 공유
@@ -65,9 +66,10 @@ public class ChatService {
         // 3. FastAPI RAG 파이프라인 호출
         int topK = request.getTopK() != null ? request.getTopK() : DEFAULT_TOP_K;
         FastApiQueryResponse fastApiResponse = fastApiClient.query(request.getQuestion(), topK);
+        List<Map<String, Object>> enrichedSources = sourceDocumentMetadataEnricher.enrich(fastApiResponse.getSources());
 
         // 4. sources 리스트를 JSON 문자열로 직렬화해 chat_messages.source_docs에 저장
-        String sourceDocsJson = serializeSources(fastApiResponse);
+        String sourceDocsJson = serializeSources(enrichedSources);
 
         // 5. 메시지에 answer와 sourceDocs를 채움. @Transactional dirty checking으로 자동 UPDATE
         message.complete(fastApiResponse.getAnswer(), sourceDocsJson);
@@ -79,7 +81,7 @@ public class ChatService {
                 .sessionId(session.getId())
                 .messageId(message.getId())
                 .answer(fastApiResponse.getAnswer())
-                .sources(fastApiResponse.getSources())
+                .sources(enrichedSources)
                 .build();
     }
 
@@ -213,12 +215,12 @@ public class ChatService {
     }
 
     // sources 리스트를 JSON 문자열로 변환. 직렬화 실패 시 빈 배열 문자열로 폴백
-    private String serializeSources(FastApiQueryResponse response) {
-        if (response.getSources() == null) {
+    private String serializeSources(List<Map<String, Object>> sources) {
+        if (sources == null) {
             return "[]";
         }
         try {
-            return objectMapper.writeValueAsString(response.getSources());
+            return objectMapper.writeValueAsString(sources);
         } catch (JsonProcessingException e) {
             log.error("sources 직렬화 실패. 빈 배열로 폴백합니다.", e);
             return "[]";
@@ -242,7 +244,8 @@ public class ChatService {
                 message.getId(),
                 session.getId(),
                 objectMapper,
-                chatStreamPersistenceService
+                chatStreamPersistenceService,
+                sourceDocumentMetadataEnricher
         );
 
         command.emitter().onCompletion(context::onClientDisconnect);

--- a/backend/src/main/java/com/documind/documind/domain/chat/SourceDocumentMetadataEnricher.java
+++ b/backend/src/main/java/com/documind/documind/domain/chat/SourceDocumentMetadataEnricher.java
@@ -1,0 +1,69 @@
+package com.documind.documind.domain.chat;
+
+import com.documind.documind.domain.document.Document;
+import com.documind.documind.domain.document.DocumentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.format.DateTimeFormatter;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * FastAPI가 반환한 출처 청크 목록에 Spring Boot가 가진 문서 메타데이터를 보강한다.
+ */
+@Service
+@RequiredArgsConstructor
+public class SourceDocumentMetadataEnricher {
+
+    private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ISO_LOCAL_DATE_TIME;
+
+    private final DocumentRepository documentRepository;
+
+    /**
+     * 출처 목록의 document_id를 기준으로 원본 문서명과 업로드 시각을 추가한다.
+     *
+     * @param sources FastAPI가 반환한 출처 청크 목록
+     * @return 문서 메타데이터가 보강된 출처 청크 목록
+     */
+    public List<Map<String, Object>> enrich(List<Map<String, Object>> sources) {
+        if (sources == null || sources.isEmpty()) {
+            return List.of();
+        }
+
+        Map<Long, Optional<Document>> documentCache = new HashMap<>();
+        return sources.stream()
+                .map(source -> enrichSource(source, documentCache))
+                .toList();
+    }
+
+    private Map<String, Object> enrichSource(Map<String, Object> source, Map<Long, Optional<Document>> documentCache) {
+        Map<String, Object> enriched = new LinkedHashMap<>(source);
+        parseDocumentId(source.get("document_id"))
+                .flatMap(documentId -> documentCache.computeIfAbsent(documentId, documentRepository::findByIdAndIsActiveTrue))
+                .ifPresent(document -> addDocumentMetadata(enriched, document));
+        return enriched;
+    }
+
+    private Optional<Long> parseDocumentId(Object value) {
+        if (value == null) {
+            return Optional.empty();
+        }
+
+        try {
+            return Optional.of(Long.parseLong(String.valueOf(value)));
+        } catch (NumberFormatException e) {
+            return Optional.empty();
+        }
+    }
+
+    private void addDocumentMetadata(Map<String, Object> source, Document document) {
+        source.put("document_original_name", document.getOriginalName());
+        source.put("document_uploaded_at", document.getCreatedAt().format(DATE_TIME_FORMATTER));
+        source.put("document_chunk_count", document.getChunkCount());
+        source.put("document_file_size", document.getFileSize());
+    }
+}

--- a/backend/src/main/java/com/documind/documind/domain/chat/SseStreamingContext.java
+++ b/backend/src/main/java/com/documind/documind/domain/chat/SseStreamingContext.java
@@ -3,11 +3,14 @@ package com.documind.documind.domain.chat;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.core.type.TypeReference;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 import reactor.core.Disposable;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -26,6 +29,7 @@ class SseStreamingContext {
     private final Long sessionId;
     private final ObjectMapper objectMapper;
     private final ChatStreamPersistenceService persistenceService;
+    private final SourceDocumentMetadataEnricher sourceDocumentMetadataEnricher;
     private final StringBuffer answerBuffer = new StringBuffer();
     private final Object persistenceLock = new Object();
     private boolean normallyCompleted;
@@ -37,13 +41,15 @@ class SseStreamingContext {
             Long messageId,
             Long sessionId,
             ObjectMapper objectMapper,
-            ChatStreamPersistenceService persistenceService
+            ChatStreamPersistenceService persistenceService,
+            SourceDocumentMetadataEnricher sourceDocumentMetadataEnricher
     ) {
         this.emitter = emitter;
         this.messageId = messageId;
         this.sessionId = sessionId;
         this.objectMapper = objectMapper;
         this.persistenceService = persistenceService;
+        this.sourceDocumentMetadataEnricher = sourceDocumentMetadataEnricher;
     }
 
     /**
@@ -135,12 +141,12 @@ class SseStreamingContext {
     }
 
     private void handleDoneEvent(String jsonData, JsonNode node) throws IOException {
-        String sourcesJson = node.has("sources")
-                ? objectMapper.writeValueAsString(node.get("sources"))
-                : "[]";
+        List<Map<String, Object>> enrichedSources = enrichDoneSources(node);
+        String sourcesJson = objectMapper.writeValueAsString(enrichedSources);
         String finalAnswer = node.has("answer")
                 ? node.get("answer").asText()
                 : currentAnswer();
+        String enrichedJsonData = replaceSources(jsonData, node, enrichedSources);
 
         synchronized (persistenceLock) {
             if (answerStored) {
@@ -150,8 +156,27 @@ class SseStreamingContext {
             answerStored = true;
             normallyCompleted = true;
         }
-        emitter.send(SseEmitter.event().data(jsonData));
+        emitter.send(SseEmitter.event().data(enrichedJsonData));
         emitter.complete();
+    }
+
+    private List<Map<String, Object>> enrichDoneSources(JsonNode node) {
+        if (!node.has("sources")) {
+            return List.of();
+        }
+        List<Map<String, Object>> sources = objectMapper.convertValue(node.get("sources"), new TypeReference<>() {});
+        return sourceDocumentMetadataEnricher.enrich(sources);
+    }
+
+    private String replaceSources(String jsonData, JsonNode node, List<Map<String, Object>> sources)
+            throws JsonProcessingException {
+        if (!node.isObject()) {
+            return jsonData;
+        }
+
+        ObjectNode outbound = (ObjectNode) node.deepCopy();
+        outbound.set("sources", objectMapper.valueToTree(sources));
+        return objectMapper.writeValueAsString(outbound);
     }
 
     private void handleErrorEvent(String jsonData, JsonNode node) {

--- a/backend/src/test/java/com/documind/documind/domain/chat/SseStreamingContextTest.java
+++ b/backend/src/test/java/com/documind/documind/domain/chat/SseStreamingContextTest.java
@@ -22,6 +22,7 @@ class SseStreamingContextTest {
 
     private final SseEmitter emitter = mock(SseEmitter.class);
     private final ChatStreamPersistenceService persistenceService = mock(ChatStreamPersistenceService.class);
+    private final SourceDocumentMetadataEnricher sourceDocumentMetadataEnricher = mock(SourceDocumentMetadataEnricher.class);
     private final ObjectMapper objectMapper = new ObjectMapper();
 
     @Test
@@ -136,12 +137,15 @@ class SseStreamingContextTest {
     }
 
     private SseStreamingContext createContext() {
+        when(sourceDocumentMetadataEnricher.enrich(any()))
+                .thenAnswer(invocation -> invocation.getArgument(0));
         return new SseStreamingContext(
                 emitter,
                 MESSAGE_ID,
                 SESSION_ID,
                 objectMapper,
-                persistenceService
+                persistenceService,
+                sourceDocumentMetadataEnricher
         );
     }
 }

--- a/backend/src/test/java/com/documind/documind/domain/document/DocumentManagementTest.java
+++ b/backend/src/test/java/com/documind/documind/domain/document/DocumentManagementTest.java
@@ -186,6 +186,39 @@ class DocumentManagementTest {
     }
 
     @Test
+    @DisplayName("문서 업로드 - 선택한 카테고리가 문서에 저장되고 목록 응답에 반환된다")
+    void upload_categorySavedAndReturnedInList() {
+        when(fastApiClient.uploadDocument(any(), anyLong()))
+                .thenReturn(new FastApiUploadResponse("success", "report.pdf", 7));
+        Category category = categoryRepository.save(Category.create("학사"));
+        MockMultipartFile file = new MockMultipartFile(
+                "file", "report.pdf", "application/pdf", new byte[100]
+        );
+
+        DocumentUploadResponse response = documentService.upload(file, category.getId(), ADMIN_USERNAME);
+
+        DocumentListResponse uploadedResponse = documentService.list().stream()
+                .filter(document -> document.getId().equals(response.getDocumentId()))
+                .findFirst()
+                .orElseThrow();
+        assertEquals(category.getId(), uploadedResponse.getCategoryId());
+        assertEquals("학사", uploadedResponse.getCategoryName());
+    }
+
+    @Test
+    @DisplayName("문서 업로드 - 존재하지 않는 카테고리는 CATEGORY_NOT_FOUND 예외를 반환한다")
+    void upload_missingCategoryThrowsException() {
+        MockMultipartFile file = new MockMultipartFile(
+                "file", "report.pdf", "application/pdf", new byte[100]
+        );
+
+        CustomException ex = assertThrows(CustomException.class,
+                () -> documentService.upload(file, 99999L, ADMIN_USERNAME));
+        assertEquals(ErrorCode.CATEGORY_NOT_FOUND, ex.getErrorCode());
+        verify(fastApiClient, never()).uploadDocument(any(), anyLong());
+    }
+
+    @Test
     @DisplayName("문서 업로드 - 허용하지 않는 파일 형식은 INVALID_FILE_TYPE 예외를 반환한다")
     void upload_invalidMimeTypeThrowsException() {
         MockMultipartFile file = new MockMultipartFile(

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1175,6 +1175,7 @@ button:disabled {
 .drawer-icon-button svg,
 .drawer-menu__item svg,
 .new-chat-button svg,
+.admin-home-link svg,
 .composer-plus svg,
 .composer-icon-button svg,
 .menu-button svg,
@@ -1596,6 +1597,27 @@ button:disabled {
   font-size: 12px;
 }
 
+.admin-home-link {
+  display: inline-grid;
+  place-items: center;
+  align-self: end;
+  justify-self: start;
+  min-width: 42px;
+  width: 42px;
+  min-height: 42px;
+  height: 42px;
+  margin: 0 0 2px 4px;
+  border-radius: 12px;
+  color: var(--chat-muted);
+  background: transparent;
+  text-decoration: none;
+}
+
+.admin-home-link:hover {
+  color: var(--college-blue);
+  background: var(--chat-subtle);
+}
+
 .history-list {
   gap: 4px;
 }
@@ -1779,6 +1801,11 @@ button:disabled {
 .chat-shell--sidebar-collapsed .new-chat-button,
 .chat-shell--sidebar-collapsed .sidebar-section {
   display: none;
+}
+
+.chat-shell--sidebar-collapsed .admin-home-link {
+  justify-self: center;
+  margin: 0;
 }
 
 .sidebar-toggle--inside {

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -760,15 +760,64 @@ button:disabled {
   line-height: 1.35;
 }
 
-.source-list p {
-  display: -webkit-box;
-  overflow: hidden;
+.source-trigger__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 7px;
+  align-items: center;
+}
+
+.source-page {
+  width: fit-content;
+  padding: 3px 8px;
+  border-radius: var(--radius-pill);
+  color: var(--action-blue-strong);
+  background: var(--action-blue-soft);
+  font-size: 12px;
+  font-weight: 800;
+}
+
+.source-path {
+  color: var(--ink-muted);
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.source-detail {
+  display: grid;
+  gap: 9px;
+}
+
+.source-detail__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin: 0;
+}
+
+.source-detail__meta div {
+  min-width: 0;
+}
+
+.source-detail__meta dd {
+  margin: 0;
+  padding: 3px 8px;
+  border-radius: var(--radius-pill);
+  color: var(--ink-muted);
+  background: var(--hairline-soft);
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.source-detail p {
+  display: block;
+  overflow: visible;
   margin: 0;
   color: var(--ink-muted);
   font-size: 14px;
   line-height: 1.5;
-  -webkit-box-orient: vertical;
-  -webkit-line-clamp: 3;
+  white-space: pre-wrap;
+  -webkit-line-clamp: unset;
 }
 
 .feedback-bar {
@@ -2004,7 +2053,7 @@ button:disabled {
 }
 
 .source-list li {
-  padding: 10px 0;
+  padding: 12px 0;
   border: 0;
   border-radius: 0;
   background: transparent;
@@ -2012,7 +2061,7 @@ button:disabled {
 
 .source-trigger {
   display: grid;
-  gap: 4px;
+  gap: 6px;
   width: 100%;
   min-width: 0;
   min-height: 0;
@@ -2031,6 +2080,69 @@ button:disabled {
 
 .source-list strong {
   font-size: 14px;
+}
+
+.source-trigger__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 7px;
+  align-items: center;
+}
+
+.source-page {
+  width: fit-content;
+  padding: 3px 8px;
+  border-radius: var(--radius-pill);
+  color: var(--action-blue-strong);
+  background: var(--action-blue-soft);
+  font-size: 12px;
+  font-weight: 800;
+}
+
+.source-path {
+  min-width: 0;
+  color: var(--chat-muted);
+  font-size: 13px;
+  font-weight: 600;
+  line-height: 1.35;
+}
+
+.source-detail {
+  display: grid;
+  gap: 9px;
+  padding-top: 2px;
+}
+
+.source-detail__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin: 0;
+}
+
+.source-detail__meta div {
+  min-width: 0;
+}
+
+.source-detail__meta dd {
+  margin: 0;
+  padding: 3px 8px;
+  border-radius: var(--radius-pill);
+  color: var(--chat-muted);
+  background: var(--chat-subtle);
+  font-size: 12px;
+  font-weight: 650;
+}
+
+.source-detail p {
+  display: block;
+  overflow: visible;
+  margin: 0;
+  color: var(--chat-muted);
+  font-size: 14px;
+  line-height: 1.6;
+  white-space: pre-wrap;
+  -webkit-line-clamp: unset;
 }
 
 .feedback-bar {

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -741,10 +741,26 @@ button:disabled {
 .source-list li {
   display: grid;
   gap: 7px;
+  padding: 0;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+}
+
+.source-document {
+  display: grid;
+  gap: 12px;
   padding: 16px 18px;
   border: 1px solid var(--hairline-soft);
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-md);
   background: var(--panel);
+  transition: border-color 160ms ease, box-shadow 160ms ease, transform 160ms ease;
+}
+
+.source-document:hover {
+  border-color: var(--hairline);
+  box-shadow: 0 14px 34px rgba(15, 23, 42, 0.09);
+  transform: translateY(-1px);
 }
 
 .source-list strong {
@@ -785,7 +801,7 @@ button:disabled {
 
 .source-detail {
   display: grid;
-  gap: 9px;
+  gap: 14px;
 }
 
 .source-detail__meta {
@@ -807,6 +823,20 @@ button:disabled {
   background: var(--hairline-soft);
   font-size: 12px;
   font-weight: 700;
+}
+
+.source-chunk-list {
+  display: grid;
+  gap: 10px;
+}
+
+.source-chunk {
+  display: grid;
+  gap: 9px;
+  padding: 13px 14px;
+  border: 1px solid var(--hairline-soft);
+  border-radius: var(--radius-sm);
+  background: var(--canvas);
 }
 
 .source-detail p {
@@ -2053,10 +2083,27 @@ button:disabled {
 }
 
 .source-list li {
-  padding: 12px 0;
+  padding: 0;
   border: 0;
   border-radius: 0;
   background: transparent;
+}
+
+.source-document {
+  display: grid;
+  gap: 12px;
+  padding: 13px 14px;
+  border: 1px solid transparent;
+  border-radius: 16px;
+  background: transparent;
+  transition: border-color 160ms ease, box-shadow 160ms ease, transform 160ms ease, background 160ms ease;
+}
+
+.source-document:hover {
+  border-color: var(--chat-border);
+  background: #ffffff;
+  box-shadow: 0 14px 30px rgba(15, 23, 42, 0.08);
+  transform: translateY(-1px);
 }
 
 .source-trigger {
@@ -2109,7 +2156,7 @@ button:disabled {
 
 .source-detail {
   display: grid;
-  gap: 9px;
+  gap: 14px;
   padding-top: 2px;
 }
 
@@ -2132,6 +2179,20 @@ button:disabled {
   background: var(--chat-subtle);
   font-size: 12px;
   font-weight: 650;
+}
+
+.source-chunk-list {
+  display: grid;
+  gap: 10px;
+}
+
+.source-chunk {
+  display: grid;
+  gap: 9px;
+  padding: 12px 13px;
+  border: 1px solid var(--chat-border);
+  border-radius: 12px;
+  background: #ffffff;
 }
 
 .source-detail p {

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -2902,6 +2902,26 @@ button:disabled {
   background: #f8fafc;
 }
 
+.admin-text-button--delete {
+  color: #b42318;
+  border-color: #f1d3d0;
+  background: #fffafa;
+}
+
+.admin-text-button--delete:hover:not(:disabled) {
+  color: #9f1f17;
+  border-color: #efc4bf;
+  background: #ffffff;
+  box-shadow: 0 10px 24px rgba(180, 35, 24, 0.11);
+}
+
+.admin-text-button--delete:disabled {
+  color: var(--chat-muted);
+  border-color: var(--chat-border);
+  background: #ffffff;
+  box-shadow: none;
+}
+
 .admin-primary-button {
   border: 0;
   color: #ffffff;

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -727,7 +727,7 @@ button:disabled {
 }
 
 .source-card h2 {
-  margin: 0 0 18px;
+  margin: 0 0 10px;
 }
 
 .source-list {
@@ -750,17 +750,16 @@ button:disabled {
 .source-document {
   display: grid;
   gap: 12px;
-  padding: 16px 18px;
-  border: 1px solid var(--hairline-soft);
+  padding: 14px 18px;
+  border: 0;
   border-radius: var(--radius-md);
-  background: var(--panel);
-  transition: border-color 160ms ease, box-shadow 160ms ease, transform 160ms ease;
+  background: transparent;
+  transition: box-shadow 160ms ease, background 160ms ease;
 }
 
 .source-document:hover {
-  border-color: var(--hairline);
+  background: #ffffff;
   box-shadow: 0 14px 34px rgba(15, 23, 42, 0.09);
-  transform: translateY(-1px);
 }
 
 .source-list strong {
@@ -2079,7 +2078,7 @@ button:disabled {
 }
 
 .source-list {
-  gap: 6px;
+  gap: 8px;
 }
 
 .source-list li {
@@ -2092,18 +2091,16 @@ button:disabled {
 .source-document {
   display: grid;
   gap: 12px;
-  padding: 13px 14px;
-  border: 1px solid transparent;
+  padding: 13px 18px;
+  border: 0;
   border-radius: 16px;
   background: transparent;
-  transition: border-color 160ms ease, box-shadow 160ms ease, transform 160ms ease, background 160ms ease;
+  transition: box-shadow 160ms ease, background 160ms ease;
 }
 
 .source-document:hover {
-  border-color: var(--chat-border);
   background: #ffffff;
   box-shadow: 0 14px 30px rgba(15, 23, 42, 0.08);
-  transform: translateY(-1px);
 }
 
 .source-trigger {

--- a/frontend/src/features/admin/AdminDashboardPage.jsx
+++ b/frontend/src/features/admin/AdminDashboardPage.jsx
@@ -399,7 +399,7 @@ function AdminDashboardPage() {
                     <time>{formatDate(document.createdAt)}</time>
                     <button
                       type="button"
-                      className="admin-text-button"
+                      className="admin-text-button admin-text-button--delete"
                       onClick={() => setDeleteTarget(document)}
                       disabled={isUploading || isDeleting}
                     >

--- a/frontend/src/features/chat/ChatPage.jsx
+++ b/frontend/src/features/chat/ChatPage.jsx
@@ -1,6 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
 import { Link } from 'react-router-dom'
-import StatusBadge from '../../components/common/StatusBadge.jsx'
 import { env } from '../../config/env.js'
 import { logout } from '../../services/authApi.js'
 import { openChatStream } from '../../services/chatStream.js'
@@ -654,14 +653,6 @@ function ChatPage() {
               <LoginIcon />
             </Link>
           )}
-          <StatusBadge active={isStreaming}>
-            {isStreaming ? (
-              <span className="status-badge__loading">
-                답변 생성 중
-                <LoadingDots />
-              </span>
-            ) : '대기 중'}
-          </StatusBadge>
         </header>
 
         <div ref={transcriptRef} className="chat-canvas" aria-live="polite">

--- a/frontend/src/features/chat/ChatPage.jsx
+++ b/frontend/src/features/chat/ChatPage.jsx
@@ -92,10 +92,6 @@ function getSourcePath(source) {
     .join(' · ')
 }
 
-function getSectionLabel(path) {
-  return path ? `섹션 ${path}` : ''
-}
-
 function toSourcePageNumber(value) {
   if (value === null || value === undefined || value === '') return null
 
@@ -108,8 +104,8 @@ function getSourcePageLabel(source) {
   const endPage = toSourcePageNumber(source.page_end ?? source.pageEnd)
 
   if (startPage === null) return ''
-  if (endPage !== null && endPage !== startPage) return `${startPage}-${endPage}페이지`
-  return `${startPage}페이지`
+  if (endPage !== null && endPage !== startPage) return `PDF ${startPage}-${endPage}페이지`
+  return `PDF ${startPage}페이지`
 }
 
 function getSourceDetailMeta(source) {
@@ -117,16 +113,16 @@ function getSourceDetailMeta(source) {
 
   return [
     getSourcePageLabel(source),
-    getSectionLabel(sourcePath),
     getChunkPositionLabel(source),
+    sourcePath,
   ].filter(Boolean)
 }
 
 function getDocumentInfoMeta(group) {
   return [
-    getSectionLabel(group.primaryPath),
     group.documentId ? `문서 ID ${group.documentId}` : '',
     group.uploadedAt ? `업로드 ${formatSourceDateTime(group.uploadedAt)}` : '',
+    group.primaryPath,
   ].filter(Boolean)
 }
 

--- a/frontend/src/features/chat/ChatPage.jsx
+++ b/frontend/src/features/chat/ChatPage.jsx
@@ -82,7 +82,7 @@ function BadgeButton({ className = '', onClick, label }) {
 }
 
 function getSourceTitle(source, index) {
-  return source.source || source.document_name || source.filename || `참조 문서 ${index + 1}`
+  return source.document_original_name || source.source || source.document_name || source.filename || `참조 문서 ${index + 1}`
 }
 
 function getSourcePath(source) {
@@ -112,14 +112,76 @@ function getSourceDetailMeta(source, index) {
   return [
     getSourcePageLabel(source),
     getSourcePath(source),
-    source.chunk_index !== null && source.chunk_index !== undefined ? `청크 ${Number(source.chunk_index) + 1}` : '',
+    getChunkIdLabel(source, index),
     source.document_id ? `문서 ID ${source.document_id}` : '',
     `출처 ${index + 1}`,
   ].filter(Boolean)
 }
 
+function getDocumentInfoMeta(group) {
+  return [
+    group.primaryPath,
+    group.documentId ? `문서 ID ${group.documentId}` : '',
+    group.uploadedAt ? `업로드 ${formatSourceDateTime(group.uploadedAt)}` : '',
+  ].filter(Boolean)
+}
+
+function getChunkIdLabel(source, index) {
+  if (source.chunk_index === null || source.chunk_index === undefined) {
+    return `청크 ${index + 1}`
+  }
+
+  const chunkNumber = Number(source.chunk_index)
+  if (!Number.isFinite(chunkNumber)) {
+    return `청크 ${index + 1}`
+  }
+
+  if (source.document_id) {
+    return `청크 ID ${source.document_id}_${chunkNumber}`
+  }
+  return `청크 ${chunkNumber + 1}`
+}
+
 function getSourceSnippet(source) {
   return source.content || source.text || source.page_content || '출처 본문이 응답에 포함되지 않았습니다.'
+}
+
+function formatSourceDateTime(value) {
+  if (!value) return ''
+  return String(value).replace('T', ' ').slice(0, 16)
+}
+
+function getSourceGroupKey(source, index) {
+  return source.document_id || source.document_original_name || source.source || source.filename || `source-${index}`
+}
+
+function groupSourcesByDocument(sources) {
+  const groups = new Map()
+
+  sources.forEach((source, index) => {
+    const key = getSourceGroupKey(source, index)
+    const existing = groups.get(key)
+    const sourcePath = getSourcePath(source)
+
+    if (existing) {
+      existing.chunks.push({ source, originalIndex: index })
+      if (!existing.primaryPath && sourcePath) {
+        existing.primaryPath = sourcePath
+      }
+      return
+    }
+
+    groups.set(key, {
+      key,
+      documentId: source.document_id,
+      title: getSourceTitle(source, index),
+      uploadedAt: source.document_uploaded_at,
+      primaryPath: sourcePath,
+      chunks: [{ source, originalIndex: index }],
+    })
+  })
+
+  return Array.from(groups.values())
 }
 
 function getRoleLabel(role) {
@@ -391,6 +453,7 @@ function ChatPage() {
   const canSend = question.trim().length > 0 && !isStreaming
   const hasConversation = submittedQuestion || answer || errorMessage
   const canGiveFeedback = Boolean(answer) && !isStreaming && !errorMessage
+  const sourceGroups = groupSourcesByDocument(sources)
 
   const resetChat = () => {
     eventSourceRef.current?.close()
@@ -629,16 +692,13 @@ function ChatPage() {
                   </article>
                 </div>
 
-                {sources.length > 0 && (
+                {sourceGroups.length > 0 && (
                   <section className="source-card" aria-label="출처 문서">
                     <h2>출처 문서</h2>
                     <ol className="source-list">
-                      {sources.map((source, index) => {
-                        const pageLabel = getSourcePageLabel(source)
-                        const sourcePath = getSourcePath(source)
-
-                        return (
-                          <li key={`${source.document_id ?? source.source ?? 'source'}-${index}`}>
+                      {sourceGroups.map((group, index) => (
+                        <li key={group.key}>
+                          <article className="source-document">
                             <button
                               type="button"
                               className="source-trigger"
@@ -646,28 +706,42 @@ function ChatPage() {
                               aria-controls={`source-detail-${index}`}
                               onClick={() => setActiveSourceIndex((prevIndex) => (prevIndex === index ? null : index))}
                             >
-                              <strong>{getSourceTitle(source, index)}</strong>
+                              <strong>{group.title}</strong>
                               <span className="source-trigger__meta">
-                                {pageLabel && <span className="source-page">{pageLabel}</span>}
-                                {sourcePath && <span className="source-path">{sourcePath}</span>}
+                                {group.primaryPath && <span className="source-path">{group.primaryPath}</span>}
+                                <span className="source-path">{group.chunks.length}개 청크</span>
                               </span>
                             </button>
                             {activeSourceIndex === index && (
                               <div id={`source-detail-${index}`} className="source-detail">
-                                <dl className="source-detail__meta" aria-label="출처 상세 정보">
-                                  {getSourceDetailMeta(source, index).map((item) => (
+                                <dl className="source-detail__meta source-detail__meta--document" aria-label="문서 상세 정보">
+                                  {getDocumentInfoMeta(group).map((item) => (
                                     <div key={item}>
                                       <dt className="sr-only">출처 정보</dt>
                                       <dd>{item}</dd>
                                     </div>
                                   ))}
                                 </dl>
-                                <p>{getSourceSnippet(source)}</p>
+                                <div className="source-chunk-list" aria-label={`${group.title} 검색 청크 목록`}>
+                                  {group.chunks.map(({ source, originalIndex }, chunkIndex) => (
+                                    <section className="source-chunk" key={`${group.key}-${originalIndex}`}>
+                                      <dl className="source-detail__meta" aria-label="청크 상세 정보">
+                                        {getSourceDetailMeta(source, chunkIndex).map((item) => (
+                                          <div key={item}>
+                                            <dt className="sr-only">청크 정보</dt>
+                                            <dd>{item}</dd>
+                                          </div>
+                                        ))}
+                                      </dl>
+                                      <p>{getSourceSnippet(source)}</p>
+                                    </section>
+                                  ))}
+                                </div>
                               </div>
                             )}
-                          </li>
-                        )
-                      })}
+                          </article>
+                        </li>
+                      ))}
                     </ol>
                   </section>
                 )}

--- a/frontend/src/features/chat/ChatPage.jsx
+++ b/frontend/src/features/chat/ChatPage.jsx
@@ -92,6 +92,32 @@ function getSourcePath(source) {
     .join(' · ')
 }
 
+function toSourcePageNumber(value) {
+  if (value === null || value === undefined || value === '') return null
+
+  const pageNumber = Number(value)
+  return Number.isFinite(pageNumber) ? pageNumber : null
+}
+
+function getSourcePageLabel(source) {
+  const startPage = toSourcePageNumber(source.page_start ?? source.pageStart ?? source.page)
+  const endPage = toSourcePageNumber(source.page_end ?? source.pageEnd)
+
+  if (startPage === null) return ''
+  if (endPage !== null && endPage !== startPage) return `${startPage}-${endPage}페이지`
+  return `${startPage}페이지`
+}
+
+function getSourceDetailMeta(source, index) {
+  return [
+    getSourcePageLabel(source),
+    getSourcePath(source),
+    source.chunk_index !== null && source.chunk_index !== undefined ? `청크 ${Number(source.chunk_index) + 1}` : '',
+    source.document_id ? `문서 ID ${source.document_id}` : '',
+    `출처 ${index + 1}`,
+  ].filter(Boolean)
+}
+
 function getSourceSnippet(source) {
   return source.content || source.text || source.page_content || '출처 본문이 응답에 포함되지 않았습니다.'
 }
@@ -607,21 +633,41 @@ function ChatPage() {
                   <section className="source-card" aria-label="출처 문서">
                     <h2>출처 문서</h2>
                     <ol className="source-list">
-                      {sources.map((source, index) => (
-                        <li key={`${source.document_id ?? source.source ?? 'source'}-${index}`}>
-                          <button
-                            type="button"
-                            className="source-trigger"
-                            onClick={() => setActiveSourceIndex((prevIndex) => (prevIndex === index ? null : index))}
-                          >
-                            <strong>{getSourceTitle(source, index)}</strong>
-                            {getSourcePath(source) && <span>{getSourcePath(source)}</span>}
-                          </button>
-                          {activeSourceIndex === index && (
-                            <p>{getSourceSnippet(source)}</p>
-                          )}
-                        </li>
-                      ))}
+                      {sources.map((source, index) => {
+                        const pageLabel = getSourcePageLabel(source)
+                        const sourcePath = getSourcePath(source)
+
+                        return (
+                          <li key={`${source.document_id ?? source.source ?? 'source'}-${index}`}>
+                            <button
+                              type="button"
+                              className="source-trigger"
+                              aria-expanded={activeSourceIndex === index}
+                              aria-controls={`source-detail-${index}`}
+                              onClick={() => setActiveSourceIndex((prevIndex) => (prevIndex === index ? null : index))}
+                            >
+                              <strong>{getSourceTitle(source, index)}</strong>
+                              <span className="source-trigger__meta">
+                                {pageLabel && <span className="source-page">{pageLabel}</span>}
+                                {sourcePath && <span className="source-path">{sourcePath}</span>}
+                              </span>
+                            </button>
+                            {activeSourceIndex === index && (
+                              <div id={`source-detail-${index}`} className="source-detail">
+                                <dl className="source-detail__meta" aria-label="출처 상세 정보">
+                                  {getSourceDetailMeta(source, index).map((item) => (
+                                    <div key={item}>
+                                      <dt className="sr-only">출처 정보</dt>
+                                      <dd>{item}</dd>
+                                    </div>
+                                  ))}
+                                </dl>
+                                <p>{getSourceSnippet(source)}</p>
+                              </div>
+                            )}
+                          </li>
+                        )
+                      })}
                     </ol>
                   </section>
                 )}

--- a/frontend/src/features/chat/ChatPage.jsx
+++ b/frontend/src/features/chat/ChatPage.jsx
@@ -92,6 +92,10 @@ function getSourcePath(source) {
     .join(' · ')
 }
 
+function getSectionLabel(path) {
+  return path ? `섹션 ${path}` : ''
+}
+
 function toSourcePageNumber(value) {
   if (value === null || value === undefined || value === '') return null
 
@@ -108,38 +112,35 @@ function getSourcePageLabel(source) {
   return `${startPage}페이지`
 }
 
-function getSourceDetailMeta(source, index) {
+function getSourceDetailMeta(source) {
+  const sourcePath = getSourcePath(source)
+
   return [
     getSourcePageLabel(source),
-    getSourcePath(source),
-    getChunkIdLabel(source, index),
-    source.document_id ? `문서 ID ${source.document_id}` : '',
-    `출처 ${index + 1}`,
+    getSectionLabel(sourcePath),
+    getChunkPositionLabel(source),
   ].filter(Boolean)
 }
 
 function getDocumentInfoMeta(group) {
   return [
-    group.primaryPath,
+    getSectionLabel(group.primaryPath),
     group.documentId ? `문서 ID ${group.documentId}` : '',
     group.uploadedAt ? `업로드 ${formatSourceDateTime(group.uploadedAt)}` : '',
   ].filter(Boolean)
 }
 
-function getChunkIdLabel(source, index) {
+function getChunkPositionLabel(source) {
   if (source.chunk_index === null || source.chunk_index === undefined) {
-    return `청크 ${index + 1}`
+    return ''
   }
 
   const chunkNumber = Number(source.chunk_index)
   if (!Number.isFinite(chunkNumber)) {
-    return `청크 ${index + 1}`
+    return ''
   }
 
-  if (source.document_id) {
-    return `청크 ID ${source.document_id}_${chunkNumber}`
-  }
-  return `청크 ${chunkNumber + 1}`
+  return `문서 내 ${chunkNumber + 1}번째 청크`
 }
 
 function getSourceSnippet(source) {
@@ -707,10 +708,6 @@ function ChatPage() {
                               onClick={() => setActiveSourceIndex((prevIndex) => (prevIndex === index ? null : index))}
                             >
                               <strong>{group.title}</strong>
-                              <span className="source-trigger__meta">
-                                {group.primaryPath && <span className="source-path">{group.primaryPath}</span>}
-                                <span className="source-path">{group.chunks.length}개 청크</span>
-                              </span>
                             </button>
                             {activeSourceIndex === index && (
                               <div id={`source-detail-${index}`} className="source-detail">
@@ -723,10 +720,10 @@ function ChatPage() {
                                   ))}
                                 </dl>
                                 <div className="source-chunk-list" aria-label={`${group.title} 검색 청크 목록`}>
-                                  {group.chunks.map(({ source, originalIndex }, chunkIndex) => (
+                                  {group.chunks.map(({ source, originalIndex }) => (
                                     <section className="source-chunk" key={`${group.key}-${originalIndex}`}>
                                       <dl className="source-detail__meta" aria-label="청크 상세 정보">
-                                        {getSourceDetailMeta(source, chunkIndex).map((item) => (
+                                        {getSourceDetailMeta(source).map((item) => (
                                           <div key={item}>
                                             <dt className="sr-only">청크 정보</dt>
                                             <dd>{item}</dd>

--- a/frontend/src/features/chat/ChatPage.jsx
+++ b/frontend/src/features/chat/ChatPage.jsx
@@ -109,12 +109,9 @@ function getSourcePageLabel(source) {
 }
 
 function getSourceDetailMeta(source) {
-  const sourcePath = getSourcePath(source)
-
   return [
     getSourcePageLabel(source),
     getChunkPositionLabel(source),
-    sourcePath,
   ].filter(Boolean)
 }
 
@@ -122,7 +119,6 @@ function getDocumentInfoMeta(group) {
   return [
     group.documentId ? `문서 ID ${group.documentId}` : '',
     group.uploadedAt ? `업로드 ${formatSourceDateTime(group.uploadedAt)}` : '',
-    group.primaryPath,
   ].filter(Boolean)
 }
 

--- a/frontend/src/features/chat/ChatPage.jsx
+++ b/frontend/src/features/chat/ChatPage.jsx
@@ -45,6 +45,15 @@ function DeleteIcon() {
   )
 }
 
+function SettingsIcon() {
+  return (
+    <svg aria-hidden="true" viewBox="0 0 24 24" focusable="false">
+      <path d="M12 15.2a3.2 3.2 0 1 0 0-6.4 3.2 3.2 0 0 0 0 6.4Z" />
+      <path d="M19.4 15a1.7 1.7 0 0 0 .34 1.88l.06.06a2.05 2.05 0 0 1-2.9 2.9l-.06-.06a1.7 1.7 0 0 0-1.88-.34 1.7 1.7 0 0 0-1.03 1.56V21a2.05 2.05 0 0 1-4.1 0v-.08A1.7 1.7 0 0 0 8.9 19.4a1.7 1.7 0 0 0-1.88.34l-.06.06a2.05 2.05 0 0 1-2.9-2.9l.06-.06A1.7 1.7 0 0 0 4.46 15 1.7 1.7 0 0 0 2.9 13.97H2.8a2.05 2.05 0 0 1 0-4.1h.08A1.7 1.7 0 0 0 4.44 8.9a1.7 1.7 0 0 0-.34-1.88l-.06-.06a2.05 2.05 0 0 1 2.9-2.9l.06.06A1.7 1.7 0 0 0 8.88 4.46 1.7 1.7 0 0 0 9.91 2.9V2.8a2.05 2.05 0 0 1 4.1 0v.08a1.7 1.7 0 0 0 1.03 1.56 1.7 1.7 0 0 0 1.88-.34l.06-.06a2.05 2.05 0 0 1 2.9 2.9l-.06.06a1.7 1.7 0 0 0-.34 1.88 1.7 1.7 0 0 0 1.56 1.03h.08a2.05 2.05 0 0 1 0 4.1h-.08A1.7 1.7 0 0 0 19.4 15Z" />
+    </svg>
+  )
+}
+
 function LoadingDots() {
   return (
     <span className="loading-dots" aria-hidden="true">
@@ -447,6 +456,7 @@ function ChatPage() {
   const hasConversation = submittedQuestion || answer || errorMessage
   const canGiveFeedback = Boolean(answer) && !isStreaming && !errorMessage
   const sourceGroups = groupSourcesByDocument(sources)
+  const isAdmin = authProfile?.role === 'ADMIN'
 
   const resetChat = () => {
     eventSourceRef.current?.close()
@@ -591,6 +601,12 @@ function ChatPage() {
               {renderHistoryContent()}
             </div>
           </div>
+
+          {isAdmin && (
+            <Link className="admin-home-link" to="/admin" aria-label="관리자 홈" title="관리자 홈">
+              <SettingsIcon />
+            </Link>
+          )}
         </aside>
       )}
 

--- a/frontend/src/features/chat/ChatPage.jsx
+++ b/frontend/src/features/chat/ChatPage.jsx
@@ -117,9 +117,12 @@ function getSourcePageLabel(source) {
 }
 
 function getSourceDetailMeta(source) {
+  const pageLabel = getSourcePageLabel(source)
+
   return [
-    getSourcePageLabel(source),
+    pageLabel,
     getChunkPositionLabel(source),
+    pageLabel ? '' : getSourcePath(source),
   ].filter(Boolean)
 }
 


### PR DESCRIPTION
## 작업 내용

- 답변 하단 출처를 문서 단위로 그룹핑해 같은 PDF의 topK 청크가 여러 출처처럼 반복 표시되지 않도록 보완
- 출처 문서 클릭 시 문서 ID, 업로드 시각, PDF 페이지, 문서 내 N번째 청크, 근거 본문을 청크별 카드로 표시
- FastAPI sources 응답에 `page`, `page_start`, `page_end`, `chunk_index` metadata 추가
- 기존 Two-Pass 청킹은 유지하고 PDF 원본 페이지 텍스트 lookup과 snippet 매칭으로 페이지 범위 추정
- 기존 ChromaDB 문서의 `chunk_index`는 Chroma id fallback으로 복원
- Spring `SourceDocumentMetadataEnricher`를 추가해 일반 채팅과 SSE 완료 이벤트 모두 문서 원본명, 업로드 시각 등 DB metadata를 보강
- 출처 상세에서 헤더 경로, 응답 내 출처 번호, 중복 청크 번호처럼 검수 가치가 낮은 정보 제거
- 문서 관리 삭제 버튼을 은은한 붉은 톤으로 조정하고 hover는 그림자 중심으로 정리
- 관리자 로그인 상태에서만 챗봇 사이드바 좌측 하단에 `/admin` 복귀 톱니바퀴 아이콘 표시
- 채팅 topbar의 `대기 중` / `답변 생성 중` 상태 배지를 제거하고 답변 카드 내부 로딩 표시만 유지
- 문서 업로드 시 선택한 `categoryId`가 문서 목록 응답의 `categoryId`, `categoryName`으로 반환되는지 테스트 보강

## 검증

- [x] `cd frontend && npm run lint`
- [x] `cd frontend && npm run build`
- [x] `python3 -m py_compile ai-server/main.py`
- [x] `cd backend && ./gradlew test`
- [x] `cd backend && ./gradlew test --tests com.documind.documind.domain.chat.SseStreamingContextTest --tests com.documind.documind.domain.chat.ChatHistoryTest`
- [x] `cd backend && ./gradlew test --tests com.documind.documind.domain.document.DocumentManagementTest`
- [x] `git diff --check`
- [x] GCP 브라우저 검수
  - 출처 문서 그룹핑 확인
  - 출처 상세 펼침 및 청크 카드 확인
  - 새로 업로드한 PDF 기준 페이지 번호 확인
  - 관리자 홈 복귀 아이콘 확인
  - topbar 상태 배지 제거 확인
  - 카테고리 생성/선택/문서 목록 표시 확인

## 이슈

Closes #15