### PR TITLE
[AI/RAG] RAG data contract trace preview 추가

### DIFF
--- a/ai-server/check_rag_contracts.py
+++ b/ai-server/check_rag_contracts.py
@@ -1,0 +1,137 @@
+"""Smoke check for the RAG data contract skeleton."""
+
+from __future__ import annotations
+
+import json
+
+from rag_contract_builders import build_parsed_block, build_source_block, header_path_from_metadata
+from rag_contracts import (
+    Candidate,
+    PageSpan,
+    RetrievalChunk,
+    SectionNode,
+    SelectedContext,
+    SelectedContextItem,
+    SourceCitation,
+    TableFact,
+    TextSpan,
+    contract_to_dict,
+)
+
+
+def build_contract_sample() -> dict:
+    """Build a minimal end-to-end contract sample without touching runtime code."""
+    metadata = {
+        "page_start": "1",
+        "page_end": "2",
+        "Header 1": "Document",
+        "Header 2": "Table Section",
+        "block_type": "table",
+        "bbox": [0, 0, 100, 50],
+    }
+    parsed_block = build_parsed_block(
+        document_id="sample",
+        document_format="pdf",
+        text="| Item | Value |\n| Item A | 10 |",
+        block_index=1,
+        metadata=metadata,
+        parser_confidence=0.95,
+    )
+    section = SectionNode(
+        section_id="doc-sample:section-table",
+        document_id="sample",
+        title="Table Section",
+        level=2,
+        path=header_path_from_metadata(metadata),
+        page_span=PageSpan(start=1, end=1),
+        block_ids=(parsed_block.block_id,),
+    )
+    source_block = build_source_block(
+        parsed_block,
+        section_id=section.section_id,
+    )
+    retrieval_chunk = RetrievalChunk(
+        retrieval_chunk_id="doc-sample:retrieval-001",
+        document_id="sample",
+        retrieval_text="Table Section Item A Value 10",
+        source_block_ids=(source_block.source_block_id,),
+        section_ids=(section.section_id,),
+        strategy="section_table",
+        chunk_role="raw",
+    )
+    table_fact = TableFact(
+        fact_id="doc-sample:fact-001",
+        fact_type="row_cell",
+        table_id="doc-sample:table-001",
+        row_subject="Item A",
+        column_path=("Value",),
+        header_path=("Table Section",),
+        value="10",
+        source_block_id=source_block.source_block_id,
+        confidence=0.95,
+    )
+    candidate = Candidate(
+        candidate_id="doc-sample:candidate-001",
+        retrieval_chunk_id=retrieval_chunk.retrieval_chunk_id,
+        scores={"vector": 0.91, "bm25": 12.5},
+        methods=("vector", "bm25", "table_fact"),
+        fact_ids=(table_fact.fact_id,),
+        source_block_ids=(source_block.source_block_id,),
+        diagnostics={"failure_type_guard": "table_relation_loss"},
+    )
+    citation = SourceCitation(
+        citation_id="doc-sample:citation-001",
+        document_id="sample",
+        source="sample.pdf",
+        page_label="PDF page 1",
+        source_block_id=source_block.source_block_id,
+        excerpt="Item A Value 10",
+        span=TextSpan(start=0, end=18),
+        confidence=0.95,
+    )
+    selected_context = SelectedContext(
+        context_id="doc-sample:context-001",
+        items=(
+            SelectedContextItem(
+                candidate_id=candidate.candidate_id,
+                prompt_text="Item A has value 10.",
+                fact_ids=(table_fact.fact_id,),
+                source_block_ids=(source_block.source_block_id,),
+            ),
+        ),
+        prompt_text="Item A has value 10.",
+        supporting_fact_ids=(table_fact.fact_id,),
+        citation_ids=(citation.citation_id,),
+    )
+
+    return {
+        "parsed_block": contract_to_dict(parsed_block),
+        "section": contract_to_dict(section),
+        "source_block": contract_to_dict(source_block),
+        "retrieval_chunk": contract_to_dict(retrieval_chunk),
+        "table_fact": contract_to_dict(table_fact),
+        "candidate": contract_to_dict(candidate),
+        "citation": contract_to_dict(citation),
+        "selected_context": contract_to_dict(selected_context),
+    }
+
+
+def main() -> None:
+    """Verify that the skeleton contracts can produce stable JSON."""
+    sample = build_contract_sample()
+    encoded = json.dumps(sample, ensure_ascii=False, sort_keys=True)
+    decoded = json.loads(encoded)
+
+    assert decoded["parsed_block"]["block_id"] == "doc-sample:block-000001"
+    assert decoded["parsed_block"]["metadata"]["block_type"] == "table"
+    assert decoded["section"]["path"] == ["Document", "Table Section"]
+    assert decoded["source_block"]["raw_text"] == sample["parsed_block"]["text"]
+    assert decoded["source_block"]["page_span"] == {"start": 1, "end": 2}
+    assert decoded["source_block"]["bbox_span"] == [[0.0, 0.0, 100.0, 50.0]]
+    assert decoded["table_fact"]["source_block_id"] == decoded["source_block"]["source_block_id"]
+    assert decoded["selected_context"]["citation_ids"] == [decoded["citation"]["citation_id"]]
+    print("rag_contracts smoke ok")
+
+
+if __name__ == "__main__":
+    main()

--- a/ai-server/main.py
+++ b/ai-server/main.py
@@ -19,6 +19,8 @@ import time
 from dataclasses import dataclass
 from threading import Lock
 
+from rag_contract_builders import build_parsed_block, build_source_block
+
 try:
     from kiwipiepy import Kiwi
 except ImportError:
@@ -3565,6 +3567,81 @@ def _append_trace_method(entry: dict, method: str) -> None:
         methods.append(method)
 
 
+def _document_format_from_source(source: object) -> str:
+    """trace 후보의 source 파일명에서 문서 형식을 보수적으로 추정한다."""
+    filename = str(source or "").strip()
+    if "." not in filename:
+        return "unknown"
+    document_format = filename.rsplit(".", 1)[-1].lower()
+    return document_format or "unknown"
+
+
+def _metadata_int(value: object) -> int | None:
+    """metadata 값이 정수로 해석될 때만 int로 반환한다."""
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _contract_block_index(chunk_id: str, meta: dict) -> int:
+    """contract preview용 block index를 기존 chunk metadata에서 복원한다."""
+    chunk_index = _metadata_int(meta.get("chunk_index"))
+    parent_chunk_index = _metadata_int(meta.get("parent_chunk_index"))
+    fact_index = _metadata_int(meta.get("fact_index"))
+    base_index = chunk_index
+    if base_index is None:
+        base_index = parent_chunk_index
+    if base_index is None:
+        base_index = _parse_chunk_index(chunk_id)
+    if base_index is None:
+        base_index = 0
+    if meta.get("chunk_role") == "table_fact" and fact_index is not None:
+        return base_index * 1000 + fact_index
+    return base_index
+
+
+def _trace_block_type(doc: str, meta: dict) -> str:
+    """trace 후보를 ParsedBlock preview에서 볼 block type으로 분류한다."""
+    metadata_block_type = str(meta.get("block_type") or "").strip()
+    if metadata_block_type:
+        return metadata_block_type
+    if meta.get("chunk_role") == "table_fact":
+        return "table_fact"
+    if _contains_table_block_near_start(doc, max_lines=20):
+        return "table"
+    return "text"
+
+
+def _contract_trace_preview(chunk_id: str, doc: str, meta: dict, preview_chars: int = 240) -> dict:
+    """현재 trace 후보를 ParsedBlock/SourceBlock 진단 preview로 변환한다."""
+    meta = meta or {}
+    try:
+        parsed_block = build_parsed_block(
+            document_id=meta.get("document_id", ""),
+            document_format=_document_format_from_source(meta.get("source")),
+            text=doc,
+            block_index=_contract_block_index(str(chunk_id), meta),
+            metadata=meta,
+            block_type=_trace_block_type(doc, meta),
+        )
+        source_block = build_source_block(parsed_block)
+        page_span = source_block.page_span
+        return {
+            "parsed_block_id": parsed_block.block_id,
+            "source_block_id": source_block.source_block_id,
+            "page_start": page_span.start if page_span else None,
+            "page_end": page_span.end if page_span else None,
+            "block_type": parsed_block.block_type,
+            "raw_text_preview": _preview_text(source_block.raw_text, preview_chars),
+        }
+    except Exception:
+        logger.exception("[rag_contract_preview] failed chunk_id=%s", chunk_id)
+        return {"error": "contract_preview_failed"}
+
+
 def _candidate_location_summary(chunk_id: str, doc: str, meta: dict, preview_chars: int = 360) -> dict:
     """trace 후보의 문서 위치와 본문 미리보기를 만든다."""
     meta = meta or {}
@@ -3580,6 +3657,7 @@ def _candidate_location_summary(chunk_id: str, doc: str, meta: dict, preview_cha
         "chunk_index": meta.get("chunk_index", _parse_chunk_index(str(chunk_id))),
         "header_path": _format_header_path(meta),
         "content_preview": _preview_text(doc, preview_chars),
+        "contract_preview": _contract_trace_preview(str(chunk_id), doc, meta),
     }
 
 

--- a/ai-server/rag_contract_builders.py
+++ b/ai-server/rag_contract_builders.py
@@ -1,0 +1,151 @@
+"""Small builders that adapt current chunk data into RAG contracts.
+
+The functions in this module are deliberately side-effect free.  They do not
+write to ChromaDB and they do not change the existing query pipeline.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from rag_contracts import BBox, JsonValue, PageSpan, ParsedBlock, SourceBlock
+
+
+def build_parsed_block(
+    *,
+    document_id: str | int,
+    document_format: str,
+    text: str,
+    block_index: int,
+    metadata: Mapping[str, Any] | None = None,
+    block_type: str | None = None,
+    parser_confidence: float | None = None,
+) -> ParsedBlock:
+    """Create a ParsedBlock from current parser/chunk text and metadata."""
+    safe_metadata = sanitize_metadata(metadata or {})
+    page_span = page_span_from_metadata(safe_metadata)
+    page = page_span.start if page_span else _coerce_int(safe_metadata.get("page"))
+    resolved_block_type = block_type or str(safe_metadata.get("block_type") or "text")
+
+    return ParsedBlock(
+        block_id=_contract_id(document_id, "block", block_index),
+        document_id=str(document_id),
+        document_format=document_format,
+        block_type=resolved_block_type,
+        text=text,
+        page=page,
+        bbox=_bbox_from_metadata(safe_metadata),
+        reading_order=block_index,
+        parser_confidence=parser_confidence,
+        metadata=safe_metadata,
+    )
+
+
+def build_source_block(
+    parsed_block: ParsedBlock,
+    *,
+    source_index: int | None = None,
+    section_id: str | None = None,
+) -> SourceBlock:
+    """Create an immutable SourceBlock from one ParsedBlock."""
+    page_span = page_span_from_metadata(parsed_block.metadata)
+    if page_span is None and parsed_block.page is not None:
+        page_span = PageSpan(parsed_block.page, parsed_block.page)
+    bbox_span = (parsed_block.bbox,) if parsed_block.bbox is not None else ()
+    index = parsed_block.reading_order if source_index is None else source_index
+
+    return SourceBlock(
+        source_block_id=_contract_id(parsed_block.document_id, "source", index or 0),
+        document_id=parsed_block.document_id,
+        raw_text=parsed_block.text,
+        page_span=page_span,
+        block_ids=(parsed_block.block_id,),
+        bbox_span=bbox_span,
+        section_id=section_id,
+    )
+
+
+def page_span_from_metadata(metadata: Mapping[str, Any]) -> PageSpan | None:
+    """Read page_start/page_end/page metadata into a PageSpan."""
+    page_start = _coerce_int(metadata.get("page_start"))
+    page_end = _coerce_int(metadata.get("page_end"))
+    page = _coerce_int(metadata.get("page"))
+
+    start = page_start if page_start is not None else page
+    end = page_end if page_end is not None else start
+    if start is None:
+        return None
+    return PageSpan(start=start, end=end)
+
+
+def header_path_from_metadata(metadata: Mapping[str, Any]) -> tuple[str, ...]:
+    """Return Header 1..6 metadata as an ordered path."""
+    path: list[str] = []
+    for level in range(1, 7):
+        value = str(metadata.get(f"Header {level}") or "").strip()
+        if value:
+            path.append(value)
+    return tuple(path)
+
+
+def sanitize_metadata(metadata: Mapping[str, Any]) -> dict[str, JsonValue]:
+    """Keep only JSON-safe metadata values for contract serialization."""
+    safe: dict[str, JsonValue] = {}
+    for key, value in metadata.items():
+        safe_value = _to_safe_json_value(value)
+        if safe_value is not _UNSUPPORTED:
+            safe[str(key)] = safe_value
+    return safe
+
+
+def _contract_id(document_id: str | int, kind: str, index: int) -> str:
+    return f"doc-{document_id}:{kind}-{index:06d}"
+
+
+def _bbox_from_metadata(metadata: Mapping[str, Any]) -> BBox | None:
+    bbox = metadata.get("bbox")
+    if not isinstance(bbox, (list, tuple)) or len(bbox) != 4:
+        return None
+    try:
+        return tuple(float(value) for value in bbox)  # type: ignore[return-value]
+    except (TypeError, ValueError):
+        return None
+
+
+def _coerce_int(value: Any) -> int | None:
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+class _Unsupported:
+    pass
+
+
+_UNSUPPORTED = _Unsupported()
+
+
+def _to_safe_json_value(value: Any) -> JsonValue | _Unsupported:
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, (list, tuple)):
+        items: list[JsonValue] = []
+        for item in value:
+            safe_item = _to_safe_json_value(item)
+            if safe_item is _UNSUPPORTED:
+                return _UNSUPPORTED
+            items.append(safe_item)
+        return items
+    if isinstance(value, Mapping):
+        safe_dict: dict[str, JsonValue] = {}
+        for key, item in value.items():
+            safe_item = _to_safe_json_value(item)
+            if safe_item is _UNSUPPORTED:
+                return _UNSUPPORTED
+            safe_dict[str(key)] = safe_item
+        return safe_dict
+    return _UNSUPPORTED

--- a/ai-server/rag_contracts.py
+++ b/ai-server/rag_contracts.py
@@ -1,0 +1,179 @@
+"""Typed RAG data contracts for the next structure-preserving pipeline.
+
+This module is intentionally not wired into ``main.py`` yet.  It defines the
+small, JSON-serializable contracts that future parser, retrieval, prompt, and
+source-citation code can share without overloading LangChain ``Document``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field, fields, is_dataclass
+from typing import Any
+
+
+JsonScalar = str | int | float | bool | None
+JsonValue = JsonScalar | list["JsonValue"] | dict[str, "JsonValue"]
+BBox = tuple[float, float, float, float]
+
+
+@dataclass(frozen=True)
+class PageSpan:
+    """A page range in a source document."""
+
+    start: int | None = None
+    end: int | None = None
+
+
+@dataclass(frozen=True)
+class TextSpan:
+    """A character range within a source block."""
+
+    start: int | None = None
+    end: int | None = None
+
+
+@dataclass(frozen=True)
+class ParsedBlock:
+    """The smallest parser-produced document block."""
+
+    block_id: str
+    document_id: str
+    document_format: str
+    block_type: str
+    text: str
+    page: int | None = None
+    bbox: BBox | None = None
+    reading_order: int | None = None
+    parser_confidence: float | None = None
+    metadata: dict[str, JsonValue] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class SectionNode:
+    """A parent-child document section that gives blocks stable context."""
+
+    section_id: str
+    document_id: str
+    title: str
+    level: int
+    parent_id: str | None = None
+    path: tuple[str, ...] = ()
+    page_span: PageSpan | None = None
+    block_ids: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class SourceBlock:
+    """An immutable raw source span used for citations and audits."""
+
+    source_block_id: str
+    document_id: str
+    raw_text: str
+    page_span: PageSpan | None = None
+    block_ids: tuple[str, ...] = ()
+    bbox_span: tuple[BBox, ...] = ()
+    section_id: str | None = None
+
+
+@dataclass(frozen=True)
+class RetrievalChunk:
+    """A text unit optimized for embedding and BM25 retrieval."""
+
+    retrieval_chunk_id: str
+    document_id: str
+    retrieval_text: str
+    source_block_ids: tuple[str, ...] = ()
+    section_ids: tuple[str, ...] = ()
+    strategy: str = "raw"
+    chunk_role: str = "raw"
+
+
+@dataclass(frozen=True)
+class TableFact:
+    """A typed table evidence unit connected to its original source block."""
+
+    fact_id: str
+    fact_type: str
+    table_id: str
+    row_subject: str
+    value: str
+    source_block_id: str
+    column_path: tuple[str, ...] = ()
+    header_path: tuple[str, ...] = ()
+    legend: str | None = None
+    note: str | None = None
+    confidence: float | None = None
+
+
+@dataclass(frozen=True)
+class Candidate:
+    """A unified retrieval candidate after vector, BM25, and fact lookup."""
+
+    candidate_id: str
+    retrieval_chunk_id: str
+    scores: dict[str, float] = field(default_factory=dict)
+    methods: tuple[str, ...] = ()
+    fact_ids: tuple[str, ...] = ()
+    source_block_ids: tuple[str, ...] = ()
+    diagnostics: dict[str, JsonValue] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class SelectedContextItem:
+    """One evidence item selected for final LLM context construction."""
+
+    candidate_id: str
+    prompt_text: str
+    fact_ids: tuple[str, ...] = ()
+    source_block_ids: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class SelectedContext:
+    """The final evidence contract that can be serialized into a prompt."""
+
+    context_id: str
+    items: tuple[SelectedContextItem, ...] = ()
+    prompt_text: str = ""
+    supporting_fact_ids: tuple[str, ...] = ()
+    citation_ids: tuple[str, ...] = ()
+    unsupported_reason: str | None = None
+
+
+@dataclass(frozen=True)
+class SourceCitation:
+    """A user-visible citation derived from SourceBlock, not retrieval text."""
+
+    citation_id: str
+    document_id: str
+    source: str
+    page_label: str
+    source_block_id: str
+    excerpt: str
+    span: TextSpan | None = None
+    confidence: float | None = None
+
+
+def contract_to_dict(contract: object) -> dict[str, JsonValue]:
+    """Convert one contract dataclass into a JSON-serializable dictionary."""
+    converted = _to_json_value(contract)
+    if not isinstance(converted, dict):
+        raise TypeError(f"Expected dataclass contract, got {type(contract).__name__}")
+    return converted
+
+
+def _to_json_value(value: Any) -> JsonValue:
+    if is_dataclass(value) and not isinstance(value, type):
+        return {
+            contract_field.name: _to_json_value(getattr(value, contract_field.name))
+            for contract_field in fields(value)
+        }
+    if isinstance(value, tuple):
+        return [_to_json_value(item) for item in value]
+    if isinstance(value, list):
+        return [_to_json_value(item) for item in value]
+    if isinstance(value, dict):
+        return {str(key): _to_json_value(item) for key, item in value.items()}
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    raise TypeError(f"Unsupported JSON contract value: {type(value).__name__}")


### PR DESCRIPTION
### 배경
현재 RAG 파이프라인은 하나의 chunk가 parser output, 검색 대상, LLM prompt 근거, 사용자 source preview, table fact 부모 데이터, debug trace 후보 역할을 동시에 맡고 있습니다.

#73에서는 이 문제를 한 번에 고치지 않고, 먼저 원문과 검색용 텍스트, 답변 근거, 사용자 출처를 분리하기 위한 data contract를 작은 단위로 관찰할 수 있게 합니다.

### 변경 내용
- RAG data contract skeleton을 추가했습니다.
  - `ParsedBlock`
  - `SectionNode`
  - `SourceBlock`
  - `RetrievalChunk`
  - `TableFact`
  - `Candidate`
  - `SelectedContext`
  - `SourceCitation`
- 기존 chunk text/metadata를 `ParsedBlock`, `SourceBlock`으로 변환하는 builder를 추가했습니다.
- `/debug/rag-trace` 후보 JSON에만 `contract_preview`를 추가했습니다.
- `SourceBlock`이 `page_start/page_end` 범위를 보존하도록 smoke check를 보강했습니다.
- `RetrievalChunk` 생성, typed `TableFact` 전체 구현, `/query sources` 변경은 이번 범위에서 제외했습니다.

### 리뷰 포인트
- `contract_preview`가 trace 응답에만 붙고, 업로드/색인/query runtime을 바꾸지 않는지 확인 부탁드립니다.
- ChromaDB 저장 schema, 검색 순위, LLM prompt, `/query` 응답은 변경하지 않았습니다.
- 이번 PR은 #73 전체 완료가 아니라 data contract 관찰 지점 추가입니다.

### 변경 파일
- `ai-server/rag_contracts.py`: RAG data contract dataclass skeleton
- `ai-server/rag_contract_builders.py`: 기존 chunk를 contract preview로 변환하는 builder
- `ai-server/check_rag_contracts.py`: JSON 직렬화와 page span smoke check
- `ai-server/main.py`: `/debug/rag-trace` 전용 `contract_preview` 추가

### 확인한 내용
- `PYTHONPYCACHEPREFIX=/private/tmp/documind-pycache python3 -m py_compile ai-server/main.py ai-server/rag_contracts.py ai-server/rag_contract_builders.py ai-server/check_rag_contracts.py`: 통과
- `PYTHONPYCACHEPREFIX=/private/tmp/documind-pycache python3 ai-server/check_rag_contracts.py`: 통과
- `_contract_trace_preview()` 직접 smoke: `page_start/page_end` 보존 확인
- GCP ai-server rebuild/restart 후 health: `{"status":"ok"}`
- GCP `/debug/rag-trace`: `final_candidates[0].contract_preview` 확인
- GCP trace-only 평가: `37/66 (56.06%)`, 기존 #72 기준선과 동일

### 이슈
Related #73
