### PR TITLE
[AI/RAG] SourceCitation contract trace preview 추가

### DIFF
--- a/ai-server/check_rag_contracts.py
+++ b/ai-server/check_rag_contracts.py
@@ -8,6 +8,7 @@ from rag_contract_builders import (
     build_parsed_block,
     build_retrieval_chunk,
     build_section_node,
+    build_source_citation,
     build_source_block,
     section_path_component_is_suspect,
     section_path_quality,
@@ -17,9 +18,7 @@ from rag_contracts import (
     Candidate,
     SelectedContext,
     SelectedContextItem,
-    SourceCitation,
     TableFact,
-    TextSpan,
     contract_to_dict,
 )
 
@@ -73,15 +72,10 @@ def build_contract_sample() -> dict:
         source_block_ids=(source_block.source_block_id,),
         diagnostics={"failure_type_guard": "table_relation_loss"},
     )
-    citation = SourceCitation(
-        citation_id="doc-sample:citation-001",
-        document_id="sample",
+    citation = build_source_citation(
+        source_block,
         source="sample.pdf",
-        page_label="PDF page 1",
-        source_block_id=source_block.source_block_id,
-        excerpt="Item A Value 10",
-        span=TextSpan(start=0, end=18),
-        confidence=0.95,
+        excerpt_chars=18,
     )
     selected_context = SelectedContext(
         context_id="doc-sample:context-001",
@@ -136,6 +130,10 @@ def main() -> None:
     assert decoded["source_block"]["section_id"] == decoded["section"]["section_id"]
     assert decoded["source_block"]["page_span"] == {"start": 1, "end": 2}
     assert decoded["source_block"]["bbox_span"] == [[0.0, 0.0, 100.0, 50.0]]
+    assert decoded["citation"]["source_block_id"] == decoded["source_block"]["source_block_id"]
+    assert decoded["citation"]["page_label"] == "pages 1-2"
+    assert decoded["citation"]["excerpt"] == "| Item | Value |\n|..."
+    assert decoded["citation"]["span"] == {"start": 0, "end": 18}
     assert decoded["retrieval_chunk"]["strategy"] == "section_prefixed_raw"
     assert decoded["retrieval_chunk"]["retrieval_text"].startswith(
         "Document > Table Section\n"

--- a/ai-server/main.py
+++ b/ai-server/main.py
@@ -24,6 +24,7 @@ from rag_contract_builders import (
     build_retrieval_chunk,
     build_section_node,
     build_source_block,
+    build_source_citation,
     section_path_component_is_suspect,
     section_path_quality,
     section_path_warnings,
@@ -3664,6 +3665,7 @@ def _text_role_trace_preview(
         "target_contract_roles": {
             "retrieval_text": "embedding_and_search",
             "source_raw_text": "source_citation_and_audit",
+            "source_citation": "user_visible_excerpt",
             "selected_context": "llm_prompt",
         },
     }
@@ -3685,6 +3687,11 @@ def _contract_trace_preview(chunk_id: str, doc: str, meta: dict, preview_chars: 
         source_block = build_source_block(
             parsed_block,
             section_id=section_node.section_id if section_node else None,
+        )
+        source_citation = build_source_citation(
+            source_block,
+            source=str(meta.get("source") or ""),
+            excerpt_chars=preview_chars,
         )
         retrieval_chunk = build_retrieval_chunk(
             parsed_block,
@@ -3719,6 +3726,15 @@ def _contract_trace_preview(chunk_id: str, doc: str, meta: dict, preview_chars: 
                 "retrieval_text_differs_from_raw": (
                     retrieval_chunk.retrieval_text != source_block.raw_text
                 ),
+            },
+            "source_citation": {
+                "citation_id": source_citation.citation_id,
+                "source_block_id": source_citation.source_block_id,
+                "source": source_citation.source,
+                "page_label": source_citation.page_label,
+                "excerpt_preview": _preview_text(source_citation.excerpt, preview_chars),
+                "excerpt_source": "source_block_raw_text",
+                "uses_retrieval_text": False,
             },
             "text_roles": _text_role_trace_preview(
                 stored_document_text=doc,

--- a/ai-server/rag_contract_builders.py
+++ b/ai-server/rag_contract_builders.py
@@ -18,7 +18,9 @@ from rag_contracts import (
     ParsedBlock,
     RetrievalChunk,
     SectionNode,
+    SourceCitation,
     SourceBlock,
+    TextSpan,
 )
 
 
@@ -73,6 +75,25 @@ def build_source_block(
         block_ids=(parsed_block.block_id,),
         bbox_span=bbox_span,
         section_id=section_id,
+    )
+
+
+def build_source_citation(
+    source_block: SourceBlock,
+    *,
+    source: str,
+    excerpt_chars: int = 200,
+) -> SourceCitation:
+    """Create a user-visible citation from SourceBlock raw text."""
+    excerpt, span = _source_excerpt(source_block.raw_text, excerpt_chars)
+    return SourceCitation(
+        citation_id=f"{source_block.source_block_id}:citation",
+        document_id=source_block.document_id,
+        source=source,
+        page_label=_page_label_from_span(source_block.page_span),
+        source_block_id=source_block.source_block_id,
+        excerpt=excerpt,
+        span=span,
     )
 
 
@@ -210,6 +231,28 @@ def _compose_retrieval_text(section_path: Sequence[str], raw_text: str) -> str:
     if raw_text.strip():
         text_parts.append(raw_text.strip())
     return "\n".join(text_parts)
+
+
+def _page_label_from_span(page_span: PageSpan | None) -> str:
+    if page_span is None or page_span.start is None:
+        return ""
+    if page_span.end is None or page_span.end == page_span.start:
+        return f"page {page_span.start}"
+    return f"pages {page_span.start}-{page_span.end}"
+
+
+def _source_excerpt(raw_text: str, max_chars: int) -> tuple[str, TextSpan | None]:
+    stripped = str(raw_text or "").strip()
+    if not stripped:
+        return "", None
+
+    limit = max(0, int(max_chars))
+    excerpt_body = stripped[:limit].rstrip() if limit else ""
+    excerpt = excerpt_body if len(stripped) <= limit else f"{excerpt_body}..."
+    start = str(raw_text).find(excerpt_body) if excerpt_body else 0
+    if start < 0:
+        start = 0
+    return excerpt, TextSpan(start=start, end=start + len(excerpt_body))
 
 
 def _bbox_from_metadata(metadata: Mapping[str, Any]) -> BBox | None:


### PR DESCRIPTION
### 관련 이슈
Related #73

### 작업 내용
- `SourceBlock.raw_text`에서 사용자 출처 표시용 `SourceCitation`을 만드는 `build_source_citation()` builder를 추가했습니다.
- `/debug/rag-trace`의 `contract_preview.source_citation`에 citation id, source block id, page label, raw excerpt preview를 표시합니다.
- contract smoke check가 citation의 source block 연결, page label, excerpt span JSON 직렬화를 검증하도록 보강했습니다.

### 리뷰 포인트
- `SourceCitation`이 `RetrievalChunk.retrieval_text`가 아니라 `SourceBlock.raw_text`에서만 만들어지는지 봐주세요.
- 이번 변경이 `/debug/rag-trace` preview에만 머물고 ChromaDB 저장값, 검색 순위, prompt, `/query` 응답을 바꾸지 않는지 봐주세요.

### 변경 파일
- `ai-server/rag_contract_builders.py`: `build_source_citation()` 및 page label/excerpt helper 추가
- `ai-server/main.py`: trace 전용 `contract_preview.source_citation` 추가
- `ai-server/check_rag_contracts.py`: SourceCitation smoke check 보강

### 확인한 내용
- `PYTHONPYCACHEPREFIX=/private/tmp/documind-pycache python3 -m py_compile ai-server/main.py ai-server/rag_contracts.py ai-server/rag_contract_builders.py ai-server/check_rag_contracts.py`: 통과
- `PYTHONPYCACHEPREFIX=/private/tmp/documind-pycache python3 ai-server/check_rag_contracts.py`: `rag_contracts smoke ok`
- `git diff --check`: 통과

### 비고
- GCP runtime 반영은 PR merge 후 최신 main 기준으로 rebuild/restart해서 확인할 예정입니다.
- 업로드, ChromaDB 저장 text/schema, embedding 입력, 검색 순위, LLM prompt, `/query` 응답은 변경하지 않았습니다.