### PR TITLE
feat(chat): 피드백 UI 개발 (#17)

### DIFF
--- a/backend/src/main/java/com/documind/documind/domain/admin/FeedbackStatsController.java
+++ b/backend/src/main/java/com/documind/documind/domain/admin/FeedbackStatsController.java
@@ -1,0 +1,45 @@
+package com.documind.documind.domain.admin;
+
+import com.documind.documind.domain.chat.ChatFeedbackRepository;
+import com.documind.documind.global.common.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 관리자 대시보드의 답변 피드백 집계 API.
+ * 상세 추적은 고도화 범위로 두고, MVP에서는 전체 좋아요/싫어요 총량만 제공한다.
+ */
+@RestController
+@RequestMapping("/api/admin/feedback-stats")
+@RequiredArgsConstructor
+public class FeedbackStatsController {
+
+    private static final byte POSITIVE_SCORE = 1;
+    private static final byte NEGATIVE_SCORE = -1;
+
+    private final ChatFeedbackRepository chatFeedbackRepository;
+
+    /**
+     * GET /api/admin/feedback-stats — 전체 답변 피드백 집계를 조회한다.
+     *
+     * @return 전체, 좋아요, 싫어요, 좋아요 비율 지표
+     */
+    @GetMapping
+    public ResponseEntity<ApiResponse<FeedbackStatsResponse>> stats() {
+        long positiveCount = chatFeedbackRepository.countByScore(POSITIVE_SCORE);
+        long negativeCount = chatFeedbackRepository.countByScore(NEGATIVE_SCORE);
+        long totalCount = positiveCount + negativeCount;
+        double positiveRate = totalCount == 0 ? 0.0 : (double) positiveCount / totalCount;
+
+        FeedbackStatsResponse response = FeedbackStatsResponse.builder()
+                .totalCount(totalCount)
+                .positiveCount(positiveCount)
+                .negativeCount(negativeCount)
+                .positiveRate(positiveRate)
+                .build();
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+}

--- a/backend/src/main/java/com/documind/documind/domain/admin/FeedbackStatsResponse.java
+++ b/backend/src/main/java/com/documind/documind/domain/admin/FeedbackStatsResponse.java
@@ -1,0 +1,24 @@
+package com.documind.documind.domain.admin;
+
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 관리자 대시보드에서 표시할 답변 피드백 집계 응답 DTO.
+ */
+@Getter
+@Builder
+public class FeedbackStatsResponse {
+
+    // 저장된 전체 피드백 수
+    private long totalCount;
+
+    // 좋아요 피드백 수
+    private long positiveCount;
+
+    // 싫어요 피드백 수
+    private long negativeCount;
+
+    // 좋아요 비율. 전체 피드백이 없으면 0.0
+    private double positiveRate;
+}

--- a/backend/src/main/java/com/documind/documind/domain/chat/ChatController.java
+++ b/backend/src/main/java/com/documind/documind/domain/chat/ChatController.java
@@ -108,6 +108,22 @@ public class ChatController {
     }
 
     /**
+     * 답변 메시지 피드백을 등록하거나 수정한다.
+     * 로그인 사용자는 JWT userId, 비로그인 사용자는 X-Session-Key로 메시지 소유권을 검증한다.
+     */
+    @PutMapping("/messages/{messageId}/feedback")
+    public ResponseEntity<ApiResponse<ChatFeedbackResponse>> updateFeedback(
+            @PathVariable Long messageId,
+            @Valid @RequestBody ChatFeedbackRequest request,
+            Authentication authentication,
+            @RequestHeader(value = "X-Session-Key", required = false) String sessionKey
+    ) {
+        Long userId = extractUserId(authentication);
+        ChatFeedbackResponse response = chatService.updateFeedback(messageId, userId, sessionKey, request);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
      * Authentication 객체에서 userId를 추출한다.
      * AnonymousAuthenticationToken.isAuthenticated()는 true를 반환하므로 instanceof로 명시적으로 구분한다.
      * 비로그인이거나 details가 JwtAuthenticationDetails가 아니면 null을 반환해 sessionKey 분기로 처리한다.

--- a/backend/src/main/java/com/documind/documind/domain/chat/ChatFeedback.java
+++ b/backend/src/main/java/com/documind/documind/domain/chat/ChatFeedback.java
@@ -51,4 +51,27 @@ public class ChatFeedback {
     protected void onUpdate() {
         this.updatedAt = LocalDateTime.now();
     }
+
+    /**
+     * 채팅 메시지에 대한 새 피드백을 생성한다.
+     *
+     * @param chatMessage 피드백 대상 메시지
+     * @param score 피드백 점수. 1은 좋아요, -1은 싫어요
+     * @return 저장 가능한 피드백 엔티티
+     */
+    public static ChatFeedback create(ChatMessage chatMessage, byte score) {
+        ChatFeedback feedback = new ChatFeedback();
+        feedback.chatMessage = chatMessage;
+        feedback.score = score;
+        return feedback;
+    }
+
+    /**
+     * 기존 피드백 점수를 수정한다.
+     *
+     * @param score 변경할 피드백 점수. 1은 좋아요, -1은 싫어요
+     */
+    public void updateScore(byte score) {
+        this.score = score;
+    }
 }

--- a/backend/src/main/java/com/documind/documind/domain/chat/ChatFeedbackRepository.java
+++ b/backend/src/main/java/com/documind/documind/domain/chat/ChatFeedbackRepository.java
@@ -19,6 +19,9 @@ public interface ChatFeedbackRepository extends JpaRepository<ChatFeedback, Long
     /** 여러 메시지 ID에 대한 피드백을 한 번에 조회한다. 세션 상세 응답 생성에 사용한다. */
     List<ChatFeedback> findByChatMessageIdIn(Collection<Long> messageIds);
 
+    /** 특정 점수의 피드백 개수를 집계한다. 관리자 대시보드 요약 지표에 사용한다. */
+    long countByScore(Byte score);
+
     /**
      * 세션 삭제 전 해당 세션 메시지에 연결된 피드백을 먼저 삭제한다.
      * chat_feedback.message_id FK가 chat_messages.id를 참조하므로 메시지 bulk delete 전에 필요하다.

--- a/backend/src/main/java/com/documind/documind/domain/chat/ChatFeedbackRepository.java
+++ b/backend/src/main/java/com/documind/documind/domain/chat/ChatFeedbackRepository.java
@@ -1,0 +1,30 @@
+package com.documind.documind.domain.chat;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+
+/** chat_feedback 테이블 CRUD를 담당하는 JPA Repository */
+public interface ChatFeedbackRepository extends JpaRepository<ChatFeedback, Long> {
+
+    /** 메시지 ID로 기존 피드백을 조회한다. 피드백 수정 시 upsert 판단에 사용한다. */
+    Optional<ChatFeedback> findByChatMessageId(Long messageId);
+
+    /** 여러 메시지 ID에 대한 피드백을 한 번에 조회한다. 세션 상세 응답 생성에 사용한다. */
+    List<ChatFeedback> findByChatMessageIdIn(Collection<Long> messageIds);
+
+    /**
+     * 세션 삭제 전 해당 세션 메시지에 연결된 피드백을 먼저 삭제한다.
+     * chat_feedback.message_id FK가 chat_messages.id를 참조하므로 메시지 bulk delete 전에 필요하다.
+     */
+    @Modifying(clearAutomatically = true)
+    @Transactional
+    @Query("DELETE FROM ChatFeedback f WHERE f.chatMessage.chatSession.id = :sessionId")
+    void deleteByChatSessionId(@Param("sessionId") Long sessionId);
+}

--- a/backend/src/main/java/com/documind/documind/domain/chat/ChatFeedbackRequest.java
+++ b/backend/src/main/java/com/documind/documind/domain/chat/ChatFeedbackRequest.java
@@ -1,0 +1,36 @@
+package com.documind.documind.domain.chat;
+
+import com.documind.documind.global.exception.CustomException;
+import com.documind.documind.global.exception.ErrorCode;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 답변 피드백 등록·수정 요청 DTO.
+ * score는 1(좋아요) 또는 -1(싫어요)만 허용한다.
+ */
+@Getter
+@NoArgsConstructor
+public class ChatFeedbackRequest {
+
+    // 피드백 점수. 1=좋아요, -1=싫어요. 0은 의미가 없으므로 서비스에서 거부한다.
+    @NotNull(message = "피드백 점수는 필수입니다.")
+    @Min(value = -1, message = "피드백 점수는 -1 또는 1이어야 합니다.")
+    @Max(value = 1, message = "피드백 점수는 -1 또는 1이어야 합니다.")
+    private Integer score;
+
+    /**
+     * 요청 점수를 DB 저장용 byte 값으로 변환한다.
+     *
+     * @return 1 또는 -1
+     */
+    public byte normalizedScore() {
+        if (score == null || score == 0) {
+            throw new CustomException(ErrorCode.INVALID_FEEDBACK_SCORE);
+        }
+        return score.byteValue();
+    }
+}

--- a/backend/src/main/java/com/documind/documind/domain/chat/ChatFeedbackResponse.java
+++ b/backend/src/main/java/com/documind/documind/domain/chat/ChatFeedbackResponse.java
@@ -1,0 +1,37 @@
+package com.documind.documind.domain.chat;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+/**
+ * 답변 피드백 등록·수정 응답 DTO.
+ */
+@Getter
+@Builder
+public class ChatFeedbackResponse {
+
+    // 피드백 대상 메시지 ID
+    private Long messageId;
+
+    // 저장된 피드백 점수. 1=좋아요, -1=싫어요
+    private Byte score;
+
+    // 피드백 최종 수정 시각
+    private LocalDateTime updatedAt;
+
+    /**
+     * ChatFeedback 엔티티를 클라이언트 응답 DTO로 변환한다.
+     *
+     * @param feedback 저장 또는 수정된 피드백 엔티티
+     * @return 클라이언트에 반환할 피드백 응답
+     */
+    public static ChatFeedbackResponse from(ChatFeedback feedback) {
+        return ChatFeedbackResponse.builder()
+                .messageId(feedback.getChatMessage().getId())
+                .score(feedback.getScore())
+                .updatedAt(feedback.getUpdatedAt())
+                .build();
+    }
+}

--- a/backend/src/main/java/com/documind/documind/domain/chat/ChatMessageRepository.java
+++ b/backend/src/main/java/com/documind/documind/domain/chat/ChatMessageRepository.java
@@ -7,12 +7,24 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Optional;
 
 /** chat_messages 테이블 CRUD를 담당하는 JPA Repository */
 public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
 
     /** 특정 세션에 속한 메시지를 시간순으로 조회한다. 세션 상세 조회 시 대화 흐름 재현에 사용한다. */
     List<ChatMessage> findByChatSessionIdOrderByCreatedAtAsc(Long sessionId);
+
+    /** messageId + userId로 소유권을 검증하며 메시지를 조회한다. 로그인 사용자의 피드백 저장에 사용한다. */
+    @Query("SELECT m FROM ChatMessage m WHERE m.id = :messageId AND m.chatSession.user.id = :userId")
+    Optional<ChatMessage> findByIdAndUserId(@Param("messageId") Long messageId, @Param("userId") Long userId);
+
+    /** messageId + sessionKey로 소유권을 검증하며 메시지를 조회한다. 비로그인 사용자의 피드백 저장에 사용한다. */
+    @Query("SELECT m FROM ChatMessage m WHERE m.id = :messageId AND m.chatSession.sessionKey = :sessionKey")
+    Optional<ChatMessage> findByIdAndSessionKey(
+            @Param("messageId") Long messageId,
+            @Param("sessionKey") String sessionKey
+    );
 
     /**
      * 세션의 메시지를 JPQL로 일괄 삭제한다.

--- a/backend/src/main/java/com/documind/documind/domain/chat/ChatMessageResponse.java
+++ b/backend/src/main/java/com/documind/documind/domain/chat/ChatMessageResponse.java
@@ -27,6 +27,9 @@ public class ChatMessageResponse {
     // 답변 근거 문서 목록. DB의 JSON 문자열을 역직렬화한 결과
     private List<Map<String, Object>> sources;
 
+    // 저장된 피드백 점수. 1=좋아요, -1=싫어요, null=미등록
+    private Byte feedbackScore;
+
     // 메시지 생성 시각
     private LocalDateTime createdAt;
 }

--- a/backend/src/main/java/com/documind/documind/domain/chat/ChatService.java
+++ b/backend/src/main/java/com/documind/documind/domain/chat/ChatService.java
@@ -37,6 +37,7 @@ public class ChatService {
 
     private final ChatSessionRepository chatSessionRepository;
     private final ChatMessageRepository chatMessageRepository;
+    private final ChatFeedbackRepository chatFeedbackRepository;
     private final ChatStreamPersistenceService chatStreamPersistenceService;
     private final SourceDocumentMetadataEnricher sourceDocumentMetadataEnricher;
     private final PromptConfigService promptConfigService;
@@ -123,14 +124,17 @@ public class ChatService {
     public ChatSessionDetailResponse getSessionDetail(Long sessionId, Long userId, String sessionKey) {
         ChatSession session = resolveSession(sessionId, userId, sessionKey);
 
-        List<ChatMessageResponse> messageResponses = chatMessageRepository
-                .findByChatSessionIdOrderByCreatedAtAsc(sessionId)
+        List<ChatMessage> messages = chatMessageRepository.findByChatSessionIdOrderByCreatedAtAsc(sessionId);
+        Map<Long, Byte> feedbackScores = loadFeedbackScores(messages);
+
+        List<ChatMessageResponse> messageResponses = messages
                 .stream()
                 .map(m -> ChatMessageResponse.builder()
                         .messageId(m.getId())
                         .question(m.getQuestion())
                         .answer(m.getAnswer())
                         .sources(deserializeSources(m.getSourceDocs()))
+                        .feedbackScore(feedbackScores.get(m.getId()))
                         .createdAt(m.getCreatedAt())
                         .build())
                 .toList();
@@ -150,8 +154,39 @@ public class ChatService {
     @Transactional
     public void deleteSession(Long sessionId, Long userId, String sessionKey) {
         resolveSession(sessionId, userId, sessionKey);
+        chatFeedbackRepository.deleteByChatSessionId(sessionId);
         chatMessageRepository.deleteByChatSessionId(sessionId);
         chatSessionRepository.deleteById(sessionId);
+    }
+
+    /**
+     * 답변 메시지에 대한 피드백을 등록하거나 수정한다.
+     * 로그인 사용자는 userId로, 비로그인 사용자는 sessionKey로 메시지 소유권을 검증한다.
+     *
+     * @param messageId 피드백 대상 메시지 ID
+     * @param userId 로그인 사용자 ID. 비로그인이면 null
+     * @param sessionKey 비로그인 세션 키
+     * @param request 피드백 점수 요청
+     * @return 저장된 피드백 정보
+     */
+    @Transactional
+    public ChatFeedbackResponse updateFeedback(
+            Long messageId,
+            Long userId,
+            String sessionKey,
+            ChatFeedbackRequest request
+    ) {
+        ChatMessage message = resolveMessage(messageId, userId, sessionKey);
+        byte score = request.normalizedScore();
+
+        ChatFeedback feedback = chatFeedbackRepository.findByChatMessageId(messageId)
+                .map(existingFeedback -> {
+                    existingFeedback.updateScore(score);
+                    return existingFeedback;
+                })
+                .orElseGet(() -> chatFeedbackRepository.save(ChatFeedback.create(message, score)));
+
+        return ChatFeedbackResponse.from(feedback);
     }
 
     // sessionId + (userId 또는 sessionKey)로 소유권을 검증하고 세션을 반환.
@@ -166,6 +201,35 @@ public class ChatService {
                     .orElseThrow(() -> new CustomException(ErrorCode.CHAT_SESSION_NOT_FOUND));
         }
         throw new CustomException(ErrorCode.CHAT_SESSION_NOT_FOUND);
+    }
+
+    // messageId + (userId 또는 sessionKey)로 소유권을 검증하고 메시지를 반환.
+    private ChatMessage resolveMessage(Long messageId, Long userId, String sessionKey) {
+        if (userId != null) {
+            return chatMessageRepository.findByIdAndUserId(messageId, userId)
+                    .orElseThrow(() -> new CustomException(ErrorCode.CHAT_MESSAGE_NOT_FOUND));
+        }
+        if (sessionKey != null) {
+            return chatMessageRepository.findByIdAndSessionKey(messageId, sessionKey)
+                    .orElseThrow(() -> new CustomException(ErrorCode.CHAT_MESSAGE_NOT_FOUND));
+        }
+        throw new CustomException(ErrorCode.CHAT_MESSAGE_NOT_FOUND);
+    }
+
+    // 세션 상세 메시지 목록에 붙일 피드백 점수를 messageId 기준 Map으로 변환한다.
+    private Map<Long, Byte> loadFeedbackScores(List<ChatMessage> messages) {
+        List<Long> messageIds = messages.stream()
+                .map(ChatMessage::getId)
+                .toList();
+        if (messageIds.isEmpty()) {
+            return Map.of();
+        }
+        return chatFeedbackRepository.findByChatMessageIdIn(messageIds)
+                .stream()
+                .collect(java.util.stream.Collectors.toMap(
+                        feedback -> feedback.getChatMessage().getId(),
+                        ChatFeedback::getScore
+                ));
     }
 
     // sourceDocs JSON 문자열을 역직렬화. null이거나 파싱 실패 시 빈 리스트로 폴백

--- a/backend/src/main/java/com/documind/documind/domain/chat/SseStreamingContext.java
+++ b/backend/src/main/java/com/documind/documind/domain/chat/SseStreamingContext.java
@@ -176,6 +176,7 @@ class SseStreamingContext {
 
         ObjectNode outbound = (ObjectNode) node.deepCopy();
         outbound.set("sources", objectMapper.valueToTree(sources));
+        outbound.put("messageId", messageId);
         return objectMapper.writeValueAsString(outbound);
     }
 

--- a/backend/src/main/java/com/documind/documind/global/config/SecurityConfig.java
+++ b/backend/src/main/java/com/documind/documind/global/config/SecurityConfig.java
@@ -79,6 +79,7 @@ public class SecurityConfig {
                     .requestMatchers(HttpMethod.GET, "/api/chat/sessions").permitAll()
                     .requestMatchers(HttpMethod.GET, "/api/chat/sessions/**").permitAll()
                     .requestMatchers(HttpMethod.DELETE, "/api/chat/sessions/**").permitAll()
+                    .requestMatchers(HttpMethod.PUT, "/api/chat/messages/*/feedback").permitAll()
                     .requestMatchers("/error", "/actuator/health").permitAll()
 
                     // 명시되지 않은 모든 요청 차단 — 새 API 추가 시 반드시 위에 명시해야 한다

--- a/backend/src/main/java/com/documind/documind/global/exception/ErrorCode.java
+++ b/backend/src/main/java/com/documind/documind/global/exception/ErrorCode.java
@@ -45,6 +45,8 @@ public enum ErrorCode {
 
     // 채팅
     CHAT_SESSION_NOT_FOUND(HttpStatus.NOT_FOUND, "채팅 세션을 찾을 수 없습니다."),
+    CHAT_MESSAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "채팅 메시지를 찾을 수 없습니다."),
+    INVALID_FEEDBACK_SCORE(HttpStatus.BAD_REQUEST, "피드백 점수는 좋아요 또는 싫어요만 가능합니다."),
     // streamId가 만료되거나 이미 소비된 경우 — 클라이언트가 새 세션을 생성하도록 유도
     STREAM_SESSION_NOT_FOUND(HttpStatus.NOT_FOUND, "스트리밍 세션을 찾을 수 없거나 만료되었습니다."),
     STREAM_SESSION_LIMIT_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS, "스트리밍 요청이 일시적으로 많습니다. 잠시 후 다시 시도해주세요."),

--- a/backend/src/test/java/com/documind/documind/domain/chat/ChatFeedbackTest.java
+++ b/backend/src/test/java/com/documind/documind/domain/chat/ChatFeedbackTest.java
@@ -1,0 +1,168 @@
+package com.documind.documind.domain.chat;
+
+import com.documind.documind.domain.auth.User;
+import com.documind.documind.domain.auth.UserRepository;
+import com.documind.documind.global.exception.CustomException;
+import com.documind.documind.global.exception.ErrorCode;
+import com.documind.documind.global.infra.fastapi.FastApiClient;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * 채팅 답변 피드백 서비스 통합 테스트.
+ * 등록, 수정, 소유권 검증, 세션 삭제 시 FK 정리를 검증한다.
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+class ChatFeedbackTest {
+
+    @Autowired
+    private ChatService chatService;
+
+    @Autowired
+    private ChatSessionRepository chatSessionRepository;
+
+    @Autowired
+    private ChatMessageRepository chatMessageRepository;
+
+    @Autowired
+    private ChatFeedbackRepository chatFeedbackRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    // @MockitoBean: ChatService 의존성인 FastApiClient를 외부 호출 없이 컨텍스트에 주입한다.
+    @MockitoBean
+    private FastApiClient fastApiClient;
+
+    private static final String SESSION_KEY = "feedback-session-key";
+
+    private ChatSession session;
+    private ChatMessage message;
+    private User user;
+    private ChatSession userSession;
+    private ChatMessage userMessage;
+
+    // 각 테스트마다 비로그인 세션과 로그인 사용자 세션을 준비한다.
+    @BeforeEach
+    void setUp() {
+        session = chatSessionRepository.save(ChatSession.create(null, SESSION_KEY, "피드백 질문"));
+        message = ChatMessage.create(session, "피드백 질문");
+        message.complete("피드백 답변", "[]");
+        chatMessageRepository.save(message);
+
+        user = userRepository.save(User.create("feedback-admin", "hashed_password", User.Role.ADMIN));
+        userSession = chatSessionRepository.save(ChatSession.create(user, null, "로그인 피드백 질문"));
+        userMessage = ChatMessage.create(userSession, "로그인 피드백 질문");
+        userMessage.complete("로그인 피드백 답변", "[]");
+        chatMessageRepository.save(userMessage);
+    }
+
+    // FK 순서에 맞춰 피드백, 메시지, 세션, 사용자를 정리한다.
+    @AfterEach
+    void tearDown() {
+        chatFeedbackRepository.deleteAll();
+        chatMessageRepository.deleteAll();
+        chatSessionRepository.deleteAll();
+        userRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("비로그인 sessionKey로 답변 피드백을 등록한다")
+    void updateFeedback_withSessionKey_createsFeedback() {
+        ChatFeedbackResponse response = chatService.updateFeedback(
+                message.getId(),
+                null,
+                SESSION_KEY,
+                feedbackRequest(1)
+        );
+
+        assertEquals(message.getId(), response.getMessageId());
+        assertEquals((byte) 1, response.getScore());
+        assertTrue(chatFeedbackRepository.findByChatMessageId(message.getId()).isPresent());
+    }
+
+    @Test
+    @DisplayName("같은 메시지에 다시 피드백하면 기존 점수를 수정한다")
+    void updateFeedback_withExistingFeedback_updatesScore() {
+        chatService.updateFeedback(message.getId(), null, SESSION_KEY, feedbackRequest(1));
+
+        ChatFeedbackResponse response = chatService.updateFeedback(
+                message.getId(),
+                null,
+                SESSION_KEY,
+                feedbackRequest(-1)
+        );
+
+        assertEquals((byte) -1, response.getScore());
+        assertEquals(1, chatFeedbackRepository.findAll().size());
+    }
+
+    @Test
+    @DisplayName("로그인 사용자는 userId 소유 메시지에 피드백할 수 있다")
+    void updateFeedback_withUserId_createsFeedback() {
+        ChatFeedbackResponse response = chatService.updateFeedback(
+                userMessage.getId(),
+                user.getId(),
+                null,
+                feedbackRequest(1)
+        );
+
+        assertEquals(userMessage.getId(), response.getMessageId());
+        assertEquals((byte) 1, response.getScore());
+    }
+
+    @Test
+    @DisplayName("소유하지 않은 메시지에 피드백하면 404를 반환한다")
+    void updateFeedback_withWrongOwner_throwsNotFound() {
+        CustomException ex = assertThrows(CustomException.class,
+                () -> chatService.updateFeedback(message.getId(), null, "wrong-key", feedbackRequest(1)));
+
+        assertEquals(ErrorCode.CHAT_MESSAGE_NOT_FOUND, ex.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("0점 피드백은 거부한다")
+    void updateFeedback_withZeroScore_throwsBadRequest() {
+        CustomException ex = assertThrows(CustomException.class,
+                () -> chatService.updateFeedback(message.getId(), null, SESSION_KEY, feedbackRequest(0)));
+
+        assertEquals(ErrorCode.INVALID_FEEDBACK_SCORE, ex.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("세션 상세 조회 응답에 저장된 피드백 점수를 포함한다")
+    void getSessionDetail_withFeedback_includesFeedbackScore() {
+        chatService.updateFeedback(message.getId(), null, SESSION_KEY, feedbackRequest(-1));
+
+        ChatSessionDetailResponse detail = chatService.getSessionDetail(session.getId(), null, SESSION_KEY);
+
+        assertEquals((byte) -1, detail.getMessages().get(0).getFeedbackScore());
+    }
+
+    @Test
+    @DisplayName("세션 삭제 시 피드백을 먼저 삭제해 FK 오류가 발생하지 않는다")
+    void deleteSession_withFeedback_deletesFeedbackAndSession() {
+        chatService.updateFeedback(message.getId(), null, SESSION_KEY, feedbackRequest(1));
+
+        chatService.deleteSession(session.getId(), null, SESSION_KEY);
+
+        assertTrue(chatFeedbackRepository.findAll().isEmpty());
+        assertTrue(chatMessageRepository.findByChatSessionIdOrderByCreatedAtAsc(session.getId()).isEmpty());
+    }
+
+    private ChatFeedbackRequest feedbackRequest(int score) {
+        ChatFeedbackRequest request = new ChatFeedbackRequest();
+        ReflectionTestUtils.setField(request, "score", score);
+        return request;
+    }
+}

--- a/backend/src/test/java/com/documind/documind/domain/chat/ChatFeedbackTest.java
+++ b/backend/src/test/java/com/documind/documind/domain/chat/ChatFeedbackTest.java
@@ -150,6 +150,16 @@ class ChatFeedbackTest {
     }
 
     @Test
+    @DisplayName("관리자 대시보드용 좋아요와 싫어요 개수를 집계한다")
+    void countByScore_returnsFeedbackCounts() {
+        chatService.updateFeedback(message.getId(), null, SESSION_KEY, feedbackRequest(1));
+        chatService.updateFeedback(userMessage.getId(), user.getId(), null, feedbackRequest(-1));
+
+        assertEquals(1, chatFeedbackRepository.countByScore((byte) 1));
+        assertEquals(1, chatFeedbackRepository.countByScore((byte) -1));
+    }
+
+    @Test
     @DisplayName("세션 삭제 시 피드백을 먼저 삭제해 FK 오류가 발생하지 않는다")
     void deleteSession_withFeedback_deletesFeedbackAndSession() {
         chatService.updateFeedback(message.getId(), null, SESSION_KEY, feedbackRequest(1));

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -851,6 +851,7 @@ button:disabled {
 
 .feedback-bar {
   display: flex;
+  align-items: center;
   gap: 12px;
   width: min(820px, calc(100% - 58px));
   margin-left: 58px;
@@ -872,6 +873,15 @@ button:disabled {
   color: var(--action-blue);
   background: var(--action-blue-soft);
   border-color: rgba(0, 91, 172, 0.16);
+}
+
+.feedback-status {
+  color: var(--ink-muted);
+  font-size: 13px;
+}
+
+.feedback-status--error {
+  color: #b42318;
 }
 
 .chat-composer {

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -875,6 +875,20 @@ button:disabled {
   border-color: rgba(0, 91, 172, 0.16);
 }
 
+.icon-action--positive:hover:not(:disabled),
+.icon-action--positive.icon-action--selected {
+  color: var(--action-blue);
+  background: var(--action-blue-soft);
+  border-color: rgba(0, 91, 172, 0.16);
+}
+
+.icon-action--negative:hover:not(:disabled),
+.icon-action--negative.icon-action--selected {
+  color: #9f1f17;
+  background: #fff7f7;
+  border-color: #efc4bf;
+}
+
 .feedback-status {
   color: var(--ink-muted);
   font-size: 13px;
@@ -3010,6 +3024,82 @@ button:disabled {
   color: var(--ink);
   font-size: 34px;
   font-weight: 600;
+}
+
+.feedback-summary {
+  display: grid;
+  gap: 16px;
+  padding: 22px;
+  border: 1px solid var(--chat-border);
+  border-radius: 18px;
+  background: #ffffff;
+}
+
+.feedback-summary header,
+.feedback-summary__legend {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.feedback-summary header div {
+  display: grid;
+  gap: 6px;
+}
+
+.feedback-summary header span,
+.feedback-summary header p,
+.feedback-summary__legend {
+  margin: 0;
+  color: var(--chat-muted);
+  font-size: 13px;
+}
+
+.feedback-summary header strong {
+  color: var(--ink);
+  font-size: 28px;
+  font-weight: 600;
+}
+
+.feedback-summary__bar {
+  display: flex;
+  overflow: hidden;
+  height: 14px;
+  border-radius: 999px;
+  background: #f1f3f5;
+}
+
+.feedback-summary__bar-positive {
+  background: var(--action-blue);
+}
+
+.feedback-summary__bar-negative {
+  background: #e66a5f;
+}
+
+.feedback-summary__legend {
+  justify-content: flex-start;
+}
+
+.feedback-summary__legend span {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+}
+
+.feedback-summary__dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 999px;
+}
+
+.feedback-summary__dot--positive {
+  background: var(--action-blue);
+}
+
+.feedback-summary__dot--negative {
+  background: #e66a5f;
 }
 
 .admin-section {

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -711,6 +711,10 @@ button:disabled {
   white-space: pre-wrap;
 }
 
+.answer-card p strong {
+  font-weight: 800;
+}
+
 .typing-caret {
   display: inline-block;
   width: 8px;
@@ -3040,6 +3044,7 @@ button:disabled {
   display: flex;
   align-items: center;
   justify-content: space-between;
+  flex-wrap: wrap;
   gap: 16px;
 }
 

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -862,14 +862,27 @@ button:disabled {
 }
 
 .icon-action {
+  display: inline-grid;
+  place-items: center;
   min-width: 0;
   min-height: 40px;
-  padding: 10px 14px;
+  width: 40px;
+  height: 40px;
+  padding: 0;
   border-color: transparent;
   border-radius: var(--radius-pill);
   color: var(--ink-muted);
   background: transparent;
-  font-size: 14px;
+}
+
+.icon-action svg {
+  width: 20px;
+  height: 20px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 1.9;
+  stroke-linecap: round;
+  stroke-linejoin: round;
 }
 
 .icon-action:hover:not(:disabled),
@@ -2338,8 +2351,13 @@ button:disabled {
 
 .icon-action {
   min-height: 32px;
-  padding: 7px 10px;
-  font-size: 13px;
+  width: 32px;
+  height: 32px;
+}
+
+.icon-action svg {
+  width: 18px;
+  height: 18px;
 }
 
 @media (max-width: 833px) {

--- a/frontend/src/features/admin/AdminDashboardPage.jsx
+++ b/frontend/src/features/admin/AdminDashboardPage.jsx
@@ -3,6 +3,7 @@ import { Link, useNavigate } from 'react-router-dom'
 import { logout } from '../../services/authApi.js'
 import { createCategory, listCategories } from '../../services/categoryApi.js'
 import { deleteDocument, listDocumentChunks, listDocuments, uploadDocument } from '../../services/documentApi.js'
+import { getFeedbackStats } from '../../services/feedbackStatsApi.js'
 import { getPromptConfig, updatePromptConfig } from '../../services/promptApi.js'
 import inqLogoUrl from '../../images/inq-logo.png'
 import inqSymbolUrl from '../../images/inq-symbol.png'
@@ -49,11 +50,23 @@ function formatDuration(durationMs) {
   return `${minutes}분 ${seconds}초`
 }
 
+function formatPercent(rate) {
+  const percent = Number(rate) * 100
+  if (!Number.isFinite(percent)) return '0%'
+  return `${Math.round(percent)}%`
+}
+
 function AdminDashboardPage() {
   const navigate = useNavigate()
   const fileInputRef = useRef(null)
   const [documents, setDocuments] = useState([])
   const [categories, setCategories] = useState([])
+  const [feedbackStats, setFeedbackStats] = useState({
+    totalCount: 0,
+    positiveCount: 0,
+    negativeCount: 0,
+    positiveRate: 0,
+  })
   const [selectedCategory, setSelectedCategory] = useState('전체')
   const [selectedFile, setSelectedFile] = useState(null)
   const [selectedUploadCategoryId, setSelectedUploadCategoryId] = useState('')
@@ -93,12 +106,19 @@ function AdminDashboardPage() {
     setErrorMessage('')
 
     try {
-      const [nextDocuments, nextCategories] = await Promise.all([
+      const [nextDocuments, nextCategories, nextFeedbackStats] = await Promise.all([
         listDocuments(),
         listCategories(),
+        getFeedbackStats(),
       ])
       setDocuments(Array.isArray(nextDocuments) ? nextDocuments : [])
       setCategories(Array.isArray(nextCategories) ? nextCategories : [])
+      setFeedbackStats(nextFeedbackStats ?? {
+        totalCount: 0,
+        positiveCount: 0,
+        negativeCount: 0,
+        positiveRate: 0,
+      })
     } catch (error) {
       setErrorMessage(error.message)
     } finally {
@@ -377,6 +397,18 @@ function AdminDashboardPage() {
               <article>
                 <span>카테고리</span>
                 <strong>{categories.length}</strong>
+              </article>
+              <article>
+                <span>좋아요</span>
+                <strong>{feedbackStats.positiveCount}</strong>
+              </article>
+              <article>
+                <span>싫어요</span>
+                <strong>{feedbackStats.negativeCount}</strong>
+              </article>
+              <article>
+                <span>긍정 비율</span>
+                <strong>{formatPercent(feedbackStats.positiveRate)}</strong>
               </article>
             </section>
           </section>

--- a/frontend/src/features/admin/AdminDashboardPage.jsx
+++ b/frontend/src/features/admin/AdminDashboardPage.jsx
@@ -411,6 +411,40 @@ function AdminDashboardPage() {
                 <strong>{formatPercent(feedbackStats.positiveRate)}</strong>
               </article>
             </section>
+
+            <section className="feedback-summary" aria-label="답변 피드백 요약">
+              <header>
+                <div>
+                  <span>답변 피드백</span>
+                  <strong>{formatPercent(feedbackStats.positiveRate)} 긍정</strong>
+                </div>
+                <p>총 {feedbackStats.totalCount}건</p>
+              </header>
+              <div
+                className="feedback-summary__bar"
+                role="img"
+                aria-label={`좋아요 ${feedbackStats.positiveCount}건, 싫어요 ${feedbackStats.negativeCount}건`}
+              >
+                <span
+                  className="feedback-summary__bar-positive"
+                  style={{ width: feedbackStats.totalCount > 0 ? formatPercent(feedbackStats.positiveRate) : '0%' }}
+                />
+                <span
+                  className="feedback-summary__bar-negative"
+                  style={{ width: feedbackStats.totalCount > 0 ? formatPercent(1 - feedbackStats.positiveRate) : '0%' }}
+                />
+              </div>
+              <div className="feedback-summary__legend">
+                <span>
+                  <i className="feedback-summary__dot feedback-summary__dot--positive" aria-hidden="true" />
+                  좋아요 {feedbackStats.positiveCount}
+                </span>
+                <span>
+                  <i className="feedback-summary__dot feedback-summary__dot--negative" aria-hidden="true" />
+                  싫어요 {feedbackStats.negativeCount}
+                </span>
+              </div>
+            </section>
           </section>
         )}
 

--- a/frontend/src/features/admin/AdminDashboardPage.jsx
+++ b/frontend/src/features/admin/AdminDashboardPage.jsx
@@ -398,18 +398,6 @@ function AdminDashboardPage() {
                 <span>카테고리</span>
                 <strong>{categories.length}</strong>
               </article>
-              <article>
-                <span>좋아요</span>
-                <strong>{feedbackStats.positiveCount}</strong>
-              </article>
-              <article>
-                <span>싫어요</span>
-                <strong>{feedbackStats.negativeCount}</strong>
-              </article>
-              <article>
-                <span>긍정 비율</span>
-                <strong>{formatPercent(feedbackStats.positiveRate)}</strong>
-              </article>
             </section>
 
             <section className="feedback-summary" aria-label="답변 피드백 요약">

--- a/frontend/src/features/chat/ChatPage.jsx
+++ b/frontend/src/features/chat/ChatPage.jsx
@@ -46,6 +46,26 @@ function DeleteIcon() {
   )
 }
 
+function ThumbUpIcon() {
+  return (
+    <svg aria-hidden="true" viewBox="0 0 24 24" focusable="false">
+      <path d="M7 10.5v9" />
+      <path d="M3.8 10.5h3.2v9H3.8a1.3 1.3 0 0 1-1.3-1.3v-6.4a1.3 1.3 0 0 1 1.3-1.3Z" />
+      <path d="M7 10.5 11.7 4a1.7 1.7 0 0 1 3 1.4l-.9 3.2h4.6a2 2 0 0 1 1.9 2.5l-1.6 6a3.3 3.3 0 0 1-3.2 2.4H7" />
+    </svg>
+  )
+}
+
+function ThumbDownIcon() {
+  return (
+    <svg aria-hidden="true" viewBox="0 0 24 24" focusable="false">
+      <path d="M7 13.5v-9" />
+      <path d="M3.8 13.5h3.2v-9H3.8a1.3 1.3 0 0 0-1.3 1.3v6.4a1.3 1.3 0 0 0 1.3 1.3Z" />
+      <path d="M7 13.5 11.7 20a1.7 1.7 0 0 0 3-1.4l-.9-3.2h4.6a2 2 0 0 0 1.9-2.5l-1.6-6a3.3 3.3 0 0 0-3.2-2.4H7" />
+    </svg>
+  )
+}
+
 function SettingsIcon() {
   return (
     <svg aria-hidden="true" viewBox="0 0 24 24" focusable="false">
@@ -822,7 +842,7 @@ function ChatPage() {
                     aria-label="좋아요"
                     title="좋아요"
                   >
-                    좋아요
+                    <ThumbUpIcon />
                   </button>
                   <button
                     type="button"
@@ -837,7 +857,7 @@ function ChatPage() {
                     aria-label="싫어요"
                     title="싫어요"
                   >
-                    싫어요
+                    <ThumbDownIcon />
                   </button>
                   {(isFeedbackSaving || feedbackError) && (
                     <span className={feedbackError ? 'feedback-status feedback-status--error' : 'feedback-status'}>

--- a/frontend/src/features/chat/ChatPage.jsx
+++ b/frontend/src/features/chat/ChatPage.jsx
@@ -212,6 +212,28 @@ function scoreFromFeedback(feedback) {
   return feedback === 'positive' ? 1 : -1
 }
 
+function renderMarkdownInline(text) {
+  return String(text)
+    .split(/(\*\*[^*]+\*\*)/g)
+    .map((part, index) => {
+      if (part.startsWith('**') && part.endsWith('**')) {
+        return <strong key={`${part}-${index}`}>{part.slice(2, -2)}</strong>
+      }
+      return part
+    })
+}
+
+function renderAnswerText(text) {
+  return String(text)
+    .split('\n')
+    .map((line, index, lines) => (
+      <span key={`${line}-${index}`}>
+        {renderMarkdownInline(line)}
+        {index < lines.length - 1 && <br />}
+      </span>
+    ))
+}
+
 function ChatPage() {
   const eventSourceRef = useRef(null)
   const transcriptRef = useRef(null)
@@ -719,7 +741,7 @@ function ChatPage() {
                     </div>
                     {answer ? (
                       <p>
-                        {answer}
+                        {renderAnswerText(answer)}
                         {isStreaming && <span className="typing-caret" aria-hidden="true" />}
                       </p>
                     ) : (

--- a/frontend/src/features/chat/ChatPage.jsx
+++ b/frontend/src/features/chat/ChatPage.jsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { env } from '../../config/env.js'
 import { logout } from '../../services/authApi.js'
+import { updateChatFeedback } from '../../services/chatFeedbackApi.js'
 import { openChatStream } from '../../services/chatStream.js'
 import { getAuthProfile, hasAccessToken } from '../../services/authStorage.js'
 import { deleteChatSession, getChatSession, listChatSessions } from '../../services/chatHistoryApi.js'
@@ -201,6 +202,16 @@ function getIdentifierLabel(role) {
   return '학번'
 }
 
+function feedbackFromScore(score) {
+  if (Number(score) === 1) return 'positive'
+  if (Number(score) === -1) return 'negative'
+  return null
+}
+
+function scoreFromFeedback(feedback) {
+  return feedback === 'positive' ? 1 : -1
+}
+
 function ChatPage() {
   const eventSourceRef = useRef(null)
   const transcriptRef = useRef(null)
@@ -214,11 +225,14 @@ function ChatPage() {
   )
   const [question, setQuestion] = useState('')
   const [submittedQuestion, setSubmittedQuestion] = useState('')
+  const [messageId, setMessageId] = useState(null)
   const [answer, setAnswer] = useState('')
   const [sources, setSources] = useState([])
   const [isStreaming, setIsStreaming] = useState(false)
   const [errorMessage, setErrorMessage] = useState('')
   const [feedback, setFeedback] = useState(null)
+  const [isFeedbackSaving, setIsFeedbackSaving] = useState(false)
+  const [feedbackError, setFeedbackError] = useState('')
   const [historySessions, setHistorySessions] = useState([])
   const [isHistoryLoading, setIsHistoryLoading] = useState(false)
   const [historyError, setHistoryError] = useState('')
@@ -292,6 +306,7 @@ function ChatPage() {
     const shouldUseAuth = refreshLoginState()
     setErrorMessage('')
     setFeedback(null)
+    setFeedbackError('')
     setActiveSourceIndex(null)
 
     try {
@@ -304,8 +319,10 @@ function ChatPage() {
       if (!lastMessage) return
 
       setSubmittedQuestion(lastMessage.question ?? detail.title ?? '')
+      setMessageId(lastMessage.messageId ?? null)
       setAnswer(lastMessage.answer ?? '')
       setSources(Array.isArray(lastMessage.sources) ? lastMessage.sources : [])
+      setFeedback(feedbackFromScore(lastMessage.feedbackScore))
     } catch (error) {
       setHistoryError(error.message)
     }
@@ -400,11 +417,13 @@ function ChatPage() {
     const sessionKey = getSessionKey()
     const shouldUseAuth = refreshLoginState()
     setSubmittedQuestion(trimmedQuestion)
+    setMessageId(null)
     setQuestion('')
     setAnswer('')
     setSources([])
     setErrorMessage('')
     setFeedback(null)
+    setFeedbackError('')
     setActiveSourceIndex(null)
     setIsStreaming(true)
 
@@ -414,10 +433,11 @@ function ChatPage() {
       sessionKey,
       topK: env.defaultTopK,
       onToken: (token) => setAnswer((prev) => prev + token),
-      onDone: ({ answer: completedAnswer, sources: nextSources }) => {
+      onDone: ({ answer: completedAnswer, messageId: completedMessageId, sources: nextSources }) => {
         if (completedAnswer) {
           setAnswer(completedAnswer)
         }
+        setMessageId(completedMessageId ?? null)
         setSources(nextSources)
         setIsStreaming(false)
         loadHistory()
@@ -434,8 +454,24 @@ function ChatPage() {
     setIsStreaming(false)
   }
 
-  const handleFeedback = (nextFeedback) => {
-    setFeedback((prevFeedback) => (prevFeedback === nextFeedback ? null : nextFeedback))
+  const handleFeedback = async (nextFeedback) => {
+    if (!messageId || isFeedbackSaving || feedback === nextFeedback) return
+
+    const shouldUseAuth = refreshLoginState()
+    setFeedbackError('')
+    setIsFeedbackSaving(true)
+
+    try {
+      const response = await updateChatFeedback(messageId, scoreFromFeedback(nextFeedback), {
+        auth: shouldUseAuth,
+        sessionKey: getSessionKey(),
+      })
+      setFeedback(feedbackFromScore(response?.score) ?? nextFeedback)
+    } catch (error) {
+      setFeedbackError(error.message)
+    } finally {
+      setIsFeedbackSaving(false)
+    }
   }
 
   const resizeComposer = (target) => {
@@ -457,7 +493,7 @@ function ChatPage() {
 
   const canSend = question.trim().length > 0 && !isStreaming
   const hasConversation = submittedQuestion || answer || errorMessage
-  const canGiveFeedback = Boolean(answer) && !isStreaming && !errorMessage
+  const canGiveFeedback = Boolean(answer) && Boolean(messageId) && !isStreaming && !errorMessage && !isFeedbackSaving
   const sourceGroups = groupSourcesByDocument(sources)
   const isAdmin = authProfile?.role === 'ADMIN'
 
@@ -465,10 +501,12 @@ function ChatPage() {
     eventSourceRef.current?.close()
     setQuestion('')
     setSubmittedQuestion('')
+    setMessageId(null)
     setAnswer('')
     setSources([])
     setErrorMessage('')
     setFeedback(null)
+    setFeedbackError('')
     setActiveSourceIndex(null)
     setIsStreaming(false)
     setIsProfileOpen(false)
@@ -486,9 +524,11 @@ function ChatPage() {
       setHistorySessions([])
       setHistoryError('')
       setSubmittedQuestion('')
+      setMessageId(null)
       setAnswer('')
       setSources([])
       setFeedback(null)
+      setFeedbackError('')
       setErrorMessage('')
       setActiveSourceIndex(null)
       setIsStreaming(false)
@@ -752,6 +792,7 @@ function ChatPage() {
                     className={feedback === 'positive' ? 'icon-action icon-action--selected' : 'icon-action'}
                     onClick={() => handleFeedback('positive')}
                     disabled={!canGiveFeedback}
+                    aria-pressed={feedback === 'positive'}
                     aria-label="좋아요"
                     title="좋아요"
                   >
@@ -762,11 +803,17 @@ function ChatPage() {
                     className={feedback === 'negative' ? 'icon-action icon-action--selected' : 'icon-action'}
                     onClick={() => handleFeedback('negative')}
                     disabled={!canGiveFeedback}
+                    aria-pressed={feedback === 'negative'}
                     aria-label="싫어요"
                     title="싫어요"
                   >
                     싫어요
                   </button>
+                  {(isFeedbackSaving || feedbackError) && (
+                    <span className={feedbackError ? 'feedback-status feedback-status--error' : 'feedback-status'}>
+                      {feedbackError || '저장 중'}
+                    </span>
+                  )}
                 </div>
               </>
             ) : (

--- a/frontend/src/features/chat/ChatPage.jsx
+++ b/frontend/src/features/chat/ChatPage.jsx
@@ -789,7 +789,11 @@ function ChatPage() {
                 <div className="feedback-bar" aria-label="답변 피드백">
                   <button
                     type="button"
-                    className={feedback === 'positive' ? 'icon-action icon-action--selected' : 'icon-action'}
+                    className={
+                      feedback === 'positive'
+                        ? 'icon-action icon-action--positive icon-action--selected'
+                        : 'icon-action icon-action--positive'
+                    }
                     onClick={() => handleFeedback('positive')}
                     disabled={!canGiveFeedback}
                     aria-pressed={feedback === 'positive'}
@@ -800,7 +804,11 @@ function ChatPage() {
                   </button>
                   <button
                     type="button"
-                    className={feedback === 'negative' ? 'icon-action icon-action--selected' : 'icon-action'}
+                    className={
+                      feedback === 'negative'
+                        ? 'icon-action icon-action--negative icon-action--selected'
+                        : 'icon-action icon-action--negative'
+                    }
                     onClick={() => handleFeedback('negative')}
                     disabled={!canGiveFeedback}
                     aria-pressed={feedback === 'negative'}

--- a/frontend/src/services/chatFeedbackApi.js
+++ b/frontend/src/services/chatFeedbackApi.js
@@ -1,0 +1,14 @@
+import { apiRequest } from './apiClient.js'
+
+function createSessionHeaders(sessionKey) {
+  return sessionKey ? { 'X-Session-Key': sessionKey } : {}
+}
+
+export async function updateChatFeedback(messageId, score, { sessionKey, auth = false } = {}) {
+  return apiRequest(`/chat/messages/${messageId}/feedback`, {
+    method: 'PUT',
+    auth,
+    headers: createSessionHeaders(sessionKey),
+    body: { score },
+  })
+}

--- a/frontend/src/services/chatStream.js
+++ b/frontend/src/services/chatStream.js
@@ -64,6 +64,7 @@ export function openChatStream({ question, sessionKey, topK, auth = false, onTok
           } else if (data.done) {
             onDone({
               answer: data.answer,
+              messageId: data.messageId,
               sources: data.sources ?? [],
             })
             closeStream()

--- a/frontend/src/services/feedbackStatsApi.js
+++ b/frontend/src/services/feedbackStatsApi.js
@@ -1,0 +1,8 @@
+import { apiRequest } from './apiClient.js'
+
+export async function getFeedbackStats() {
+  return apiRequest('/admin/feedback-stats', {
+    method: 'GET',
+    auth: true,
+  })
+}


### PR DESCRIPTION
## 작업 내용

- 답변 메시지에 대한 좋아요/싫어요 피드백 등록 및 수정 API를 추가했습니다.
- 로그인 사용자는 JWT userId, 비로그인 사용자는 X-Session-Key로 메시지 소유권을 검증합니다.
- SSE 스트리밍 완료 이벤트에 messageId를 포함해 답변 직후 피드백 저장이 가능하도록 했습니다.
- 채팅 이력 상세 응답에 feedbackScore를 포함해 기존 선택 상태를 복원합니다.
- 관리자 대시보드에 좋아요/싫어요 집계와 긍정 비율 시각화를 추가했습니다.
- 피드백 버튼을 엄지 위/아래 아이콘으로 변경하고, 좋아요/싫어요 선택 색상을 분리했습니다.
- 답변 본문의 **굵게** Markdown 표현을 실제 굵은 글씨로 표시하도록 보정했습니다.

## 검증

- [x] `cd backend && ./gradlew test --tests com.documind.documind.domain.chat.ChatFeedbackTest`
- [x] `cd backend && ./gradlew test`
- [x] `cd frontend && npm run lint`
- [x] `cd frontend && npm run build`
- [x] `git diff --check`

## 이슈

Closes #17