### PR TITLE
[AI/RAG] section path trace quality 표시

### DIFF
--- a/ai-server/check_rag_contracts.py
+++ b/ai-server/check_rag_contracts.py
@@ -4,7 +4,13 @@ from __future__ import annotations
 
 import json
 
-from rag_contract_builders import build_parsed_block, build_section_node, build_source_block
+from rag_contract_builders import (
+    build_parsed_block,
+    build_section_node,
+    build_source_block,
+    section_path_quality,
+    section_path_warnings,
+)
 from rag_contracts import (
     Candidate,
     RetrievalChunk,
@@ -119,6 +125,9 @@ def main() -> None:
     assert decoded["section"]["title"] == "Table Section"
     assert decoded["section"]["level"] == 2
     assert decoded["section"]["page_span"] == {"start": 1, "end": 2}
+    assert section_path_quality(("Document", "Table Section")) == "ok"
+    assert section_path_quality(("569명",)) == "suspect"
+    assert "numeric_value_section_component" in section_path_warnings(("569명",))
     assert decoded["source_block"]["raw_text"] == sample["parsed_block"]["text"]
     assert decoded["source_block"]["section_id"] == decoded["section"]["section_id"]
     assert decoded["source_block"]["page_span"] == {"start": 1, "end": 2}

--- a/ai-server/main.py
+++ b/ai-server/main.py
@@ -19,7 +19,13 @@ import time
 from dataclasses import dataclass
 from threading import Lock
 
-from rag_contract_builders import build_parsed_block, build_section_node, build_source_block
+from rag_contract_builders import (
+    build_parsed_block,
+    build_section_node,
+    build_source_block,
+    section_path_quality,
+    section_path_warnings,
+)
 
 try:
     from kiwipiepy import Kiwi
@@ -3633,13 +3639,16 @@ def _contract_trace_preview(chunk_id: str, doc: str, meta: dict, preview_chars: 
             section_id=section_node.section_id if section_node else None,
         )
         page_span = source_block.page_span
+        section_path = list(section_node.path) if section_node else []
         return {
             "parsed_block_id": parsed_block.block_id,
             "source_block_id": source_block.source_block_id,
             "section_id": section_node.section_id if section_node else None,
             "section_title": section_node.title if section_node else None,
             "section_level": section_node.level if section_node else None,
-            "section_path": list(section_node.path) if section_node else [],
+            "section_path": section_path,
+            "section_path_quality": section_path_quality(section_path),
+            "section_path_warnings": list(section_path_warnings(section_path)),
             "page_start": page_span.start if page_span else None,
             "page_end": page_span.end if page_span else None,
             "block_type": parsed_block.block_type,

--- a/ai-server/rag_contract_builders.py
+++ b/ai-server/rag_contract_builders.py
@@ -8,7 +8,8 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from hashlib import sha1
-from typing import Any
+import re
+from typing import Any, Sequence
 
 from rag_contracts import BBox, JsonValue, PageSpan, ParsedBlock, SectionNode, SourceBlock
 
@@ -109,6 +110,34 @@ def header_path_from_metadata(metadata: Mapping[str, Any]) -> tuple[str, ...]:
     return tuple(path)
 
 
+def section_path_quality(path: Sequence[str]) -> str:
+    """Return whether a section path looks usable for trace diagnostics."""
+    warnings = section_path_warnings(path)
+    if "missing_section_path" in warnings:
+        return "missing"
+    return "suspect" if warnings else "ok"
+
+
+def section_path_warnings(path: Sequence[str]) -> tuple[str, ...]:
+    """Return generic warnings for section paths that look like table values."""
+    if not path:
+        return ("missing_section_path",)
+
+    warnings: set[str] = set()
+    for component in path:
+        normalized = re.sub(r"\s+", " ", str(component or "").strip())
+        if not normalized:
+            warnings.add("empty_section_component")
+            continue
+        if _TABLE_VALUE_LIKE_SECTION_PATTERN.fullmatch(normalized):
+            warnings.add("numeric_value_section_component")
+        if "|" in normalized or "<br" in normalized.lower():
+            warnings.add("table_markup_section_component")
+        if len(normalized) > 80:
+            warnings.add("overlong_section_component")
+    return tuple(sorted(warnings))
+
+
 def sanitize_metadata(metadata: Mapping[str, Any]) -> dict[str, JsonValue]:
     """Keep only JSON-safe metadata values for contract serialization."""
     safe: dict[str, JsonValue] = {}
@@ -152,6 +181,10 @@ class _Unsupported:
 
 
 _UNSUPPORTED = _Unsupported()
+
+_TABLE_VALUE_LIKE_SECTION_PATTERN = re.compile(
+    r"^[\d\s,./~:·ㆍ+-]+(?:명|원|점|일|개|건|회|차|%|학점|시간|쪽|페이지)?$"
+)
 
 
 def _to_safe_json_value(value: Any) -> JsonValue | _Unsupported:


### PR DESCRIPTION
### 배경

#73에서는 RAG data contract를 runtime에 바로 연결하지 않고 `/debug/rag-trace`에서 안전하게 관찰하고 있습니다. PR #76에서 `SectionNode` preview를 추가한 뒤 GCP P0 trace를 확인하니, 일부 모집요강 후보의 `section_path`가 `569명` 같은 표 값으로 오염되는 사례가 확인됐습니다.

이 값을 바로 `RetrievalChunk`나 prompt context에 연결하면 문서 구조를 잘못 신뢰할 수 있으므로, trace 전용 품질 표시를 먼저 추가합니다.

### 변경 내용

- `section_path_quality()`를 추가해 section path를 `ok`, `suspect`, `missing`으로 분류합니다.
- `section_path_warnings()`를 추가해 숫자 값, 표 markup, 과도하게 긴 component를 경고합니다.
- `/debug/rag-trace`의 `contract_preview`에 `section_path_quality`, `section_path_warnings`를 추가합니다.
- contract smoke check에 정상 path와 `569명` suspect path assertion을 추가합니다.

### 리뷰 포인트

- `569명`, `30,000원` 같은 table value 형태를 generic pattern으로 감지하는지 확인 부탁드립니다.
- 이번 변경이 trace-only 필드 추가에 머물러 ChromaDB 저장, 검색 순위, prompt, `/query` 응답을 바꾸지 않는지 봐 주세요.
- 이 변경을 `RetrievalChunk` 연결 전 안전장치로 보는 판단이 적절한지 확인 부탁드립니다.

### 변경 파일

- `ai-server/rag_contract_builders.py`: section path quality/warning helper 추가
- `ai-server/main.py`: trace 전용 `contract_preview`에 quality/warnings 노출
- `ai-server/check_rag_contracts.py`: JSON smoke check와 suspect path assertion 추가

### 확인한 내용

- 로컬 `PYTHONPYCACHEPREFIX=/private/tmp/documind-pycache python3 -m py_compile ai-server/main.py ai-server/rag_contracts.py ai-server/rag_contract_builders.py ai-server/check_rag_contracts.py` 통과
- 로컬 `PYTHONPYCACHEPREFIX=/private/tmp/documind-pycache python3 ai-server/check_rag_contracts.py` 통과
- 로컬 `git diff --check` 통과
- GCP `documind_gcp` ai-server health `{"status":"ok"}` 확인
- GCP 컨테이너 `py_compile`, `check_rag_contracts.py` 통과
- GCP `/debug/rag-trace`에서 `section_path=["569명"]`, `section_path_quality="suspect"`, `section_path_warnings=["numeric_value_section_component"]` 확인
- GCP trace-only `evaluate_rag.py`: 37/66 통과, 56.06%

### 이슈

Related #73
