### PR TITLE
[AI/RAG] 비용 표 근거를 답변 context에 반영

### DIFF
--- a/ai-server/main.py
+++ b/ai-server/main.py
@@ -2175,12 +2175,10 @@ QUERY_TERM_SYNONYMS = {
     "방법": {"방법", "절차", "신청", "신청절차", "제출"},
     "주의사항": {"주의사항", "유의사항", "유의", "주의"},
     "전과": {"전과", "전과제도", "전과시행"},
-    "비용": {"비용", "금액", "요금", "가격", "전형료", "면접고사료"},
-    "금액": {"금액", "비용", "요금", "가격", "전형료", "면접고사료"},
-    "요금": {"요금", "비용", "금액", "가격", "전형료", "면접고사료"},
-    "가격": {"가격", "비용", "금액", "요금", "전형료", "면접고사료"},
-    "전형료": {"전형료", "비용", "금액", "요금"},
-    "면접고사료": {"면접고사료", "면접료", "비용", "금액", "요금"},
+    "비용": {"비용", "금액", "요금", "가격"},
+    "금액": {"금액", "비용", "요금", "가격"},
+    "요금": {"요금", "비용", "금액", "가격"},
+    "가격": {"가격", "비용", "금액", "요금"},
     "모집": {"모집", "모집인원", "모집정원", "정원"},
     "인원": {"인원", "모집인원", "모집정원", "정원"},
     "정원": {"정원", "모집인원", "모집정원", "인원"},
@@ -2208,7 +2206,6 @@ QUERY_TABLE_INTENT_TERMS = {
     "값", "수치", "공식", "수식", "상수", "계수", "인원", "정원", "모집", "모집인원", "모집정원",
     "점수", "가산점", "등급", "기간", "날짜", "일정", "서류", "자격", "학과", "과목", "항목",
     "복장", "상의", "하의", "신발", "비용", "금액", "얼마", "요금", "가격", "납부", "원", "무료",
-    "전형료", "면접고사료", "면접료",
 }
 QUERY_LIST_COLLECTION_TERMS = {"학과", "과목", "서류", "시설", "항목", "종류", "전형", "대상"}
 QUERY_COLLECTION_WHERE_TERMS = {"학과", "과목", "서류", "항목", "종류", "전형", "대상"}
@@ -2227,7 +2224,7 @@ INTENT_QUERY_TERMS = {
     "list": {"무엇", "뭐", "무슨", "어떤", "목록", "종류", "있어", "있나요", "있습니까", "포함"},
     "location": {"어디", "위치", "장소", "주소", "소재지", "몇층", "층", "호관", "찾아오"},
     "time": {"시간", "이용시간", "운영시간", "언제", "몇시", "기간", "평일", "주말", "공휴일", "방학"},
-    "cost": {"비용", "금액", "얼마", "요금", "가격", "납부", "원", "무료", "전형료", "면접고사료", "면접료"},
+    "cost": {"비용", "금액", "얼마", "요금", "가격", "납부", "원", "무료"},
     "attire": {"복장", "옷", "상의", "하의", "신발", "티셔츠", "스타킹", "단화"},
     "documents": {"서류", "제출서류", "증빙", "첨부", "제출", "준비물"},
     "eligibility": {"자격", "지원자격", "대상", "조건", "요건"},
@@ -2240,7 +2237,7 @@ INTENT_EVIDENCE_TERMS = {
     "list": {"시설", "목록", "종류", "항목", "포함", "운영", "이용"},
     "location": {"위치", "장소", "주소", "소재지", "호관", "층", "도로", "길", "정문", "후문", "옆", "앞", "뒤", "내", "근처", "캠퍼스"},
     "time": {"시간", "이용", "이용시간", "운영시간", "기간", "평일", "주말", "공휴일", "방학", "중식", "휴무", "운영"},
-    "cost": {"비용", "금액", "요금", "가격", "납부", "원", "무료", "환불", "전형료", "면접고사료", "면접료", "계"},
+    "cost": {"비용", "금액", "요금", "가격", "납부", "원", "무료", "환불"},
     "attire": {"복장", "수험생", "상의", "하의", "신발", "티셔츠", "스타킹", "단화", "바지", "스커트"},
     "documents": {"서류", "제출서류", "증빙", "첨부", "제출", "발급", "원본", "사본"},
     "eligibility": {"자격", "대상", "조건", "요건", "해당자", "지원"},
@@ -2307,6 +2304,7 @@ INTENT_DEFAULT_LABELS = {
 }
 TABLE_BRIDGE_CONTEXT_LABEL_TERMS = ("면접", "정시", "수시1차", "수시2차", "수시")
 TABLE_FACT_LABEL_KEYS = {"구분", "분류", "유형"}
+MONEY_VALUE_PATTERN = re.compile(r"\d[\d,]*(?:\s*)(?:원|만원|천원|억원|조원)")
 
 
 @dataclass(frozen=True)
@@ -2496,12 +2494,16 @@ def _score_table_fact_for_question(fact: str, question: str) -> int:
     """질문과 table_fact의 lexical 관련도를 계산한다."""
     fact_lower = fact.lower()
     subject_terms, intent_terms = _extract_lexical_query_terms(question)
-    if subject_terms and not any(_term_in_text(term, fact) for term in subject_terms):
+    asks_cost_value = bool(intent_terms & INTENT_QUERY_TERMS["cost"])
+    has_money_value = bool(MONEY_VALUE_PATTERN.search(fact))
+    if subject_terms and not any(_term_in_text(term, fact) for term in subject_terms) and not asks_cost_value:
         return 0
 
     score = 0
     score += sum(12 for term in subject_terms if _term_in_text(term, fact))
     score += sum(4 for term in intent_terms if _term_in_text(term, fact))
+    if asks_cost_value and has_money_value:
+        score += 24
 
     asks_count_value = bool(intent_terms & {"모집", "인원", "정원", "모집인원", "모집정원"})
     has_primary_count_column = bool(re.search(r"(모집\s*정원|모집정원|합계|총|전체|total)\s*=", fact_lower))
@@ -2516,8 +2518,7 @@ def _score_table_fact_for_question(fact: str, question: str) -> int:
 def _lookup_lexical_table_fact_candidates(question: str, limit: int = 5) -> list[dict]:
     """표 질의에서 벡터 검색이 놓치는 table_fact 후보를 score와 함께 찾는다."""
     subject_terms, intent_terms = _extract_lexical_query_terms(question)
-    subjectless_cost_query = bool(intent_terms & INTENT_QUERY_TERMS["cost"])
-    if not intent_terms or (not subject_terms and not subjectless_cost_query):
+    if not subject_terms or not intent_terms:
         return []
 
     try:
@@ -3015,13 +3016,20 @@ def _table_fact_matches_query_attribute(fact: str, analysis: QueryAnalysis) -> b
     return False
 
 
-def _is_table_label_pair(key: str, value: str, analysis: QueryAnalysis) -> bool:
-    """표의 구분/분류용 셀처럼 답변값으로 쓰면 안 되는 pair를 제외한다."""
+def _is_table_label_key(key: str) -> bool:
+    """표의 구분/분류용 column인지 판단한다."""
     normalized_key = re.sub(r"\s+", "", key.lower())
-    normalized_value = re.sub(r"\s+", "", value.lower())
     if normalized_key in TABLE_FACT_LABEL_KEYS:
         return True
     if normalized_key.endswith("구분"):
+        return True
+    return False
+
+
+def _is_table_label_pair(key: str, value: str, analysis: QueryAnalysis) -> bool:
+    """표의 구분/분류용 셀처럼 답변값으로 쓰면 안 되는 pair를 제외한다."""
+    normalized_value = re.sub(r"\s+", "", value.lower())
+    if _is_table_label_key(key):
         return True
     if normalized_value in {"수시", "정시", "수시1차", "수시2차"}:
         return True
@@ -3169,6 +3177,30 @@ def _derive_table_legend_list_evidence_facts(facts: list[str], analysis: QueryAn
     return evidence_facts
 
 
+def _derive_cost_table_evidence_facts(facts: list[str]) -> list[str]:
+    """금액 값이 들어 있는 표 행을 column label과 함께 직접 근거로 만든다."""
+    evidence_facts: list[str] = []
+    seen_facts: set[str] = set()
+    for fact in facts:
+        subject = _extract_table_fact_row_subject(fact)
+        cost_pairs: list[str] = []
+        for key, value in _extract_table_fact_pairs(fact):
+            if not value or _is_table_label_key(key):
+                continue
+            if MONEY_VALUE_PATTERN.search(value) or "무료" in value:
+                cost_pairs.append(f"{key} {value}")
+
+        if not subject or not cost_pairs:
+            continue
+
+        evidence_fact = f"- {subject}: {'; '.join(cost_pairs)}"
+        if evidence_fact in seen_facts:
+            continue
+        seen_facts.add(evidence_fact)
+        evidence_facts.append(evidence_fact)
+    return evidence_facts
+
+
 def _derive_query_table_evidence_facts(facts: list[str], analysis: QueryAnalysis) -> list[str]:
     """같은 표 안의 subject 행과 속성 행을 조합해 질문에 직접 답하는 fact를 만든다."""
     if analysis.intent not in TABLE_BRIDGE_EVIDENCE_INTENTS or not facts:
@@ -3178,10 +3210,11 @@ def _derive_query_table_evidence_facts(facts: list[str], analysis: QueryAnalysis
     if legend_list_evidence:
         return legend_list_evidence
 
+    if analysis.intent == "cost":
+        return _derive_cost_table_evidence_facts(facts)
+
     subject_related = any(_subject_strongly_matches_text(fact, analysis) for fact in facts)
-    # 비용 질문은 "원서 접수 비용"처럼 subject가 표 행 이름이 아니라 표 제목/속성으로 표현될 수 있다.
-    # 이때는 비용 intent가 직접 맞는 행 fact만 아래 attribute_facts 단계에서 보수적으로 고른다.
-    if not subject_related and analysis.intent != "cost":
+    if not subject_related:
         return []
 
     attribute_facts = []

--- a/ai-server/main.py
+++ b/ai-server/main.py
@@ -2175,10 +2175,6 @@ QUERY_TERM_SYNONYMS = {
     "방법": {"방법", "절차", "신청", "신청절차", "제출"},
     "주의사항": {"주의사항", "유의사항", "유의", "주의"},
     "전과": {"전과", "전과제도", "전과시행"},
-    "비용": {"비용", "금액", "요금", "가격"},
-    "금액": {"금액", "비용", "요금", "가격"},
-    "요금": {"요금", "비용", "금액", "가격"},
-    "가격": {"가격", "비용", "금액", "요금"},
     "모집": {"모집", "모집인원", "모집정원", "정원"},
     "인원": {"인원", "모집인원", "모집정원", "정원"},
     "정원": {"정원", "모집인원", "모집정원", "인원"},
@@ -2205,7 +2201,7 @@ QUERY_WEAK_SUBJECT_TERMS = {
 QUERY_TABLE_INTENT_TERMS = {
     "값", "수치", "공식", "수식", "상수", "계수", "인원", "정원", "모집", "모집인원", "모집정원",
     "점수", "가산점", "등급", "기간", "날짜", "일정", "서류", "자격", "학과", "과목", "항목",
-    "복장", "상의", "하의", "신발", "비용", "금액", "얼마", "요금", "가격", "납부", "원", "무료",
+    "복장", "상의", "하의", "신발",
 }
 QUERY_LIST_COLLECTION_TERMS = {"학과", "과목", "서류", "시설", "항목", "종류", "전형", "대상"}
 QUERY_COLLECTION_WHERE_TERMS = {"학과", "과목", "서류", "항목", "종류", "전형", "대상"}
@@ -2469,16 +2465,23 @@ def _extract_lexical_query_terms(question: str) -> tuple[set[str], set[str]]:
     subject_terms: set[str] = set()
     intent_terms: set[str] = set()
     normalized_question = _compact_search_text(question)
+    raw_tokens = [token.strip().lower() for token in re.findall(r"[0-9A-Za-z가-힣]+", question)]
+    normalized_tokens = [_normalize_query_token(token) for token in raw_tokens]
+    detected_intent = _detect_query_intent(
+        question,
+        [token for token in normalized_tokens if len(token) >= 2],
+    )
+    table_intent_terms = set(QUERY_TABLE_INTENT_TERMS)
+    if detected_intent:
+        table_intent_terms.update(INTENT_QUERY_TERMS.get(detected_intent, set()))
 
-    for token in re.findall(r"[0-9A-Za-z가-힣]+", question):
-        raw_token = token.strip().lower()
-        normalized = _normalize_query_token(raw_token)
-        if len(normalized) < 2 and normalized not in QUERY_TABLE_INTENT_TERMS:
+    for raw_token, normalized in zip(raw_tokens, normalized_tokens):
+        if len(normalized) < 2 and normalized not in table_intent_terms:
             continue
 
         expanded_terms = {raw_token, normalized}
         expanded_terms.update(QUERY_TERM_SYNONYMS.get(normalized, set()))
-        if expanded_terms & QUERY_TABLE_INTENT_TERMS:
+        if expanded_terms & table_intent_terms:
             intent_terms.update(term for term in expanded_terms if len(term) >= 2)
         else:
             subject_terms.update(term for term in expanded_terms if len(term) >= 3 and term not in QUERY_GENERIC_TERMS)
@@ -3177,7 +3180,7 @@ def _derive_table_legend_list_evidence_facts(facts: list[str], analysis: QueryAn
     return evidence_facts
 
 
-def _derive_cost_table_evidence_facts(facts: list[str]) -> list[str]:
+def _derive_money_table_evidence_facts(facts: list[str]) -> list[str]:
     """금액 값이 들어 있는 표 행을 column label과 함께 직접 근거로 만든다."""
     evidence_facts: list[str] = []
     seen_facts: set[str] = set()
@@ -3211,7 +3214,7 @@ def _derive_query_table_evidence_facts(facts: list[str], analysis: QueryAnalysis
         return legend_list_evidence
 
     if analysis.intent == "cost":
-        return _derive_cost_table_evidence_facts(facts)
+        return _derive_money_table_evidence_facts(facts)
 
     subject_related = any(_subject_strongly_matches_text(fact, analysis) for fact in facts)
     if not subject_related:

--- a/ai-server/main.py
+++ b/ai-server/main.py
@@ -2300,7 +2300,7 @@ INTENT_DEFAULT_LABELS = {
 }
 TABLE_BRIDGE_CONTEXT_LABEL_TERMS = ("면접", "정시", "수시1차", "수시2차", "수시")
 TABLE_FACT_LABEL_KEYS = {"구분", "분류", "유형"}
-MONEY_VALUE_PATTERN = re.compile(r"\d[\d,]*(?:\s*)(?:원|만원|천원|억원|조원)")
+MONEY_VALUE_PATTERN = re.compile(r"\d[\d,]*(?:\.\d+)?\s*(?:(?:천|만|억|조)\s*)?원")
 
 
 @dataclass(frozen=True)
@@ -2493,14 +2493,16 @@ def _extract_lexical_query_terms(question: str) -> tuple[set[str], set[str]]:
     return subject_terms, intent_terms
 
 
-def _score_table_fact_for_question(fact: str, question: str) -> int:
+def _score_table_fact_for_question(fact: str, question: str, allow_cost_subject_fallback: bool = False) -> int:
     """질문과 table_fact의 lexical 관련도를 계산한다."""
     fact_lower = fact.lower()
     subject_terms, intent_terms = _extract_lexical_query_terms(question)
     asks_cost_value = bool(intent_terms & INTENT_QUERY_TERMS["cost"])
     has_money_value = bool(MONEY_VALUE_PATTERN.search(fact))
-    if subject_terms and not any(_term_in_text(term, fact) for term in subject_terms) and not asks_cost_value:
-        return 0
+    subject_matches = any(_term_in_text(term, fact) for term in subject_terms)
+    if subject_terms and not subject_matches:
+        if not (allow_cost_subject_fallback and asks_cost_value and has_money_value):
+            return 0
 
     score = 0
     score += sum(12 for term in subject_terms if _term_in_text(term, fact))
@@ -3262,14 +3264,24 @@ def _attach_runtime_table_facts(question: str, docs: list[str], metadatas: list[
             continue
 
         extracted_facts = _extract_table_facts(doc, runtime_meta)
+        allow_cost_subject_fallback = (
+            analysis is not None
+            and _allow_cost_table_subject_fallback(doc, runtime_meta, analysis)
+        )
         if analysis is not None:
-            bridge_source_facts = _get_matched_table_facts(runtime_meta) + extracted_facts
-            for evidence_fact in _derive_query_table_evidence_facts(bridge_source_facts, analysis):
-                runtime_meta = _append_query_evidence_fact(runtime_meta, evidence_fact)
+            can_extract_evidence = analysis.intent != "cost" or allow_cost_subject_fallback
+            if can_extract_evidence:
+                bridge_source_facts = _get_matched_table_facts(runtime_meta) + extracted_facts
+                for evidence_fact in _derive_query_table_evidence_facts(bridge_source_facts, analysis):
+                    runtime_meta = _append_query_evidence_fact(runtime_meta, evidence_fact)
 
         scored_facts: list[tuple[int, str]] = []
         for fact in extracted_facts:
-            score = _score_table_fact_for_question(fact, question)
+            score = _score_table_fact_for_question(
+                fact,
+                question,
+                allow_cost_subject_fallback=allow_cost_subject_fallback,
+            )
             if score > 0:
                 scored_facts.append((score, fact))
 
@@ -3285,6 +3297,15 @@ def _best_runtime_table_fact_score(meta: dict, question: str) -> int:
     """runtime metadata에 붙은 table_fact 중 질문과 가장 관련 높은 점수를 반환한다."""
     facts = _get_matched_table_facts(meta)
     return max((_score_table_fact_for_question(fact, question) for fact in facts), default=0)
+
+
+def _allow_cost_table_subject_fallback(doc: str, meta: dict, analysis: QueryAnalysis) -> bool:
+    """비용 표 fallback은 parent raw chunk가 질문 subject를 담고 있을 때만 허용한다."""
+    if analysis.intent != "cost":
+        return False
+    if not analysis.subject_terms and not analysis.primary_terms:
+        return True
+    return _subject_matches_text(_build_sparse_search_text(doc, meta or {}), analysis)
 
 
 def _score_subject_match(text: str, analysis: QueryAnalysis) -> int:

--- a/ai-server/main.py
+++ b/ai-server/main.py
@@ -2175,6 +2175,12 @@ QUERY_TERM_SYNONYMS = {
     "방법": {"방법", "절차", "신청", "신청절차", "제출"},
     "주의사항": {"주의사항", "유의사항", "유의", "주의"},
     "전과": {"전과", "전과제도", "전과시행"},
+    "비용": {"비용", "금액", "요금", "가격", "전형료", "면접고사료"},
+    "금액": {"금액", "비용", "요금", "가격", "전형료", "면접고사료"},
+    "요금": {"요금", "비용", "금액", "가격", "전형료", "면접고사료"},
+    "가격": {"가격", "비용", "금액", "요금", "전형료", "면접고사료"},
+    "전형료": {"전형료", "비용", "금액", "요금"},
+    "면접고사료": {"면접고사료", "면접료", "비용", "금액", "요금"},
     "모집": {"모집", "모집인원", "모집정원", "정원"},
     "인원": {"인원", "모집인원", "모집정원", "정원"},
     "정원": {"정원", "모집인원", "모집정원", "인원"},
@@ -2201,7 +2207,8 @@ QUERY_WEAK_SUBJECT_TERMS = {
 QUERY_TABLE_INTENT_TERMS = {
     "값", "수치", "공식", "수식", "상수", "계수", "인원", "정원", "모집", "모집인원", "모집정원",
     "점수", "가산점", "등급", "기간", "날짜", "일정", "서류", "자격", "학과", "과목", "항목",
-    "복장", "상의", "하의", "신발",
+    "복장", "상의", "하의", "신발", "비용", "금액", "얼마", "요금", "가격", "납부", "원", "무료",
+    "전형료", "면접고사료", "면접료",
 }
 QUERY_LIST_COLLECTION_TERMS = {"학과", "과목", "서류", "시설", "항목", "종류", "전형", "대상"}
 QUERY_COLLECTION_WHERE_TERMS = {"학과", "과목", "서류", "항목", "종류", "전형", "대상"}
@@ -2220,7 +2227,7 @@ INTENT_QUERY_TERMS = {
     "list": {"무엇", "뭐", "무슨", "어떤", "목록", "종류", "있어", "있나요", "있습니까", "포함"},
     "location": {"어디", "위치", "장소", "주소", "소재지", "몇층", "층", "호관", "찾아오"},
     "time": {"시간", "이용시간", "운영시간", "언제", "몇시", "기간", "평일", "주말", "공휴일", "방학"},
-    "cost": {"비용", "금액", "얼마", "요금", "가격", "납부", "원", "무료"},
+    "cost": {"비용", "금액", "얼마", "요금", "가격", "납부", "원", "무료", "전형료", "면접고사료", "면접료"},
     "attire": {"복장", "옷", "상의", "하의", "신발", "티셔츠", "스타킹", "단화"},
     "documents": {"서류", "제출서류", "증빙", "첨부", "제출", "준비물"},
     "eligibility": {"자격", "지원자격", "대상", "조건", "요건"},
@@ -2233,7 +2240,7 @@ INTENT_EVIDENCE_TERMS = {
     "list": {"시설", "목록", "종류", "항목", "포함", "운영", "이용"},
     "location": {"위치", "장소", "주소", "소재지", "호관", "층", "도로", "길", "정문", "후문", "옆", "앞", "뒤", "내", "근처", "캠퍼스"},
     "time": {"시간", "이용", "이용시간", "운영시간", "기간", "평일", "주말", "공휴일", "방학", "중식", "휴무", "운영"},
-    "cost": {"비용", "금액", "요금", "가격", "납부", "원", "무료", "환불"},
+    "cost": {"비용", "금액", "요금", "가격", "납부", "원", "무료", "환불", "전형료", "면접고사료", "면접료", "계"},
     "attire": {"복장", "수험생", "상의", "하의", "신발", "티셔츠", "스타킹", "단화", "바지", "스커트"},
     "documents": {"서류", "제출서류", "증빙", "첨부", "제출", "발급", "원본", "사본"},
     "eligibility": {"자격", "대상", "조건", "요건", "해당자", "지원"},
@@ -2387,6 +2394,7 @@ def _normalize_query_token(token: str) -> str:
     """조사와 어미가 붙은 질문 token을 검색 발췌용 핵심어로 정리한다."""
     normalized = token.strip().lower()
     for suffix in (
+        "인가요", "입니까", "이에요", "예요", "인가", "인지", "이야",
         "에게는", "한테는", "에서는", "으로는", "로는", "에는",
         "으로", "에서", "에게", "한테", "부터", "까지",
         "은", "는", "이", "가", "을", "를", "의", "도", "만", "와", "과", "에", "로",
@@ -2508,7 +2516,8 @@ def _score_table_fact_for_question(fact: str, question: str) -> int:
 def _lookup_lexical_table_fact_candidates(question: str, limit: int = 5) -> list[dict]:
     """표 질의에서 벡터 검색이 놓치는 table_fact 후보를 score와 함께 찾는다."""
     subject_terms, intent_terms = _extract_lexical_query_terms(question)
-    if not subject_terms or not intent_terms:
+    subjectless_cost_query = bool(intent_terms & INTENT_QUERY_TERMS["cost"])
+    if not intent_terms or (not subject_terms and not subjectless_cost_query):
         return []
 
     try:
@@ -3170,14 +3179,19 @@ def _derive_query_table_evidence_facts(facts: list[str], analysis: QueryAnalysis
         return legend_list_evidence
 
     subject_related = any(_subject_strongly_matches_text(fact, analysis) for fact in facts)
-    if not subject_related:
+    # 비용 질문은 "원서 접수 비용"처럼 subject가 표 행 이름이 아니라 표 제목/속성으로 표현될 수 있다.
+    # 이때는 비용 intent가 직접 맞는 행 fact만 아래 attribute_facts 단계에서 보수적으로 고른다.
+    if not subject_related and analysis.intent != "cost":
         return []
 
     attribute_facts = []
     for fact in facts:
         if not _table_fact_matches_query_attribute(fact, analysis):
             continue
-        if analysis.intent in TABLE_DIRECT_ROW_ATTRIBUTE_INTENTS and not _subject_strongly_matches_text(fact, analysis):
+        if (
+            analysis.intent in TABLE_DIRECT_ROW_ATTRIBUTE_INTENTS
+            and not _subject_strongly_matches_text(fact, analysis)
+        ):
             continue
         attribute_facts.append(fact)
     if not attribute_facts:


### PR DESCRIPTION
### 관련 이슈
Related #73

### 배경
- PR #89/#90 이후 `/query` source preview는 원서 접수 비용 표와 `30,000원`, `50,000원`을 정확히 보여준다.
- 하지만 실제 answer는 `정확한 금액은 명시되지 않았다`고 답해, source preview가 아니라 LLM prompt context의 table evidence 전달이 문제로 남았다.
- 단순히 `전형료`, `면접고사료`를 동의어로 추가하면 다음 문서의 `응시료`, `수수료`, `검정료`마다 코드를 늘려야 하므로 유지보수성이 낮다.

### 변경 내용
- PR 중간에 추가했던 비용 synonym과 `QUERY_TABLE_INTENT_TERMS` 비용 중복 목록을 제거했다.
- 비용 판단은 기존 `INTENT_QUERY_TERMS`의 rule 기반 intent 분석만 재사용한다.
- `전형료`, `면접고사료` 같은 문서별 column label은 코드 동의어로 추가하지 않는다.
- `MONEY_VALUE_PATTERN`으로 `30,000원`, `10만 원`, `5천 원`처럼 금액 값이 들어 있는 table cell을 value type 구조로 식별한다.
- cost intent에서는 금액 값이 있는 표 행을 `row label + column label + value` 형태의 직접 근거로 만든다.
- 전역 table_fact lexical 검색에서는 비용 질문이어도 subject 불일치 금액 fact를 제외한다.
- 금액 row fallback은 이미 검색된 parent raw chunk가 질문 subject를 담고 있을 때만 허용한다.
- `얼마인가요` 같은 질문형 어미를 `얼마`로 정규화해 table intent 판정이 흔들리지 않게 했다.

### 리뷰 포인트
- 이 변경은 query-time 질문 분석과 table_fact prompt context 보강만 대상으로 한다.
- 업로드 flow, ChromaDB 저장 schema, retrieval_chunks 저장/조회, source preview 응답은 변경하지 않았다.
- 비용 명칭을 하드코딩하지 않고 금액 cell 구조를 사용하므로, 다른 문서의 `응시료`, `수수료`, `검정료` 같은 column label도 원문 그대로 근거에 포함된다.
- 표 안에 여러 금액이 있으면 단일 값으로 뭉개지 않고 row/column label과 함께 나열하는 방식이다.

### Codex review 대응
- P2 비용 표 검색 subject filter: `기숙사 비용` 같은 subject 질문에서 unrelated 등록금/식비 금액 fact가 전역 후보로 들어오지 않도록 차단했다.
- P2 금액 공백 표기: `10만 원`, `5천 원`, `1억 원` 같은 보조 단위 + 공백 + 원 표기를 금액으로 인식하도록 보강했다.

### 변경 파일
- `ai-server/main.py`: 기존 intent 분석 재사용, 금액 값 pattern, money table evidence 생성 경로, subject fallback 제한 추가

### 확인한 내용
- `PYTHONPYCACHEPREFIX=/private/tmp/documind-pycache python3 -m py_compile ai-server/main.py ai-server/rag_contracts.py ai-server/rag_contract_builders.py ai-server/check_rag_contracts.py`: 통과
- `PYTHONPYCACHEPREFIX=/private/tmp/documind-pycache python3 ai-server/check_rag_contracts.py`: 통과
- generic money table evidence smoke: 통과
- cost subject fallback review smoke: 통과
- money value spacing smoke: 통과
- `git diff --check`: 통과

### 비고
- 로컬에서는 LLM 호출 없이 prompt context 구성까지 검증했다.
- merge 후 GCP에서 `/api/chat` answer가 `비면접학과 30,000원`, `면접학과 50,000원`을 실제로 답하는지 확인한다.