### PR TITLE
[AI/RAG] RetrievalChunk contract trace preview 추가

### DIFF
--- a/ai-server/check_rag_contracts.py
+++ b/ai-server/check_rag_contracts.py
@@ -6,6 +6,7 @@ import json
 
 from rag_contract_builders import (
     build_parsed_block,
+    build_retrieval_chunk,
     build_section_node,
     build_source_block,
     section_path_component_is_suspect,
@@ -14,7 +15,6 @@ from rag_contract_builders import (
 )
 from rag_contracts import (
     Candidate,
-    RetrievalChunk,
     SelectedContext,
     SelectedContextItem,
     SourceCitation,
@@ -48,14 +48,10 @@ def build_contract_sample() -> dict:
         parsed_block,
         section_id=section.section_id,
     )
-    retrieval_chunk = RetrievalChunk(
-        retrieval_chunk_id="doc-sample:retrieval-001",
-        document_id="sample",
-        retrieval_text="Table Section Item A Value 10",
-        source_block_ids=(source_block.source_block_id,),
-        section_ids=(section.section_id,),
-        strategy="section_table",
-        chunk_role="raw",
+    retrieval_chunk = build_retrieval_chunk(
+        parsed_block,
+        source_block,
+        section,
     )
     table_fact = TableFact(
         fact_id="doc-sample:fact-001",
@@ -140,8 +136,35 @@ def main() -> None:
     assert decoded["source_block"]["section_id"] == decoded["section"]["section_id"]
     assert decoded["source_block"]["page_span"] == {"start": 1, "end": 2}
     assert decoded["source_block"]["bbox_span"] == [[0.0, 0.0, 100.0, 50.0]]
+    assert decoded["retrieval_chunk"]["strategy"] == "section_prefixed_raw"
+    assert decoded["retrieval_chunk"]["retrieval_text"].startswith(
+        "Document > Table Section\n"
+    )
+    assert decoded["retrieval_chunk"]["source_block_ids"] == [
+        decoded["source_block"]["source_block_id"]
+    ]
+    assert decoded["retrieval_chunk"]["section_ids"] == [decoded["section"]["section_id"]]
     assert decoded["table_fact"]["source_block_id"] == decoded["source_block"]["source_block_id"]
     assert decoded["selected_context"]["citation_ids"] == [decoded["citation"]["citation_id"]]
+
+    suspect_metadata = {"Header 1": "423만원"}
+    suspect_parsed = build_parsed_block(
+        document_id="sample",
+        document_format="pdf",
+        text="원서접수 비용 423만원",
+        block_index=2,
+        metadata=suspect_metadata,
+    )
+    suspect_section = build_section_node(suspect_parsed)
+    assert suspect_section is not None
+    suspect_source = build_source_block(
+        suspect_parsed,
+        section_id=suspect_section.section_id,
+    )
+    suspect_retrieval = build_retrieval_chunk(suspect_parsed, suspect_source, suspect_section)
+    assert suspect_retrieval.strategy == "raw"
+    assert suspect_retrieval.section_ids == ()
+    assert suspect_retrieval.retrieval_text == suspect_source.raw_text
     print("rag_contracts smoke ok")
 
 

--- a/ai-server/main.py
+++ b/ai-server/main.py
@@ -21,6 +21,7 @@ from threading import Lock
 
 from rag_contract_builders import (
     build_parsed_block,
+    build_retrieval_chunk,
     build_section_node,
     build_source_block,
     section_path_component_is_suspect,
@@ -3653,6 +3654,11 @@ def _contract_trace_preview(chunk_id: str, doc: str, meta: dict, preview_chars: 
             parsed_block,
             section_id=section_node.section_id if section_node else None,
         )
+        retrieval_chunk = build_retrieval_chunk(
+            parsed_block,
+            source_block,
+            section_node,
+        )
         page_span = source_block.page_span
         section_path = list(section_node.path) if section_node else []
         return {
@@ -3668,6 +3674,20 @@ def _contract_trace_preview(chunk_id: str, doc: str, meta: dict, preview_chars: 
             "page_end": page_span.end if page_span else None,
             "block_type": parsed_block.block_type,
             "raw_text_preview": _preview_text(source_block.raw_text, preview_chars),
+            "retrieval_chunk": {
+                "retrieval_chunk_id": retrieval_chunk.retrieval_chunk_id,
+                "strategy": retrieval_chunk.strategy,
+                "chunk_role": retrieval_chunk.chunk_role,
+                "source_block_ids": list(retrieval_chunk.source_block_ids),
+                "section_ids": list(retrieval_chunk.section_ids),
+                "retrieval_text_preview": _preview_text(
+                    retrieval_chunk.retrieval_text,
+                    preview_chars,
+                ),
+                "retrieval_text_differs_from_raw": (
+                    retrieval_chunk.retrieval_text != source_block.raw_text
+                ),
+            },
         }
     except Exception:
         logger.exception("[rag_contract_preview] failed chunk_id=%s", chunk_id)

--- a/ai-server/rag_contract_builders.py
+++ b/ai-server/rag_contract_builders.py
@@ -11,7 +11,15 @@ from hashlib import sha1
 import re
 from typing import Any, Sequence
 
-from rag_contracts import BBox, JsonValue, PageSpan, ParsedBlock, SectionNode, SourceBlock
+from rag_contracts import (
+    BBox,
+    JsonValue,
+    PageSpan,
+    ParsedBlock,
+    RetrievalChunk,
+    SectionNode,
+    SourceBlock,
+)
 
 
 def build_parsed_block(
@@ -65,6 +73,33 @@ def build_source_block(
         block_ids=(parsed_block.block_id,),
         bbox_span=bbox_span,
         section_id=section_id,
+    )
+
+
+def build_retrieval_chunk(
+    parsed_block: ParsedBlock,
+    source_block: SourceBlock,
+    section_node: SectionNode | None = None,
+    *,
+    retrieval_index: int | None = None,
+) -> RetrievalChunk:
+    """Create a RetrievalChunk preview without changing stored index text."""
+    section_path = section_node.path if section_node else ()
+    trusted_section = bool(section_node and section_path_quality(section_path) == "ok")
+    retrieval_text = _compose_retrieval_text(
+        section_path if trusted_section else (),
+        parsed_block.text,
+    )
+    index = parsed_block.reading_order if retrieval_index is None else retrieval_index
+
+    return RetrievalChunk(
+        retrieval_chunk_id=_contract_id(parsed_block.document_id, "retrieval", index or 0),
+        document_id=parsed_block.document_id,
+        retrieval_text=retrieval_text,
+        source_block_ids=(source_block.source_block_id,),
+        section_ids=(section_node.section_id,) if section_node and trusted_section else (),
+        strategy="section_prefixed_raw" if trusted_section else "raw",
+        chunk_role=str(parsed_block.metadata.get("chunk_role") or "raw"),
     )
 
 
@@ -161,6 +196,20 @@ def _contract_id(document_id: str | int, kind: str, index: int) -> str:
 def _section_id(document_id: str | int, path: tuple[str, ...]) -> str:
     path_digest = sha1("\x1f".join(path).encode("utf-8")).hexdigest()[:12]
     return f"doc-{document_id}:section-{path_digest}"
+
+
+def _compose_retrieval_text(section_path: Sequence[str], raw_text: str) -> str:
+    sections = [
+        str(component).strip()
+        for component in section_path
+        if str(component).strip()
+    ]
+    text_parts = []
+    if sections:
+        text_parts.append(" > ".join(sections))
+    if raw_text.strip():
+        text_parts.append(raw_text.strip())
+    return "\n".join(text_parts)
 
 
 def _bbox_from_metadata(metadata: Mapping[str, Any]) -> BBox | None:


### PR DESCRIPTION
### 배경
- #73의 핵심 문제는 하나의 chunk가 원문, 검색용 텍스트, prompt 근거, 사용자 출처를 동시에 맡는 구조입니다.
- 지금까지 `ParsedBlock`, `SourceBlock`, `SectionNode`를 `/debug/rag-trace`에서 관찰했고, header path 오염을 줄이는 작업까지 진행했습니다.
- 다음 단계로 검색용 텍스트인 `RetrievalChunk`를 실제 runtime에 바로 연결하지 않고 trace preview에서만 관찰할 수 있게 합니다.

### 변경 내용
- `build_retrieval_chunk()` builder를 추가했습니다.
- section path 품질이 `ok`일 때만 section path를 retrieval text 앞에 붙이고, `423만원` 같은 suspect path는 `raw` strategy로 fallback합니다.
- `/debug/rag-trace`의 `contract_preview.retrieval_chunk`에 retrieval id, strategy, source/section 연결, retrieval text preview를 추가했습니다.
- `check_rag_contracts.py`에 정상 section path와 suspect section path fallback assertion을 추가했습니다.

### 리뷰 포인트
- `RetrievalChunk`가 아직 ChromaDB 저장 text나 ranking에 연결되지 않고 trace preview에만 노출되는지 확인 부탁드립니다.
- suspect section path를 retrieval text에도 붙이지 않는 fallback 기준이 적절한지 봐주세요.
- source 원문(`SourceBlock.raw_text`)과 검색용 text(`RetrievalChunk.retrieval_text`)의 역할 분리가 명확한지 확인 부탁드립니다.

### 변경 파일
- `ai-server/rag_contract_builders.py`: `build_retrieval_chunk()`와 retrieval text compose helper 추가
- `ai-server/main.py`: `/debug/rag-trace` contract preview에 `retrieval_chunk` 진단 필드 추가
- `ai-server/check_rag_contracts.py`: RetrievalChunk builder와 suspect path fallback smoke assertion 추가

### 확인한 내용
- `PYTHONPYCACHEPREFIX=/private/tmp/documind-pycache python3 -m py_compile ai-server/main.py ai-server/rag_contracts.py ai-server/rag_contract_builders.py ai-server/check_rag_contracts.py` 통과
- `PYTHONPYCACHEPREFIX=/private/tmp/documind-pycache python3 ai-server/check_rag_contracts.py` 통과
- `git diff --check -- ai-server/main.py ai-server/rag_contract_builders.py ai-server/check_rag_contracts.py` 통과
- GCP runtime 반영 검증은 미실행: 로컬 Codex 환경에서 직접 SSH 22번은 timeout이고 `gcloud`가 없어 Web SSH/IAP 자동 접속을 수행할 수 없습니다.

### 이슈
Related #73