### PR TITLE
[AI/RAG] typed TableFact QueryIntent contract 추가

### DIFF
--- a/ai-server/check_rag_contracts.py
+++ b/ai-server/check_rag_contracts.py
@@ -6,11 +6,14 @@ import json
 
 from rag_contract_builders import (
     build_parsed_block,
+    build_query_intent,
     build_retrieval_chunk,
     build_section_node,
     build_source_citation,
     build_source_reference,
     build_source_block,
+    build_table_cell_fact,
+    infer_table_value_type,
     section_path_component_is_suspect,
     section_path_quality,
     section_path_warnings,
@@ -19,7 +22,6 @@ from rag_contracts import (
     Candidate,
     SelectedContext,
     SelectedContextItem,
-    TableFact,
     contract_to_dict,
 )
 
@@ -53,16 +55,27 @@ def build_contract_sample() -> dict:
         source_block,
         section,
     )
-    table_fact = TableFact(
-        fact_id="doc-sample:fact-001",
-        fact_type="row_cell",
-        table_id="doc-sample:table-001",
-        row_subject="Item A",
-        column_path=("Value",),
-        header_path=("Table Section",),
-        value="10",
+    table_fact = build_table_cell_fact(
+        document_id="sample",
+        table_index=1,
+        row_index=1,
+        column_index=1,
+        row_label="Item A",
+        column_label="Value",
+        value="10만 원",
         source_block_id=source_block.source_block_id,
+        caption="Table Section",
+        header_path=("Table Section",),
         confidence=0.95,
+    )
+    query_intent = build_query_intent(
+        query="원서 접수 비용은 얼마인가요?",
+        intent="cost",
+        subject_terms=("원서", "접수"),
+        primary_terms=("원서접수",),
+        context_terms=("원서", "접수", "비용", "얼마"),
+        intent_terms=("비용", "얼마"),
+        notes=("temporary rule-based bridge before QueryIntent runtime",),
     )
     candidate = Candidate(
         candidate_id="doc-sample:candidate-001",
@@ -104,6 +117,7 @@ def build_contract_sample() -> dict:
         "source_block": contract_to_dict(source_block),
         "retrieval_chunk": contract_to_dict(retrieval_chunk),
         "table_fact": contract_to_dict(table_fact),
+        "query_intent": contract_to_dict(query_intent),
         "candidate": contract_to_dict(candidate),
         "citation": contract_to_dict(citation),
         "source_reference": contract_to_dict(source_reference),
@@ -159,6 +173,21 @@ def main() -> None:
     ]
     assert decoded["retrieval_chunk"]["section_ids"] == [decoded["section"]["section_id"]]
     assert decoded["table_fact"]["source_block_id"] == decoded["source_block"]["source_block_id"]
+    assert decoded["table_fact"]["row_label"] == "Item A"
+    assert decoded["table_fact"]["column_label"] == "Value"
+    assert decoded["table_fact"]["value"] == "10만 원"
+    assert decoded["table_fact"]["value_type"] == "money"
+    assert decoded["table_fact"]["unit"] == "만원"
+    assert decoded["table_fact"]["caption"] == "Table Section"
+    assert decoded["query_intent"]["intent"] == "cost"
+    assert decoded["query_intent"]["subject_terms"] == ["원서", "접수"]
+    assert decoded["query_intent"]["primary_terms"] == ["원서접수"]
+    assert decoded["query_intent"]["intent_terms"] == ["비용", "얼마"]
+    assert decoded["query_intent"]["runtime_connection"] == "trace_only"
+    assert infer_table_value_type("30,000원") == ("money", "원")
+    assert infer_table_value_type("5천 원") == ("money", "천원")
+    assert infer_table_value_type("12명") == ("count", "명")
+    assert infer_table_value_type("2026.05.27") == ("date", None)
     assert decoded["selected_context"]["citation_ids"] == [decoded["citation"]["citation_id"]]
 
     suspect_metadata = {"Header 1": "423만원"}

--- a/ai-server/rag_contract_builders.py
+++ b/ai-server/rag_contract_builders.py
@@ -16,11 +16,13 @@ from rag_contracts import (
     JsonValue,
     PageSpan,
     ParsedBlock,
+    QueryIntent,
     RetrievalChunk,
     SectionNode,
     SourceCitation,
     SourceBlock,
     SourceReference,
+    TableFact,
     TextSpan,
 )
 
@@ -152,6 +154,83 @@ def build_retrieval_chunk(
     )
 
 
+def build_table_cell_fact(
+    *,
+    document_id: str | int,
+    table_index: int,
+    row_index: int,
+    column_index: int,
+    row_label: str,
+    column_label: str,
+    value: str,
+    source_block_id: str,
+    caption: str | None = None,
+    column_path: Sequence[str] = (),
+    header_path: Sequence[str] = (),
+    fact_type: str = "cell",
+    confidence: float | None = None,
+) -> TableFact:
+    """Create a typed TableFact from one table cell and its row/column labels."""
+    cleaned_value = _clean_cell_text(value)
+    value_type, unit = infer_table_value_type(cleaned_value)
+    resolved_column_path = tuple(
+        str(part).strip()
+        for part in column_path
+        if str(part).strip()
+    )
+    if not resolved_column_path and column_label.strip():
+        resolved_column_path = (_clean_cell_text(column_label),)
+
+    return TableFact(
+        fact_id=_table_fact_id(document_id, table_index, row_index, column_index),
+        fact_type=fact_type,
+        table_id=_contract_id(document_id, "table", table_index),
+        row_label=_clean_cell_text(row_label) or "해당 행",
+        column_label=_clean_cell_text(column_label) or f"열 {column_index + 1}",
+        value=cleaned_value,
+        source_block_id=source_block_id,
+        value_type=value_type,
+        unit=unit,
+        row_index=row_index,
+        column_index=column_index,
+        column_path=resolved_column_path,
+        header_path=tuple(str(part).strip() for part in header_path if str(part).strip()),
+        caption=_clean_cell_text(caption or "") or None,
+        confidence=confidence,
+    )
+
+
+def build_query_intent(
+    *,
+    query: str,
+    intent: str | None,
+    subject_terms: Sequence[str] = (),
+    primary_terms: Sequence[str] = (),
+    context_terms: Sequence[str] = (),
+    intent_terms: Sequence[str] = (),
+    extraction_method: str = "rule_based",
+    vocabulary_source: str = "INTENT_QUERY_TERMS",
+    runtime_connection: str = "trace_only",
+    confidence: float | None = None,
+    notes: Sequence[str] = (),
+) -> QueryIntent:
+    """Create a typed QueryIntent from current query-analysis output."""
+    return QueryIntent(
+        intent_id=_query_intent_id(query),
+        query=query,
+        intent=intent,
+        subject_terms=_stable_terms(subject_terms),
+        primary_terms=_stable_terms(primary_terms),
+        context_terms=_stable_terms(context_terms),
+        intent_terms=_stable_terms(intent_terms),
+        extraction_method=extraction_method,
+        vocabulary_source=vocabulary_source,
+        runtime_connection=runtime_connection,
+        confidence=confidence,
+        notes=tuple(str(note).strip() for note in notes if str(note).strip()),
+    )
+
+
 def build_section_node(parsed_block: ParsedBlock) -> SectionNode | None:
     """Create a SectionNode from Header 1..6 metadata when a path exists."""
     path = header_path_from_metadata(parsed_block.metadata)
@@ -238,8 +317,38 @@ def sanitize_metadata(metadata: Mapping[str, Any]) -> dict[str, JsonValue]:
     return safe
 
 
+def infer_table_value_type(value: str) -> tuple[str, str | None]:
+    """Infer a coarse value type and unit from a table cell value."""
+    text = _clean_cell_text(value)
+    money_match = _MONEY_VALUE_PATTERN.search(text)
+    if money_match:
+        scale = money_match.group("scale") or ""
+        return "money", f"{scale}원" if scale else "원"
+    if _COUNT_VALUE_PATTERN.fullmatch(text):
+        return "count", "명"
+    if _DATE_VALUE_PATTERN.search(text):
+        return "date", None
+    if _NUMBER_VALUE_PATTERN.fullmatch(text):
+        return "number", None
+    return "text", None
+
+
 def _contract_id(document_id: str | int, kind: str, index: int) -> str:
     return f"doc-{document_id}:{kind}-{index:06d}"
+
+
+def _table_fact_id(
+    document_id: str | int,
+    table_index: int,
+    row_index: int,
+    column_index: int,
+) -> str:
+    return f"doc-{document_id}:table-{table_index:06d}:r{row_index:04d}:c{column_index:04d}"
+
+
+def _query_intent_id(query: str) -> str:
+    query_digest = sha1(str(query or "").strip().encode("utf-8")).hexdigest()[:12]
+    return f"query-intent-{query_digest}"
 
 
 def _section_id(document_id: str | int, path: tuple[str, ...]) -> str:
@@ -302,6 +411,14 @@ def _coerce_int(value: Any) -> int | None:
         return None
 
 
+def _clean_cell_text(value: str) -> str:
+    return re.sub(r"\s+", " ", str(value or "").replace("<br>", " ")).strip()
+
+
+def _stable_terms(terms: Sequence[str]) -> tuple[str, ...]:
+    return tuple(sorted({str(term).strip() for term in terms if str(term).strip()}))
+
+
 class _Unsupported:
     pass
 
@@ -335,6 +452,10 @@ _SECTION_PATH_COMPONENT_BLOCKING_WARNINGS = {
     "numeric_value_section_component",
     "table_markup_section_component",
 }
+_MONEY_VALUE_PATTERN = re.compile(r"\d[\d,]*(?:\.\d+)?\s*(?P<scale>천|만|억|조)?\s*원")
+_COUNT_VALUE_PATTERN = re.compile(r"\d[\d,]*\s*명")
+_DATE_VALUE_PATTERN = re.compile(r"\d{4}[.-]\d{1,2}(?:[.-]\d{1,2})?")
+_NUMBER_VALUE_PATTERN = re.compile(r"\d[\d,]*(?:\.\d+)?")
 
 
 def _to_safe_json_value(value: Any) -> JsonValue | _Unsupported:

--- a/ai-server/rag_contracts.py
+++ b/ai-server/rag_contracts.py
@@ -111,14 +111,38 @@ class TableFact:
     fact_id: str
     fact_type: str
     table_id: str
-    row_subject: str
+    row_label: str
+    column_label: str
     value: str
     source_block_id: str
+    value_type: str = "text"
+    unit: str | None = None
+    row_index: int | None = None
+    column_index: int | None = None
     column_path: tuple[str, ...] = ()
     header_path: tuple[str, ...] = ()
+    caption: str | None = None
     legend: str | None = None
     note: str | None = None
     confidence: float | None = None
+
+
+@dataclass(frozen=True)
+class QueryIntent:
+    """A typed query-understanding result that can replace scattered heuristics."""
+
+    intent_id: str
+    query: str
+    intent: str | None
+    subject_terms: tuple[str, ...] = ()
+    primary_terms: tuple[str, ...] = ()
+    context_terms: tuple[str, ...] = ()
+    intent_terms: tuple[str, ...] = ()
+    extraction_method: str = "rule_based"
+    vocabulary_source: str = "INTENT_QUERY_TERMS"
+    runtime_connection: str = "trace_only"
+    confidence: float | None = None
+    notes: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
### 관련 이슈
Related #73

### 작업 내용
- typed `TableFact` contract를 `row_label`, `column_label`, `value`, `unit`, `value_type` 중심으로 확장했다.
- rule 기반 질문 분석 결과를 담을 `QueryIntent` contract를 추가했다.
- `build_table_cell_fact()`, `build_query_intent()`, `infer_table_value_type()` builder를 추가했다.
- `check_rag_contracts.py`에 typed `TableFact`/`QueryIntent` JSON smoke와 value type smoke를 보강했다.

### 리뷰 포인트
- 이번 PR은 runtime 연결 없이 contract skeleton과 builder만 추가한다.
- `/query`, 업로드 flow, ChromaDB 저장 schema, 검색 순위, prompt context, source preview는 변경하지 않는다.
- `TableFact` 필드가 후속 row/column/cell retrieval에 충분한지 확인한다.
- `QueryIntent`가 rule 기반 heuristic 제거를 위한 중간 contract로 적절한지 확인한다.

### 변경 파일
- `ai-server/rag_contracts.py`: `TableFact` 필드 확장, `QueryIntent` 추가
- `ai-server/rag_contract_builders.py`: typed fact/intent builder와 value type 추론 추가
- `ai-server/check_rag_contracts.py`: contract JSON smoke와 value type assertion 보강

### 확인한 내용
- `PYTHONPYCACHEPREFIX=/private/tmp/documind-pycache python3 -m py_compile ai-server/main.py ai-server/rag_contracts.py ai-server/rag_contract_builders.py ai-server/check_rag_contracts.py`: 통과
- `PYTHONPYCACHEPREFIX=/private/tmp/documind-pycache python3 ai-server/check_rag_contracts.py`: 통과
- typed `TableFact` / `QueryIntent` JSON smoke: 통과
- money/count/date/number value type smoke: 통과
- `git diff --check`: 통과

### 비고
- PR #91에서 확인한 결론대로, 비용 intent 단어 목록을 계속 늘리는 대신 typed `TableFact`와 `QueryIntent`로 책임 경계를 분리하기 위한 기반 작업이다.
- 실제 `/debug/rag-trace` preview 또는 `/query` runtime 연결은 후속 PR에서 다룬다.