### PR TITLE
[AI/RAG] SourceBlock source 관련 excerpt 선택

### DIFF
--- a/ai-server/main.py
+++ b/ai-server/main.py
@@ -3858,20 +3858,73 @@ def _load_source_block_texts(source_lookup_ids: list[str]) -> dict[str, tuple[st
     return loaded
 
 
-def _fallback_source_preview_text(doc: str, meta: dict) -> str:
+def _source_preview_evidence_texts(meta: dict) -> list[str]:
+    """source preview line 선택에 사용할 runtime evidence text를 모은다."""
+    evidence_texts: list[str] = []
+    evidence_texts.extend(_get_matched_table_facts(meta))
+    query_evidence_facts = meta.get("query_evidence_facts")
+    if isinstance(query_evidence_facts, list):
+        evidence_texts.extend(str(fact) for fact in query_evidence_facts)
+    elif query_evidence_facts:
+        evidence_texts.append(str(query_evidence_facts))
+    return evidence_texts
+
+
+def _source_preview_value_terms(meta: dict) -> set[str]:
+    """금액/수치처럼 사용자가 확인하려는 값을 먼저 찾기 위한 term 후보를 만든다."""
+    terms: set[str] = set()
+    for text in _source_preview_evidence_texts(meta):
+        for token in re.findall(r"[0-9][0-9,]*(?:원|만원|명|점|%)?", text):
+            normalized_token = token.strip().lower()
+            if len(normalized_token) >= 2:
+                terms.add(normalized_token)
+    return terms
+
+
+def _source_preview_candidate_terms(meta: dict, analysis: QueryAnalysis | None) -> set[str]:
+    """SourceBlock raw text에서 사용자에게 보여줄 관련 line을 찾기 위한 term 후보를 만든다."""
+    terms: set[str] = set()
+    if analysis is not None:
+        terms.update(analysis.primary_terms)
+        terms.update(analysis.context_terms)
+        terms.update(analysis.subject_terms)
+
+    for text in _source_preview_evidence_texts(meta):
+        for token in re.findall(r"[0-9][0-9,]*(?:원|만원|명|점|%)?|[A-Za-z가-힣]{2,}", text):
+            normalized_token = token.strip().lower()
+            if len(normalized_token) >= 2:
+                terms.add(normalized_token)
+    return terms
+
+
+def _source_relevant_excerpt(text: str, meta: dict, analysis: QueryAnalysis | None, preview_chars: int) -> str:
+    """SourceBlock raw text 안에서 질문/근거와 가까운 원문 excerpt를 고른다."""
+    value_terms = _source_preview_value_terms(meta)
+    value_excerpt = _select_relevant_excerpt(text, value_terms, window=2, max_lines=8)
+    if value_excerpt:
+        return value_excerpt[:preview_chars]
+
+    terms = _source_preview_candidate_terms(meta, analysis)
+    excerpt = _select_relevant_excerpt(text, terms, window=2, max_lines=8)
+    if excerpt:
+        return excerpt[:preview_chars]
+    return str(text)[:preview_chars]
+
+
+def _fallback_source_preview_text(doc: str, meta: dict, analysis: QueryAnalysis | None = None, preview_chars: int = 200) -> str:
     """source_blocks 조회 실패 시 기존 runtime text로 돌아가되 table_fact는 부모 원문을 우선한다."""
     if meta.get("chunk_role") == "table_fact":
         parent_content = str(meta.get("parent_content") or "").strip()
         if parent_content:
-            return parent_content
+            return _source_relevant_excerpt(parent_content, meta, analysis, preview_chars)
 
         parent_chunk_id = str(meta.get("parent_chunk_id") or "").strip()
         if parent_chunk_id:
             parent_doc, _ = _load_parent_chunk(parent_chunk_id)
             if parent_doc:
-                return str(parent_doc)
+                return _source_relevant_excerpt(str(parent_doc), meta, analysis, preview_chars)
 
-    return str(doc)
+    return _source_relevant_excerpt(str(doc), meta, analysis, preview_chars)
 
 
 def _source_preview_content(
@@ -3879,6 +3932,7 @@ def _source_preview_content(
     meta: dict,
     preview_chars: int = 200,
     source_block_cache: dict[str, tuple[str, dict]] | None = None,
+    analysis: QueryAnalysis | None = None,
 ) -> str:
     """사용자에게 보여줄 source preview를 검색용 doc이 아니라 SourceBlock 원문 기준으로 만든다."""
     source_lookup_id = str(meta.get("source_lookup_id") or "").strip()
@@ -3888,9 +3942,9 @@ def _source_preview_content(
         else:
             source_text, _ = source_block_cache.get(source_lookup_id, (None, None))
         if source_text:
-            return source_text[:preview_chars]
+            return _source_relevant_excerpt(source_text, meta, analysis, preview_chars)
 
-    return _fallback_source_preview_text(doc, meta)[:preview_chars]
+    return _fallback_source_preview_text(doc, meta, analysis, preview_chars)
 
 
 def _build_parent_metadata_from_fact(fact_meta: dict) -> dict:
@@ -5048,7 +5102,7 @@ def _prepare_query(question: str, top_k: int, system_prompt: str | None = None) 
             "page_end": meta.get("page_end"),
             "chunk_index": meta.get("chunk_index", _parse_chunk_index(chunk_id)),
             # 청크 전체를 반환하면 응답이 너무 커지므로 200자 미리보기만 포함
-            "content": _source_preview_content(doc, meta, source_block_cache=source_block_cache)
+            "content": _source_preview_content(doc, meta, source_block_cache=source_block_cache, analysis=analysis)
         }
         # MarkdownHeaderTextSplitter가 부여한 헤더 메타데이터(Header 1, Header 2 등)를 함께 반환
         for k, v in meta.items():


### PR DESCRIPTION
### 관련 이슈
Related #73

### 작업 내용
- `/query sources[].content`가 SourceBlock raw text의 첫 200자만 반환하지 않고, 질문/근거와 가까운 raw line excerpt를 우선 반환하도록 개선합니다.
- `matched_table_facts`, `query_evidence_facts`에서 금액/수치 term을 먼저 추출해 SourceBlock raw text 안에서 실제 원문 line을 찾습니다.
- 값 term으로 찾지 못하면 질문 subject/context term 기준으로 raw line을 찾고, 그래도 없으면 기존 first excerpt로 fallback합니다.

### 리뷰 포인트
- synthetic table_fact text를 사용자 source로 직접 반환하지 않고 SourceBlock raw text 안의 line만 반환하는지 확인 부탁드립니다.
- 검색 순위, prompt context, 답변 생성 로직이 바뀌지 않는지 확인 부탁드립니다.
- 관련 line을 못 찾는 경우 기존 first excerpt fallback이 유지되는지 확인 부탁드립니다.

### 변경 파일
- `ai-server/main.py`: source preview 관련 term 추출과 SourceBlock raw relevant excerpt 선택

### 확인한 내용
- `PYTHONPYCACHEPREFIX=/private/tmp/documind-pycache python3 -m py_compile ai-server/main.py ai-server/rag_contracts.py ai-server/rag_contract_builders.py ai-server/check_rag_contracts.py`: 통과
- `PYTHONPYCACHEPREFIX=/private/tmp/documind-pycache python3 ai-server/check_rag_contracts.py`: 통과
- SourceBlock raw relevant excerpt smoke: 통과
- `_prepare_query()` source relevant excerpt smoke: 통과
- `git diff --check`: 통과

### 비고
- GCP runtime 검증은 PR 생성 후 Web SSH에서 `원서 접수 비용` source preview가 `전형료`, `30,000원` 주변 원문 line을 보여주는지 확인합니다.
- 이번 PR은 #73의 하위 단계라 issue 전체를 닫지 않습니다.