### PR TITLE
[AI/RAG] SourceReference contract trace preview 추가

### DIFF
--- a/ai-server/check_rag_contracts.py
+++ b/ai-server/check_rag_contracts.py
@@ -81,7 +81,7 @@ def build_contract_sample() -> dict:
     source_reference = build_source_reference(
         source_block,
         lookup_id="sample_1",
-        metadata_keys=("source_block_id", "source_lookup_id"),
+        future_metadata_keys=("source_block_id", "source_lookup_id"),
     )
     selected_context = SelectedContext(
         context_id="doc-sample:context-001",
@@ -145,7 +145,8 @@ def main() -> None:
     assert decoded["source_reference"]["source_collection"] == "documents"
     assert decoded["source_reference"]["lookup_id"] == "sample_1"
     assert decoded["source_reference"]["runtime_connection"] == "trace_only"
-    assert decoded["source_reference"]["metadata_keys"] == [
+    assert decoded["source_reference"]["metadata_keys"] == []
+    assert decoded["source_reference"]["future_metadata_keys"] == [
         "source_block_id",
         "source_lookup_id",
     ]

--- a/ai-server/check_rag_contracts.py
+++ b/ai-server/check_rag_contracts.py
@@ -9,6 +9,7 @@ from rag_contract_builders import (
     build_retrieval_chunk,
     build_section_node,
     build_source_citation,
+    build_source_reference,
     build_source_block,
     section_path_component_is_suspect,
     section_path_quality,
@@ -77,6 +78,11 @@ def build_contract_sample() -> dict:
         source="sample.pdf",
         excerpt_chars=18,
     )
+    source_reference = build_source_reference(
+        source_block,
+        lookup_id="sample_1",
+        metadata_keys=("source_block_id", "source_lookup_id"),
+    )
     selected_context = SelectedContext(
         context_id="doc-sample:context-001",
         items=(
@@ -100,6 +106,7 @@ def build_contract_sample() -> dict:
         "table_fact": contract_to_dict(table_fact),
         "candidate": contract_to_dict(candidate),
         "citation": contract_to_dict(citation),
+        "source_reference": contract_to_dict(source_reference),
         "selected_context": contract_to_dict(selected_context),
     }
 
@@ -134,6 +141,14 @@ def main() -> None:
     assert decoded["citation"]["page_label"] == "pages 1-2"
     assert decoded["citation"]["excerpt"] == "| Item | Value |\n|..."
     assert decoded["citation"]["span"] == {"start": 0, "end": 18}
+    assert decoded["source_reference"]["source_block_id"] == decoded["source_block"]["source_block_id"]
+    assert decoded["source_reference"]["source_collection"] == "documents"
+    assert decoded["source_reference"]["lookup_id"] == "sample_1"
+    assert decoded["source_reference"]["runtime_connection"] == "trace_only"
+    assert decoded["source_reference"]["metadata_keys"] == [
+        "source_block_id",
+        "source_lookup_id",
+    ]
     assert decoded["retrieval_chunk"]["strategy"] == "section_prefixed_raw"
     assert decoded["retrieval_chunk"]["retrieval_text"].startswith(
         "Document > Table Section\n"

--- a/ai-server/main.py
+++ b/ai-server/main.py
@@ -25,6 +25,7 @@ from rag_contract_builders import (
     build_section_node,
     build_source_block,
     build_source_citation,
+    build_source_reference,
     section_path_component_is_suspect,
     section_path_quality,
     section_path_warnings,
@@ -3671,6 +3672,50 @@ def _text_role_trace_preview(
     }
 
 
+def _source_reference_trace_preview(chunk_id: str, meta: dict, source_block, retrieval_chunk) -> dict:
+    """Show how a retrieval candidate can look up raw source text later."""
+    chunk_role = str(meta.get("chunk_role") or "raw")
+    parent_chunk_id = str(meta.get("parent_chunk_id") or "").strip()
+    if chunk_role == "table_fact" and parent_chunk_id:
+        lookup_id = parent_chunk_id
+        lookup_strategy = "table_fact_parent_chunk_id"
+        metadata_keys = ("parent_chunk_id", "source_block_id", "source_lookup_id")
+    else:
+        lookup_id = str(chunk_id)
+        lookup_strategy = "current_chunk_id"
+        metadata_keys = ("source_block_id", "source_lookup_id")
+
+    source_reference = build_source_reference(
+        source_block,
+        lookup_id=lookup_id,
+        source_collection="documents",
+        lookup_strategy=lookup_strategy,
+        metadata_keys=metadata_keys,
+        notes=(
+            "current documents collection still stores shared runtime text",
+            "future retrieval index should keep this pointer before changing stored document text",
+        ),
+    )
+
+    return {
+        "runtime_connection": source_reference.runtime_connection,
+        "source_block_id": source_reference.source_block_id,
+        "source_collection": source_reference.source_collection,
+        "lookup_id": source_reference.lookup_id,
+        "lookup_strategy": source_reference.lookup_strategy,
+        "available_in_current_runtime": source_reference.available_in_current_runtime,
+        "metadata_keys": list(source_reference.metadata_keys),
+        "retrieval_chunk_source_block_ids": list(retrieval_chunk.source_block_ids),
+        "requires_lookup_before_retrieval_text_indexing": True,
+        "target_flow": [
+            "candidate_retrieval_chunk",
+            "source_reference",
+            "source_block_raw_text",
+            "source_citation",
+        ],
+    }
+
+
 def _contract_trace_preview(chunk_id: str, doc: str, meta: dict, preview_chars: int = 240) -> dict:
     """현재 trace 후보를 ParsedBlock/SourceBlock 진단 preview로 변환한다."""
     meta = meta or {}
@@ -3736,6 +3781,12 @@ def _contract_trace_preview(chunk_id: str, doc: str, meta: dict, preview_chars: 
                 "excerpt_source": "source_block_raw_text",
                 "uses_retrieval_text": False,
             },
+            "source_reference": _source_reference_trace_preview(
+                str(chunk_id),
+                meta,
+                source_block,
+                retrieval_chunk,
+            ),
             "text_roles": _text_role_trace_preview(
                 stored_document_text=doc,
                 source_raw_text=source_block.raw_text,

--- a/ai-server/main.py
+++ b/ai-server/main.py
@@ -3679,11 +3679,13 @@ def _source_reference_trace_preview(chunk_id: str, meta: dict, source_block, ret
     if chunk_role == "table_fact" and parent_chunk_id:
         lookup_id = parent_chunk_id
         lookup_strategy = "table_fact_parent_chunk_id"
-        metadata_keys = ("parent_chunk_id", "source_block_id", "source_lookup_id")
+        lookup_id_origin = "metadata.parent_chunk_id"
+        metadata_keys = ("parent_chunk_id",)
     else:
         lookup_id = str(chunk_id)
         lookup_strategy = "current_chunk_id"
-        metadata_keys = ("source_block_id", "source_lookup_id")
+        lookup_id_origin = "result_chunk_id"
+        metadata_keys = ()
 
     source_reference = build_source_reference(
         source_block,
@@ -3691,6 +3693,7 @@ def _source_reference_trace_preview(chunk_id: str, meta: dict, source_block, ret
         source_collection="documents",
         lookup_strategy=lookup_strategy,
         metadata_keys=metadata_keys,
+        future_metadata_keys=("source_block_id", "source_lookup_id"),
         notes=(
             "current documents collection still stores shared runtime text",
             "future retrieval index should keep this pointer before changing stored document text",
@@ -3703,8 +3706,10 @@ def _source_reference_trace_preview(chunk_id: str, meta: dict, source_block, ret
         "source_collection": source_reference.source_collection,
         "lookup_id": source_reference.lookup_id,
         "lookup_strategy": source_reference.lookup_strategy,
+        "lookup_id_origin": lookup_id_origin,
         "available_in_current_runtime": source_reference.available_in_current_runtime,
         "metadata_keys": list(source_reference.metadata_keys),
+        "future_metadata_keys": list(source_reference.future_metadata_keys),
         "retrieval_chunk_source_block_ids": list(retrieval_chunk.source_block_ids),
         "requires_lookup_before_retrieval_text_indexing": True,
         "target_flow": [

--- a/ai-server/rag_contract_builders.py
+++ b/ai-server/rag_contract_builders.py
@@ -107,6 +107,7 @@ def build_source_reference(
     runtime_connection: str = "trace_only",
     available_in_current_runtime: bool = True,
     metadata_keys: Sequence[str] = (),
+    future_metadata_keys: Sequence[str] = (),
     notes: Sequence[str] = (),
 ) -> SourceReference:
     """Create a lookup reference from a retrieval candidate to source raw text."""
@@ -119,6 +120,7 @@ def build_source_reference(
         runtime_connection=runtime_connection,
         available_in_current_runtime=available_in_current_runtime,
         metadata_keys=tuple(metadata_keys),
+        future_metadata_keys=tuple(future_metadata_keys),
         notes=tuple(notes),
     )
 

--- a/ai-server/rag_contract_builders.py
+++ b/ai-server/rag_contract_builders.py
@@ -20,6 +20,7 @@ from rag_contracts import (
     SectionNode,
     SourceCitation,
     SourceBlock,
+    SourceReference,
     TextSpan,
 )
 
@@ -94,6 +95,31 @@ def build_source_citation(
         source_block_id=source_block.source_block_id,
         excerpt=excerpt,
         span=span,
+    )
+
+
+def build_source_reference(
+    source_block: SourceBlock,
+    *,
+    lookup_id: str,
+    source_collection: str = "documents",
+    lookup_strategy: str = "current_chunk_id",
+    runtime_connection: str = "trace_only",
+    available_in_current_runtime: bool = True,
+    metadata_keys: Sequence[str] = (),
+    notes: Sequence[str] = (),
+) -> SourceReference:
+    """Create a lookup reference from a retrieval candidate to source raw text."""
+    return SourceReference(
+        source_block_id=source_block.source_block_id,
+        document_id=source_block.document_id,
+        source_collection=source_collection,
+        lookup_id=lookup_id,
+        lookup_strategy=lookup_strategy,
+        runtime_connection=runtime_connection,
+        available_in_current_runtime=available_in_current_runtime,
+        metadata_keys=tuple(metadata_keys),
+        notes=tuple(notes),
     )
 
 

--- a/ai-server/rag_contracts.py
+++ b/ai-server/rag_contracts.py
@@ -76,6 +76,21 @@ class SourceBlock:
 
 
 @dataclass(frozen=True)
+class SourceReference:
+    """A lookup pointer from retrieval candidates back to source raw text."""
+
+    source_block_id: str
+    document_id: str
+    source_collection: str
+    lookup_id: str
+    lookup_strategy: str
+    runtime_connection: str = "trace_only"
+    available_in_current_runtime: bool = True
+    metadata_keys: tuple[str, ...] = ()
+    notes: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
 class RetrievalChunk:
     """A text unit optimized for embedding and BM25 retrieval."""
 

--- a/ai-server/rag_contracts.py
+++ b/ai-server/rag_contracts.py
@@ -87,6 +87,7 @@ class SourceReference:
     runtime_connection: str = "trace_only"
     available_in_current_runtime: bool = True
     metadata_keys: tuple[str, ...] = ()
+    future_metadata_keys: tuple[str, ...] = ()
     notes: tuple[str, ...] = ()
 
 


### PR DESCRIPTION
### 관련 이슈
Related #73

### 작업 내용
- 검색 후보가 원문 `SourceBlock.raw_text`를 다시 찾기 위한 `SourceReference` contract를 추가했습니다.
- `/debug/rag-trace`의 `contract_preview.source_reference`에 source block id, source collection, lookup id, lookup strategy, metadata keys를 표시합니다.
- contract smoke check가 `SourceReference` JSON 직렬화와 source block 연결을 검증하도록 보강했습니다.

### 리뷰 포인트
- `SourceReference`가 실제 ChromaDB 저장값이나 query runtime을 바꾸지 않고 trace preview에만 머무는지 봐주세요.
- `RetrievalChunk`를 실제 indexing에 연결하기 전 필요한 source raw lookup 경계를 충분히 표현하는지 봐주세요.

### 변경 파일
- `ai-server/rag_contracts.py`: `SourceReference` dataclass 추가
- `ai-server/rag_contract_builders.py`: `build_source_reference()` 추가
- `ai-server/main.py`: trace 전용 `contract_preview.source_reference` 추가
- `ai-server/check_rag_contracts.py`: SourceReference smoke check 보강

### 확인한 내용
- `PYTHONPYCACHEPREFIX=/private/tmp/documind-pycache python3 -m py_compile ai-server/main.py ai-server/rag_contracts.py ai-server/rag_contract_builders.py ai-server/check_rag_contracts.py`: 통과
- `PYTHONPYCACHEPREFIX=/private/tmp/documind-pycache python3 ai-server/check_rag_contracts.py`: `rag_contracts smoke ok`
- `PYTHONPYCACHEPREFIX=/private/tmp/documind-pycache ai-server/venv/bin/python -c <_contract_trace_preview 직접 smoke>`: `trace_only sample_1 current_chunk_id True`
- `git diff --check`: 통과

### 비고
- GCP runtime 반영은 PR merge 후 최신 main 기준으로 rebuild/restart해서 확인할 예정입니다.
- 업로드, ChromaDB 저장 text/schema, embedding 입력, 검색 순위, BM25 cache, LLM prompt, `/query` 응답은 변경하지 않았습니다.