### PR TITLE
[AI/RAG] suspect header metadata carry 방지

### DIFF
--- a/ai-server/check_rag_contracts.py
+++ b/ai-server/check_rag_contracts.py
@@ -8,6 +8,7 @@ from rag_contract_builders import (
     build_parsed_block,
     build_section_node,
     build_source_block,
+    section_path_component_is_suspect,
     section_path_quality,
     section_path_warnings,
 )
@@ -127,6 +128,9 @@ def main() -> None:
     assert decoded["section"]["page_span"] == {"start": 1, "end": 2}
     assert section_path_quality(("Document", "Table Section")) == "ok"
     assert section_path_quality(("569명",)) == "suspect"
+    assert section_path_component_is_suspect("569명") is True
+    assert section_path_component_is_suspect("30,000원") is True
+    assert section_path_component_is_suspect("2. 정원외 전형 모집인원") is False
     assert "numeric_value_section_component" in section_path_warnings(("569명",))
     assert decoded["source_block"]["raw_text"] == sample["parsed_block"]["text"]
     assert decoded["source_block"]["section_id"] == decoded["section"]["section_id"]

--- a/ai-server/main.py
+++ b/ai-server/main.py
@@ -23,6 +23,7 @@ from rag_contract_builders import (
     build_parsed_block,
     build_section_node,
     build_source_block,
+    section_path_component_is_suspect,
     section_path_quality,
     section_path_warnings,
 )
@@ -317,10 +318,23 @@ def _update_active_headers(active_headers: dict[str, str], chunk_metadata: dict)
         value = str(chunk_metadata.get(key, "")).strip()
         if not value:
             continue
+        if section_path_component_is_suspect(value):
+            continue
 
         active_headers[key] = value
         for lower_level in range(level + 1, 7):
             active_headers.pop(f"Header {lower_level}", None)
+
+
+def _clean_chunk_header_metadata(chunk_metadata: dict) -> dict:
+    """표 값처럼 보이는 Markdown header metadata는 청크 제목 경로에서 제외한다."""
+    cleaned = dict(chunk_metadata)
+    for level in range(1, 7):
+        key = f"Header {level}"
+        value = str(cleaned.get(key, "")).strip()
+        if value and section_path_component_is_suspect(value):
+            cleaned.pop(key, None)
+    return cleaned
 
 
 def _split_loaded_documents(docs: list[Document]) -> list[Document]:
@@ -338,10 +352,11 @@ def _split_loaded_documents(docs: list[Document]) -> list[Document]:
     for raw_doc in docs:
         page_chunks = _two_pass_split(raw_doc.page_content)
         for chunk in page_chunks:
-            _update_active_headers(active_headers, chunk.metadata)
+            chunk_metadata = _clean_chunk_header_metadata(chunk.metadata)
+            _update_active_headers(active_headers, chunk_metadata)
             metadata = dict(raw_doc.metadata)
             metadata.update(active_headers)
-            metadata.update(chunk.metadata)
+            metadata.update(chunk_metadata)
             split_docs.append(Document(page_content=chunk.page_content, metadata=metadata))
 
     return split_docs

--- a/ai-server/rag_contract_builders.py
+++ b/ai-server/rag_contract_builders.py
@@ -138,6 +138,12 @@ def section_path_warnings(path: Sequence[str]) -> tuple[str, ...]:
     return tuple(sorted(warnings))
 
 
+def section_path_component_is_suspect(component: object) -> bool:
+    """Return True when one section component should not be trusted as a heading."""
+    warnings = set(section_path_warnings((str(component or "").strip(),)))
+    return bool(warnings & _SECTION_PATH_COMPONENT_BLOCKING_WARNINGS)
+
+
 def sanitize_metadata(metadata: Mapping[str, Any]) -> dict[str, JsonValue]:
     """Keep only JSON-safe metadata values for contract serialization."""
     safe: dict[str, JsonValue] = {}
@@ -185,6 +191,10 @@ _UNSUPPORTED = _Unsupported()
 _TABLE_VALUE_LIKE_SECTION_PATTERN = re.compile(
     r"^[\d\s,./~:·ㆍ+-]+(?:명|원|점|일|개|건|회|차|%|학점|시간|쪽|페이지)?$"
 )
+_SECTION_PATH_COMPONENT_BLOCKING_WARNINGS = {
+    "numeric_value_section_component",
+    "table_markup_section_component",
+}
 
 
 def _to_safe_json_value(value: Any) -> JsonValue | _Unsupported:


### PR DESCRIPTION
### 배경

#73 trace preview에서 `section_path=["569명"]`처럼 표 값이 문서 제목 경로로 저장되는 사례를 확인했습니다. GCP ChromaDB 조회 결과 이 값은 `/debug/rag-trace` 표시 문제가 아니라 raw chunk/table_fact metadata에 이미 저장된 `Header 1` 오염이었습니다.

### 변경 내용

- `section_path_component_is_suspect()`를 추가해 숫자+단위 또는 table markup처럼 제목이 아닌 header component를 판정합니다.
- `_clean_chunk_header_metadata()`를 추가해 현재 chunk의 suspect `Header 1..6` 값을 제거합니다.
- `_update_active_headers()`가 suspect header를 다음 page/chunk로 carry-forward하지 않도록 막았습니다.
- smoke check에 `569명`, `30,000원`, `2. 정원외 전형 모집인원` 판정 기준을 추가했습니다.

### 리뷰 포인트

- 특정 모집요강, 학과명, 전형명, 페이지 번호 hard coding 없이 generic numeric/table-markup pattern만 차단하는지 봐주세요.
- 기존 ChromaDB schema, 검색 순위, LLM prompt, `/query` 응답을 바꾸지 않고 future upload split metadata만 바꾸는 범위인지 봐주세요.
- `2. 정원외 전형 모집인원` 같은 정상 번호형 제목은 유지되는지 봐주세요.

### 변경 파일

- `ai-server/main.py`: PDF page split에서 suspect header metadata를 제거하고 active header carry-forward를 제한합니다.
- `ai-server/rag_contract_builders.py`: section path component 단위 suspect 판정 helper를 추가합니다.
- `ai-server/check_rag_contracts.py`: header component 판정 smoke check를 추가합니다.

### 확인한 내용

- 로컬 `PYTHONPYCACHEPREFIX=/private/tmp/documind-pycache python3 -m py_compile ai-server/main.py ai-server/rag_contracts.py ai-server/rag_contract_builders.py ai-server/check_rag_contracts.py` 통과
- 로컬 `PYTHONPYCACHEPREFIX=/private/tmp/documind-pycache python3 ai-server/check_rag_contracts.py` 통과 (`rag_contracts smoke ok`)
- 로컬 `git diff --check` 통과
- GCP `documind_gcp` ai-server health `{"status":"ok"}`
- GCP 컨테이너 `py_compile` 통과
- GCP 컨테이너 `check_rag_contracts.py` 통과 (`rag_contracts smoke ok`)
- GCP synthetic split smoke 통과: `569명`은 header path에서 제거되고 `2. 정원외 전형 모집인원`은 유지됨
- GCP trace-only `evaluate_rag.py`: 37/66 통과, 56.06%

### 이슈

Related #73
