### PR TITLE
[AI/RAG] 금액 section path suspect 규칙 일반화

### DIFF
--- a/ai-server/check_rag_contracts.py
+++ b/ai-server/check_rag_contracts.py
@@ -130,8 +130,12 @@ def main() -> None:
     assert section_path_quality(("569명",)) == "suspect"
     assert section_path_component_is_suspect("569명") is True
     assert section_path_component_is_suspect("30,000원") is True
+    assert section_path_component_is_suspect("423만원") is True
+    assert section_path_component_is_suspect("1조원") is True
     assert section_path_component_is_suspect("2. 정원외 전형 모집인원") is False
+    assert section_path_component_is_suspect("2026학년도 입학전형") is False
     assert "numeric_value_section_component" in section_path_warnings(("569명",))
+    assert "numeric_value_section_component" in section_path_warnings(("423만원",))
     assert decoded["source_block"]["raw_text"] == sample["parsed_block"]["text"]
     assert decoded["source_block"]["section_id"] == decoded["section"]["section_id"]
     assert decoded["source_block"]["page_span"] == {"start": 1, "end": 2}

--- a/ai-server/rag_contract_builders.py
+++ b/ai-server/rag_contract_builders.py
@@ -188,8 +188,28 @@ class _Unsupported:
 
 _UNSUPPORTED = _Unsupported()
 
+_NUMERIC_SECTION_VALUE_UNITS = (
+    "명",
+    "점",
+    "일",
+    "개",
+    "건",
+    "회",
+    "차",
+    "%",
+    "학점",
+    "시간",
+    "쪽",
+    "페이지",
+)
+_NUMERIC_SECTION_UNIT_PATTERN = "|".join(
+    re.escape(unit) for unit in _NUMERIC_SECTION_VALUE_UNITS
+)
+# Korean currency values often combine a magnitude word with "원": 만원, 억원, 조원.
+_KOREAN_CURRENCY_UNIT_PATTERN = r"(?:[십백천만억조경]+)?원"
 _TABLE_VALUE_LIKE_SECTION_PATTERN = re.compile(
-    r"^[\d\s,./~:·ㆍ+-]+(?:명|원|점|일|개|건|회|차|%|학점|시간|쪽|페이지)?$"
+    rf"^[\d\s,./~:·ㆍ+-]+"
+    rf"(?:{_KOREAN_CURRENCY_UNIT_PATTERN}|{_NUMERIC_SECTION_UNIT_PATTERN})?$"
 )
 _SECTION_PATH_COMPONENT_BLOCKING_WARNINGS = {
     "numeric_value_section_component",


### PR DESCRIPTION
### 배경
- #73 RAG data contract 검증 중 `원서 접수 비용은 얼마인가요?` trace에서 `section_path=423만원`이 `quality=ok`로 남는 사례를 확인했습니다.
- `423만원`은 문서 제목이 아니라 표의 금액 값에 가까우므로, Header metadata로 carry-forward되면 section path가 오염될 수 있습니다.
- 단순히 `만원`, `천원`, `억원`을 계속 나열하는 방식은 유지보수성이 낮아 금액 단위 규칙을 분리했습니다.

### 변경 내용
- 숫자 section 값의 일반 단위 목록을 `_NUMERIC_SECTION_VALUE_UNITS`로 분리했습니다.
- 한국어 금액 단위는 `십/백/천/만/억/조/경 + 원` 형태의 `_KOREAN_CURRENCY_UNIT_PATTERN`으로 일반화했습니다.
- `423만원`, `1조원`은 suspect로 판정하고, `2026학년도 입학전형`, `2. 정원외 전형 모집인원`은 제목으로 유지되는 smoke assertion을 추가했습니다.

### 리뷰 포인트
- 금액 단위 pattern이 특정 모집요강 전용 하드코딩이 아니라 일반적인 숫자값 heading 차단 규칙으로 충분한지 확인 부탁드립니다.
- 숫자가 포함된 실제 제목을 과도하게 제거하지 않도록 둔 반례 assertion이 적절한지 봐주세요.

### 변경 파일
- `ai-server/rag_contract_builders.py`: section path suspect 판정용 숫자 단위와 한국어 금액 단위 pattern 분리
- `ai-server/check_rag_contracts.py`: 금액 단위 suspect와 제목형 반례 assertion 추가

### 확인한 내용
- `PYTHONPYCACHEPREFIX=/private/tmp/documind-pycache python3 -m py_compile ai-server/rag_contracts.py ai-server/rag_contract_builders.py ai-server/check_rag_contracts.py` 통과
- `PYTHONPYCACHEPREFIX=/private/tmp/documind-pycache python3 ai-server/check_rag_contracts.py` 통과
- `git diff --check -- ai-server/rag_contract_builders.py ai-server/check_rag_contracts.py` 통과
- GCP runtime 반영 검증은 미실행: 현재 Codex 로컬 환경에서 직접 SSH 22번 포트는 timeout이고 `gcloud`가 없어 Web SSH/IAP 접속을 자동화할 수 없었습니다.

### 이슈
Related #73