### PR TITLE
[AI/RAG] section path metadata 진단 스크립트 추가

### DIFF
--- a/ai-server/check_section_paths.py
+++ b/ai-server/check_section_paths.py
@@ -1,0 +1,144 @@
+import argparse
+import json
+import os
+from collections import Counter, defaultdict
+from typing import Any
+
+from rag_contract_builders import (
+    header_path_from_metadata,
+    section_path_quality,
+    section_path_warnings,
+)
+
+
+def _create_client():
+    import chromadb
+
+    chroma_host = os.getenv("CHROMA_HOST")
+    chroma_port = int(os.getenv("CHROMA_PORT", "8001"))
+    chroma_path = os.getenv("CHROMA_PATH", "./chroma_db")
+    if chroma_host:
+        return chromadb.HttpClient(host=chroma_host, port=chroma_port)
+    return chromadb.PersistentClient(path=chroma_path)
+
+
+def _sample_entry(
+    chunk_id: str,
+    metadata: dict[str, Any],
+    path: tuple[str, ...],
+    warnings: tuple[str, ...],
+) -> dict[str, Any]:
+    return {
+        "chunk_id": chunk_id,
+        "document_id": metadata.get("document_id", ""),
+        "source": metadata.get("source", ""),
+        "chunk_role": metadata.get("chunk_role", "raw"),
+        "page": metadata.get("page"),
+        "page_start": metadata.get("page_start"),
+        "page_end": metadata.get("page_end"),
+        "chunk_index": metadata.get("chunk_index"),
+        "header_path": list(path),
+        "warnings": list(warnings),
+    }
+
+
+def summarize_section_paths(
+    ids: list[str],
+    metadatas: list[dict[str, Any] | None],
+    *,
+    sample_limit: int = 10,
+) -> dict[str, Any]:
+    quality_counts: Counter[str] = Counter()
+    warning_counts: Counter[str] = Counter()
+    role_counts: dict[str, Counter[str]] = defaultdict(Counter)
+    source_counts: dict[str, Counter[str]] = defaultdict(Counter)
+    samples: list[dict[str, Any]] = []
+
+    for chunk_id, metadata in zip(ids, metadatas):
+        metadata = metadata or {}
+        path = header_path_from_metadata(metadata)
+        quality = section_path_quality(path)
+        warnings = section_path_warnings(path)
+        role = str(metadata.get("chunk_role") or "raw")
+        source = str(metadata.get("source") or "")
+
+        quality_counts[quality] += 1
+        role_counts[role][quality] += 1
+        source_counts[source][quality] += 1
+        for warning in warnings:
+            warning_counts[warning] += 1
+
+        if quality == "suspect" and len(samples) < sample_limit:
+            samples.append(_sample_entry(str(chunk_id), metadata, path, warnings))
+
+    return {
+        "total_entries": len(metadatas),
+        "quality_counts": dict(sorted(quality_counts.items())),
+        "warning_counts": dict(sorted(warning_counts.items())),
+        "role_counts": {role: dict(sorted(counts.items())) for role, counts in sorted(role_counts.items())},
+        "source_counts": {source: dict(sorted(counts.items())) for source, counts in sorted(source_counts.items())},
+        "suspect_samples": samples,
+    }
+
+
+def _print_text(summary: dict[str, Any]) -> None:
+    print(f"total_entries: {summary['total_entries']}")
+    print("quality_counts:")
+    for quality, count in summary["quality_counts"].items():
+        print(f"  {quality}: {count}")
+
+    print("warning_counts:")
+    for warning, count in summary["warning_counts"].items():
+        print(f"  {warning}: {count}")
+
+    print("role_counts:")
+    for role, counts in summary["role_counts"].items():
+        joined = ", ".join(f"{quality}={count}" for quality, count in counts.items())
+        print(f"  {role}: {joined}")
+
+    print("suspect_samples:")
+    for sample in summary["suspect_samples"]:
+        path = " > ".join(str(item) for item in sample["header_path"])
+        warnings = ", ".join(str(item) for item in sample["warnings"])
+        print(
+            "  - "
+            f"chunk_id={sample['chunk_id']} "
+            f"document_id={sample['document_id']} "
+            f"role={sample['chunk_role']} "
+            f"page={sample['page_start'] or sample['page']} "
+            f"path={path} "
+            f"warnings={warnings}"
+        )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Summarize Header 1..6 section path quality stored in ChromaDB."
+    )
+    parser.add_argument("--document-id", help="Limit the check to one document_id.")
+    parser.add_argument("--sample-limit", type=int, default=10, help="Maximum suspect samples to print.")
+    parser.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
+    args = parser.parse_args()
+
+    client = _create_client()
+    collection = client.get_collection("documents")
+    where = {"document_id": str(args.document_id)} if args.document_id else None
+    results = (
+        collection.get(where=where, include=["metadatas"])
+        if where
+        else collection.get(include=["metadatas"])
+    )
+    summary = summarize_section_paths(
+        [str(chunk_id) for chunk_id in results.get("ids", [])],
+        results.get("metadatas", []),
+        sample_limit=max(0, args.sample_limit),
+    )
+
+    if args.json:
+        print(json.dumps(summary, ensure_ascii=False, indent=2, sort_keys=True))
+    else:
+        _print_text(summary)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### 배경

PR #78에서 숫자형 표 값이 `Header 1..6` metadata로 carry-forward되지 않도록 막았습니다. 하지만 기존 GCP ChromaDB에는 PR #78 이전에 생성된 metadata가 남아 있어서, clean reindex 전후 section path 품질을 수치로 비교할 진단 도구가 필요합니다.

### 변경 내용

- `ai-server/check_section_paths.py`를 추가했습니다.
- ChromaDB `documents` collection의 `Header 1..6` metadata를 읽어 `ok`, `suspect`, `missing` 분포를 집계합니다.
- warning count, chunk role별 quality count, suspect sample을 출력합니다.
- `--document-id`, `--sample-limit`, `--json` 옵션을 지원합니다.

### 리뷰 포인트

- 스크립트가 ChromaDB를 읽기만 하고 delete/reindex/write를 수행하지 않는지 봐주세요.
- 기존 `rag_contract_builders.py`의 `section_path_quality()`와 `section_path_warnings()`를 재사용해 trace 기준과 진단 기준이 어긋나지 않는지 봐주세요.
- 로컬 순수 함수 smoke를 위해 `chromadb` import를 CLI 실행 시점으로 늦춘 방식이 적절한지 봐주세요.

### 변경 파일

- `ai-server/check_section_paths.py`: ChromaDB 저장 metadata의 section path 품질 분포를 출력하는 진단 CLI입니다.

### 확인한 내용

- 로컬 `PYTHONPYCACHEPREFIX=/private/tmp/documind-pycache python3 -m py_compile ai-server/check_section_paths.py ai-server/rag_contract_builders.py ai-server/rag_contracts.py` 통과
- 로컬 순수 함수 smoke 통과 (`check_section_paths smoke ok`)
- 로컬 `git diff --check` 통과
- GCP `documind_gcp` ai-server rebuild 완료
- GCP 컨테이너 `py_compile` 통과
- GCP `dc exec -T ai-server python /app/check_section_paths.py --document-id 11 --sample-limit 8` 실행 확인
- GCP 기존 `document_id=11` 결과: total 476, missing 15, ok 43, suspect 418, `numeric_value_section_component` 418

### 이슈

Related #73
