### PR TITLE
[AI/RAG] /query source preview를 SourceBlock 원문 기준으로 전환

### DIFF
--- a/ai-server/main.py
+++ b/ai-server/main.py
@@ -3608,17 +3608,42 @@ def _load_source_block_text(source_lookup_id: str) -> tuple[str | None, dict | N
     if not source_lookup_id:
         return None, None
 
-    try:
-        result = source_block_collection.get(ids=[source_lookup_id], include=["documents", "metadatas"])
-    except Exception:
-        logger.exception("[query_source] failed_to_load_source_block source_lookup_id=%s", source_lookup_id)
-        return None, None
+    loaded = _load_source_block_texts([source_lookup_id])
+    return loaded.get(source_lookup_id, (None, None))
 
+
+def _load_source_block_texts(source_lookup_ids: list[str]) -> dict[str, tuple[str, dict]]:
+    """source_blocks collection에서 사용자 출처용 원문 text를 batch 조회한다."""
+    unique_lookup_ids: list[str] = []
+    seen: set[str] = set()
+    for lookup_id in source_lookup_ids:
+        normalized_lookup_id = str(lookup_id or "").strip()
+        if normalized_lookup_id and normalized_lookup_id not in seen:
+            seen.add(normalized_lookup_id)
+            unique_lookup_ids.append(normalized_lookup_id)
+
+    if not unique_lookup_ids:
+        return {}
+
+    try:
+        result = source_block_collection.get(ids=unique_lookup_ids, include=["documents", "metadatas"])
+    except Exception:
+        logger.exception("[query_source] failed_to_load_source_blocks count=%s", len(unique_lookup_ids))
+        return {}
+
+    result_ids = result.get("ids") or []
     documents = result.get("documents") or []
     metadatas = result.get("metadatas") or []
-    if not documents:
-        return None, None
-    return str(documents[0] or ""), (metadatas[0] if metadatas else {})
+    if not result_ids and documents:
+        result_ids = unique_lookup_ids[:len(documents)]
+
+    loaded: dict[str, tuple[str, dict]] = {}
+    for index, lookup_id in enumerate(result_ids):
+        if index >= len(documents):
+            continue
+        metadata = metadatas[index] if index < len(metadatas) and metadatas[index] else {}
+        loaded[str(lookup_id)] = (str(documents[index] or ""), metadata)
+    return loaded
 
 
 def _fallback_source_preview_text(doc: str, meta: dict) -> str:
@@ -3637,11 +3662,19 @@ def _fallback_source_preview_text(doc: str, meta: dict) -> str:
     return str(doc)
 
 
-def _source_preview_content(doc: str, meta: dict, preview_chars: int = 200) -> str:
+def _source_preview_content(
+    doc: str,
+    meta: dict,
+    preview_chars: int = 200,
+    source_block_cache: dict[str, tuple[str, dict]] | None = None,
+) -> str:
     """사용자에게 보여줄 source preview를 검색용 doc이 아니라 SourceBlock 원문 기준으로 만든다."""
     source_lookup_id = str(meta.get("source_lookup_id") or "").strip()
     if source_lookup_id:
-        source_text, _ = _load_source_block_text(source_lookup_id)
+        if source_block_cache is None:
+            source_text, _ = _load_source_block_text(source_lookup_id)
+        else:
+            source_text, _ = source_block_cache.get(source_lookup_id, (None, None))
         if source_text:
             return source_text[:preview_chars]
 
@@ -4531,6 +4564,11 @@ def _prepare_query(question: str, top_k: int, system_prompt: str | None = None) 
     # 출처 목록 구성: document_id, source(파일명), 페이지, 청크 미리보기, 헤더 메타데이터 포함
     sources = []
     source_chars = [len(doc) for doc in docs]
+    source_lookup_ids = [
+        str((meta or {}).get("source_lookup_id") or "").strip()
+        for meta in metadatas
+    ]
+    source_block_cache = _load_source_block_texts(source_lookup_ids)
     for doc, meta, chunk_id in zip(docs, metadatas, ids):
         meta = meta or {}
         source: dict = {
@@ -4541,7 +4579,7 @@ def _prepare_query(question: str, top_k: int, system_prompt: str | None = None) 
             "page_end": meta.get("page_end"),
             "chunk_index": meta.get("chunk_index", _parse_chunk_index(chunk_id)),
             # 청크 전체를 반환하면 응답이 너무 커지므로 200자 미리보기만 포함
-            "content": _source_preview_content(doc, meta)
+            "content": _source_preview_content(doc, meta, source_block_cache=source_block_cache)
         }
         # MarkdownHeaderTextSplitter가 부여한 헤더 메타데이터(Header 1, Header 2 등)를 함께 반환
         for k, v in meta.items():

--- a/ai-server/main.py
+++ b/ai-server/main.py
@@ -3603,6 +3603,51 @@ def _load_parent_chunk(parent_chunk_id: str) -> tuple[str | None, dict | None]:
     return documents[0], (metadatas[0] if metadatas else {})
 
 
+def _load_source_block_text(source_lookup_id: str) -> tuple[str | None, dict | None]:
+    """source_blocks collection에서 사용자 출처용 원문 text를 조회한다."""
+    if not source_lookup_id:
+        return None, None
+
+    try:
+        result = source_block_collection.get(ids=[source_lookup_id], include=["documents", "metadatas"])
+    except Exception:
+        logger.exception("[query_source] failed_to_load_source_block source_lookup_id=%s", source_lookup_id)
+        return None, None
+
+    documents = result.get("documents") or []
+    metadatas = result.get("metadatas") or []
+    if not documents:
+        return None, None
+    return str(documents[0] or ""), (metadatas[0] if metadatas else {})
+
+
+def _fallback_source_preview_text(doc: str, meta: dict) -> str:
+    """source_blocks 조회 실패 시 기존 runtime text로 돌아가되 table_fact는 부모 원문을 우선한다."""
+    if meta.get("chunk_role") == "table_fact":
+        parent_content = str(meta.get("parent_content") or "").strip()
+        if parent_content:
+            return parent_content
+
+        parent_chunk_id = str(meta.get("parent_chunk_id") or "").strip()
+        if parent_chunk_id:
+            parent_doc, _ = _load_parent_chunk(parent_chunk_id)
+            if parent_doc:
+                return str(parent_doc)
+
+    return str(doc)
+
+
+def _source_preview_content(doc: str, meta: dict, preview_chars: int = 200) -> str:
+    """사용자에게 보여줄 source preview를 검색용 doc이 아니라 SourceBlock 원문 기준으로 만든다."""
+    source_lookup_id = str(meta.get("source_lookup_id") or "").strip()
+    if source_lookup_id:
+        source_text, _ = _load_source_block_text(source_lookup_id)
+        if source_text:
+            return source_text[:preview_chars]
+
+    return _fallback_source_preview_text(doc, meta)[:preview_chars]
+
+
 def _build_parent_metadata_from_fact(fact_meta: dict) -> dict:
     """table_fact metadata에서 사용자에게 노출할 부모 raw 청크 metadata를 복원한다."""
     parent_meta = dict(fact_meta or {})
@@ -4496,7 +4541,7 @@ def _prepare_query(question: str, top_k: int, system_prompt: str | None = None) 
             "page_end": meta.get("page_end"),
             "chunk_index": meta.get("chunk_index", _parse_chunk_index(chunk_id)),
             # 청크 전체를 반환하면 응답이 너무 커지므로 200자 미리보기만 포함
-            "content": doc[:200]
+            "content": _source_preview_content(doc, meta)
         }
         # MarkdownHeaderTextSplitter가 부여한 헤더 메타데이터(Header 1, Header 2 등)를 함께 반환
         for k, v in meta.items():


### PR DESCRIPTION
### 관련 이슈
Related #73

### 배경
- PR #85에서 원문 출처 조각을 `source_blocks` collection에 별도로 저장하는 경계를 만들었다.
- 기존 `/query` 응답의 `sources[].content`는 검색 후보 `doc[:200]`을 그대로 사용해, 검색용 text와 사용자 출처 preview가 계속 같은 문자열을 공유했다.
- RetrievalChunk 검색 text를 나중에 가공하더라도 사용자에게는 원문 기준 source preview를 보여주기 위해 `/query` source 생성 경로를 먼저 분리한다.

### 작업 내용
- `source_lookup_id`가 있는 후보는 `source_blocks` collection에서 raw source text를 조회해 `sources[].content`로 사용한다.
- `source_lookup_id`는 source 루프 전에 모아 한 번의 batch `get()`으로 조회하고, 루프에서는 cache를 사용한다.
- source block 조회 실패 시 기존 doc text로 fallback한다.
- `table_fact` 후보 fallback은 fact text 자체보다 `parent_content` 또는 `parent_chunk_id`로 읽은 부모 raw chunk를 우선 사용한다.
- `/query/stream`은 `_prepare_query()`를 공유하므로 완료 이벤트의 `sources` preview만 같은 효과를 받는다.

### 리뷰 포인트
- `_prepare_query()`에서 source preview만 바뀌고, 검색 순위와 LLM prompt context가 바뀌지 않는지 확인해 주세요.
- `source_blocks` 조회 실패나 기존 색인처럼 `source_lookup_id`가 없는 경우 fallback이 기존 동작을 유지하는지 확인해 주세요.
- `table_fact` 후보가 사용자 출처에 fact 문장만 노출하지 않고 부모 raw/source block을 우선하는지 확인해 주세요.

### 변경 파일
- `ai-server/main.py`: source block lookup helper와 source preview fallback helper를 추가하고, `sources[].content` 생성만 SourceBlock 원문 기준으로 전환

### 확인한 내용
- `PYTHONPYCACHEPREFIX=/private/tmp/documind-pycache python3 -m py_compile ai-server/main.py ai-server/rag_contracts.py ai-server/rag_contract_builders.py ai-server/check_rag_contracts.py`: 통과
- `PYTHONPYCACHEPREFIX=/private/tmp/documind-pycache python3 ai-server/check_rag_contracts.py`: 통과
- `ai-server/venv/bin/python` source preview helper smoke: 통과
- `ai-server/venv/bin/python` `_prepare_query()` source preview smoke: 통과
- `git diff --check`: 통과
- `git status --short --branch`: 확인

### 비고
- GCP runtime 검증은 로컬 shell에 `gcloud`가 없고 직접 SSH 22번 접속이 이전 세션에서 timeout이었으므로 PR 생성 전 자동 수행하지 않았다.
- 업로드 흐름, ChromaDB `documents` 저장 schema, 검색 순위, LLM prompt context, 답변 생성 로직은 변경하지 않았다.
- Codex review P2의 N+1 source block 조회 지적을 반영해 batch lookup으로 보완했다.
