### PR TITLE
chore(review): Codex 모듈별 리뷰 지시어 정리 (#18)

### DIFF
--- a/ai-server/AGENTS.md
+++ b/ai-server/AGENTS.md
@@ -1,5 +1,8 @@
 # AI Server Review Guide
 
+> 이 파일은 GitHub PR에서 `@codex review`가 ai-server 변경을 검토할 때 참고하도록 저장소에 커밋된 공개 리뷰 체크리스트다.
+> 비밀값, 로컬 운영 정보, 현재 진행률은 넣지 않는다. 실제 FastAPI/RAG 구조와 맞지 않는 항목은 잘못된 리뷰를 유도하므로 바로 수정하거나 제거한다.
+
 ## Review guidelines
 
 - 리뷰 코멘트는 한국어로 작성한다.
@@ -11,7 +14,6 @@
 - 청킹 로직이 한글 문서의 제목, 표, 목록, 페이지 경계를 과도하게 깨뜨리지 않는지 확인한다.
 - ChromaDB metadata에는 문서 ID, 원본 파일명, 헤더 경로처럼 출처 표시와 삭제에 필요한 값이 유지되는지 확인한다.
 - Ollama 모델명, 임베딩 모델명, Chroma host 같은 운영 설정은 환경변수로 분리되는지 확인한다.
-- Langfuse 추적은 키가 없을 때 비활성화되어도 핵심 질의응답 흐름을 깨지 않는지 확인한다.
 
 ## Clean code checklist
 

--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -1,5 +1,8 @@
 # Backend Review Guide
 
+> 이 파일은 GitHub PR에서 `@codex review`가 backend 변경을 검토할 때 참고하도록 저장소에 커밋된 공개 리뷰 체크리스트다.
+> 비밀값, 로컬 운영 정보, 현재 진행률은 넣지 않는다. 실제 Spring Boot 구조와 맞지 않는 항목은 잘못된 리뷰를 유도하므로 바로 수정하거나 제거한다.
+
 ## Review guidelines
 
 - 리뷰 코멘트는 한국어로 작성한다.

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -1,5 +1,8 @@
 # Frontend Review Guide
 
+> 이 파일은 GitHub PR에서 `@codex review`가 frontend 변경을 검토할 때 참고하도록 저장소에 커밋된 공개 리뷰 체크리스트다.
+> 비밀값, 로컬 운영 정보, 현재 진행률은 넣지 않는다. 실제 React/Vite 구조와 맞지 않는 항목은 잘못된 리뷰를 유도하므로 바로 수정하거나 제거한다.
+
 ## Review guidelines
 
 - 리뷰 코멘트는 한국어로 작성한다.


### PR DESCRIPTION
## 배경

GitHub PR에서 `@codex review`가 backend, frontend, ai-server 변경을 볼 때 각 기술 스택별 위험을 더 정확히 보도록 모듈별 `AGENTS.md`의 목적을 명확히 합니다.

## 변경 내용

- `backend/AGENTS.md`, `frontend/AGENTS.md`, `ai-server/AGENTS.md` 상단에 공개 리뷰 체크리스트 목적을 명시했습니다.
- 모듈별 `AGENTS.md`에는 비밀값, 로컬 운영 정보, 현재 진행률을 넣지 않는다는 원칙을 추가했습니다.
- `ai-server/AGENTS.md`에서 현재 구조와 맞지 않는 Langfuse 리뷰 항목을 제거했습니다.

## 리뷰 포인트

- 모듈별 리뷰 체크리스트가 실제 backend/frontend/ai-server 구조와 맞는지 확인 부탁드립니다.
- 공개 저장소에 남겨도 되는 내용만 포함되어 있는지 봐주세요.
- Codex 리뷰가 불필요한 지적을 만들 만한 오래된 항목이 남아 있는지 봐주세요.

## 변경 파일

- `backend/AGENTS.md`
- `frontend/AGENTS.md`
- `ai-server/AGENTS.md`

## 확인한 내용

`git diff --check`로 공백 오류가 없는 것을 확인했습니다.

## 이슈

Related #18