### PR TITLE
[AI/RAG] SectionNode contract trace preview 추가

### DIFF
--- a/ai-server/check_rag_contracts.py
+++ b/ai-server/check_rag_contracts.py
@@ -4,12 +4,10 @@ from __future__ import annotations
 
 import json
 
-from rag_contract_builders import build_parsed_block, build_source_block, header_path_from_metadata
+from rag_contract_builders import build_parsed_block, build_section_node, build_source_block
 from rag_contracts import (
     Candidate,
-    PageSpan,
     RetrievalChunk,
-    SectionNode,
     SelectedContext,
     SelectedContextItem,
     SourceCitation,
@@ -37,15 +35,8 @@ def build_contract_sample() -> dict:
         metadata=metadata,
         parser_confidence=0.95,
     )
-    section = SectionNode(
-        section_id="doc-sample:section-table",
-        document_id="sample",
-        title="Table Section",
-        level=2,
-        path=header_path_from_metadata(metadata),
-        page_span=PageSpan(start=1, end=1),
-        block_ids=(parsed_block.block_id,),
-    )
+    section = build_section_node(parsed_block)
+    assert section is not None
     source_block = build_source_block(
         parsed_block,
         section_id=section.section_id,
@@ -125,7 +116,11 @@ def main() -> None:
     assert decoded["parsed_block"]["block_id"] == "doc-sample:block-000001"
     assert decoded["parsed_block"]["metadata"]["block_type"] == "table"
     assert decoded["section"]["path"] == ["Document", "Table Section"]
+    assert decoded["section"]["title"] == "Table Section"
+    assert decoded["section"]["level"] == 2
+    assert decoded["section"]["page_span"] == {"start": 1, "end": 2}
     assert decoded["source_block"]["raw_text"] == sample["parsed_block"]["text"]
+    assert decoded["source_block"]["section_id"] == decoded["section"]["section_id"]
     assert decoded["source_block"]["page_span"] == {"start": 1, "end": 2}
     assert decoded["source_block"]["bbox_span"] == [[0.0, 0.0, 100.0, 50.0]]
     assert decoded["table_fact"]["source_block_id"] == decoded["source_block"]["source_block_id"]

--- a/ai-server/main.py
+++ b/ai-server/main.py
@@ -19,7 +19,7 @@ import time
 from dataclasses import dataclass
 from threading import Lock
 
-from rag_contract_builders import build_parsed_block, build_source_block
+from rag_contract_builders import build_parsed_block, build_section_node, build_source_block
 
 try:
     from kiwipiepy import Kiwi
@@ -3627,11 +3627,19 @@ def _contract_trace_preview(chunk_id: str, doc: str, meta: dict, preview_chars: 
             metadata=meta,
             block_type=_trace_block_type(doc, meta),
         )
-        source_block = build_source_block(parsed_block)
+        section_node = build_section_node(parsed_block)
+        source_block = build_source_block(
+            parsed_block,
+            section_id=section_node.section_id if section_node else None,
+        )
         page_span = source_block.page_span
         return {
             "parsed_block_id": parsed_block.block_id,
             "source_block_id": source_block.source_block_id,
+            "section_id": section_node.section_id if section_node else None,
+            "section_title": section_node.title if section_node else None,
+            "section_level": section_node.level if section_node else None,
+            "section_path": list(section_node.path) if section_node else [],
             "page_start": page_span.start if page_span else None,
             "page_end": page_span.end if page_span else None,
             "block_type": parsed_block.block_type,

--- a/ai-server/rag_contract_builders.py
+++ b/ai-server/rag_contract_builders.py
@@ -7,9 +7,10 @@ write to ChromaDB and they do not change the existing query pipeline.
 from __future__ import annotations
 
 from collections.abc import Mapping
+from hashlib import sha1
 from typing import Any
 
-from rag_contracts import BBox, JsonValue, PageSpan, ParsedBlock, SourceBlock
+from rag_contracts import BBox, JsonValue, PageSpan, ParsedBlock, SectionNode, SourceBlock
 
 
 def build_parsed_block(
@@ -66,6 +67,25 @@ def build_source_block(
     )
 
 
+def build_section_node(parsed_block: ParsedBlock) -> SectionNode | None:
+    """Create a SectionNode from Header 1..6 metadata when a path exists."""
+    path = header_path_from_metadata(parsed_block.metadata)
+    if not path:
+        return None
+
+    parent_path = path[:-1]
+    return SectionNode(
+        section_id=_section_id(parsed_block.document_id, path),
+        document_id=parsed_block.document_id,
+        title=path[-1],
+        level=len(path),
+        parent_id=_section_id(parsed_block.document_id, parent_path) if parent_path else None,
+        path=path,
+        page_span=page_span_from_metadata(parsed_block.metadata),
+        block_ids=(parsed_block.block_id,),
+    )
+
+
 def page_span_from_metadata(metadata: Mapping[str, Any]) -> PageSpan | None:
     """Read page_start/page_end/page metadata into a PageSpan."""
     page_start = _coerce_int(metadata.get("page_start"))
@@ -101,6 +121,11 @@ def sanitize_metadata(metadata: Mapping[str, Any]) -> dict[str, JsonValue]:
 
 def _contract_id(document_id: str | int, kind: str, index: int) -> str:
     return f"doc-{document_id}:{kind}-{index:06d}"
+
+
+def _section_id(document_id: str | int, path: tuple[str, ...]) -> str:
+    path_digest = sha1("\x1f".join(path).encode("utf-8")).hexdigest()[:12]
+    return f"doc-{document_id}:section-{path_digest}"
 
 
 def _bbox_from_metadata(metadata: Mapping[str, Any]) -> BBox | None:


### PR DESCRIPTION
### 배경

#73에서는 RAG data contract를 기존 runtime에 바로 연결하지 않고 `/debug/rag-trace`에서만 안전하게 관찰하는 방식으로 진행하고 있습니다. PR #75에서 `ParsedBlock`/`SourceBlock` preview를 추가했지만, source 후보가 어느 문서 섹션 아래에 있는지 보는 `SectionNode` 관찰값은 아직 없었습니다.

### 변경 내용

- `Header 1..6` metadata를 `SectionNode`로 변환하는 `build_section_node()` builder를 추가했습니다.
- `/debug/rag-trace`의 `contract_preview`에 `section_id`, `section_title`, `section_level`, `section_path`를 추가했습니다.
- `SourceBlock.section_id`가 trace preview에서 생성된 section과 연결되도록 했습니다.
- contract smoke check가 수동 `SectionNode` 생성 대신 builder 경로를 검증하도록 보강했습니다.

### 리뷰 포인트

- 변경 위치가 `_candidate_location_summary()` 아래 trace 출력 경로에만 머무르는지 봐주세요.
- `SectionNode` id가 header path 기반 stable id로 충분한지 봐주세요.
- 업로드, ChromaDB 저장, 검색 순위, LLM prompt, `/query` 응답을 건드리지 않는지 봐주세요.

### 변경 파일

- `ai-server/rag_contract_builders.py`: `build_section_node()`와 section id 생성 helper 추가
- `ai-server/main.py`: trace 전용 `contract_preview`에 section preview 필드 추가
- `ai-server/check_rag_contracts.py`: SectionNode builder smoke check 추가

### 확인한 내용

- 로컬: `PYTHONPYCACHEPREFIX=/private/tmp/documind-pycache python3 -m py_compile ai-server/main.py ai-server/rag_contracts.py ai-server/rag_contract_builders.py ai-server/check_rag_contracts.py` 통과
- 로컬: `PYTHONPYCACHEPREFIX=/private/tmp/documind-pycache python3 ai-server/check_rag_contracts.py` 통과
- 로컬: `git diff --check` 통과
- GCP: `documind_gcp` ai-server rebuild/restart 후 health `{"status":"ok"}`
- GCP: 컨테이너 `py_compile`, `check_rag_contracts.py` 통과
- GCP: `/debug/rag-trace`에서 `contract_preview.section_path` 확인
- GCP: trace-only 평가 `37/66 (56.06%)`로 #72 기준선과 동일

### 이슈

Related #73
