### PR TITLE
[AI/RAG] OpenDataLoader JSON contract adapter smoke 추가

### DIFF
--- a/ai-server/check_opendataloader_contract_adapter.py
+++ b/ai-server/check_opendataloader_contract_adapter.py
@@ -143,6 +143,23 @@ def build_adapter_sample() -> dict:
                 "bounding box": [10, 300, 500, 340],
                 "content": "반복 라벨 반복 라벨",
             },
+            {
+                "type": "text_block",
+                "page number": 1,
+                "bounding box": [10, 220, 500, 290],
+                "kids": [
+                    {
+                        "type": "paragraph",
+                        "page number": 1,
+                        "content": "컨테이너 첫 문장",
+                    },
+                    {
+                        "type": "paragraph",
+                        "page number": 1,
+                        "content": "컨테이너 둘째 문장",
+                    },
+                ],
+            },
         ],
     }
     result = adapt_opendataloader_json_page(
@@ -177,11 +194,17 @@ def main() -> None:
         "table",
         "list",
         "paragraph",
+        "paragraph",
+        "paragraph",
     ]
+    block_texts = [block["text"] for block in parsed_blocks]
     assert parsed_blocks[2]["metadata"]["Header 1"] == "문서 제목"
     assert parsed_blocks[2]["metadata"]["Header 2"] == "표 영역"
     assert parsed_blocks[3]["text"].splitlines()[0] == "구분 | 지원 | 지원 | 설명"
     assert parsed_blocks[3]["text"].splitlines()[1] == "구분 | 수시 | 정시 | 비고"
+    assert "컨테이너 첫 문장\n컨테이너 둘째 문장" not in block_texts
+    assert block_texts.count("컨테이너 첫 문장") == 1
+    assert block_texts.count("컨테이너 둘째 문장") == 1
     assert "첫 번째 항목 보조 설명" in parsed_blocks[4]["text"]
     assert "두 번째 항목" in parsed_blocks[4]["text"]
     assert parsed_blocks[0]["page"] == 1

--- a/ai-server/check_opendataloader_contract_adapter.py
+++ b/ai-server/check_opendataloader_contract_adapter.py
@@ -31,6 +31,17 @@ def build_adapter_sample() -> dict:
                 "content": "표 영역",
             },
             {
+                "type": "header",
+                "page number": 1,
+                "kids": [
+                    {
+                        "type": "paragraph",
+                        "page number": 1,
+                        "content": "반복 머리말",
+                    }
+                ],
+            },
+            {
                 "type": "paragraph",
                 "page number": 1,
                 "bounding box": [10, 620, 280, 650],
@@ -138,6 +149,17 @@ def build_adapter_sample() -> dict:
                 ],
             },
             {
+                "type": "footer",
+                "page number": 1,
+                "kids": [
+                    {
+                        "type": "paragraph",
+                        "page number": 1,
+                        "content": "반복 꼬리말",
+                    }
+                ],
+            },
+            {
                 "type": "paragraph",
                 "page number": 1,
                 "bounding box": [10, 300, 500, 340],
@@ -194,6 +216,7 @@ def main() -> None:
     sample = build_adapter_sample()
 
     parsed_blocks = sample["parsed_blocks"]
+    section_nodes = sample["section_nodes"]
     source_blocks = sample["source_blocks"]
     table_facts = sample["table_facts"]
     evidence_text = sample["evidence_text"]
@@ -212,6 +235,7 @@ def main() -> None:
         "paragraph",
     ]
     block_texts = [block["text"] for block in parsed_blocks]
+    section_by_path = {tuple(section["path"]): section for section in section_nodes}
     assert parsed_blocks[2]["metadata"]["Header 1"] == "문서 제목"
     assert parsed_blocks[2]["metadata"]["Header 2"] == "표 영역"
     assert parsed_blocks[3]["text"].splitlines()[0] == "구분 | 지원 | 지원 | 설명"
@@ -222,6 +246,8 @@ def main() -> None:
     assert parsed_blocks[7]["block_type"] == "formula"
     assert source_blocks[6]["raw_text"] == "그림 1. 구조 보존 adapter 처리 흐름"
     assert source_blocks[7]["raw_text"] == "정확도 = 정답 수 / 전체 질문 수"
+    assert "반복 머리말" not in block_texts
+    assert "반복 꼬리말" not in block_texts
     assert "컨테이너 첫 문장\n컨테이너 둘째 문장" not in block_texts
     assert block_texts.count("컨테이너 첫 문장") == 1
     assert block_texts.count("컨테이너 둘째 문장") == 1
@@ -232,6 +258,14 @@ def main() -> None:
     assert source_blocks[0]["raw_text"] == "문서 제목"
     assert source_blocks[0]["page_span"] == {"start": 1, "end": 1}
     assert source_blocks[0]["bbox_span"] == [[10.0, 700.0, 200.0, 730.0]]
+
+    root_section = section_by_path[("문서 제목",)]
+    table_section = section_by_path[("문서 제목", "표 영역")]
+    assert root_section["block_ids"] == [parsed_blocks[0]["block_id"]]
+    assert table_section["block_ids"] == [
+        block["block_id"] for block in parsed_blocks[1:]
+    ]
+    assert table_section["page_span"] == {"start": 1, "end": 1}
 
     money_fact = next(fact for fact in table_facts if fact["value"] == "10,000원")
     assert money_fact["row_label"] == "항목 A"

--- a/ai-server/check_opendataloader_contract_adapter.py
+++ b/ai-server/check_opendataloader_contract_adapter.py
@@ -1,0 +1,243 @@
+"""Smoke checks for the OpenDataLoader JSON contract adapter."""
+
+from __future__ import annotations
+
+from opendataloader_contract_adapter import (
+    adapt_opendataloader_json_page,
+    render_table_facts_as_evidence_text,
+)
+from rag_contracts import contract_to_dict
+
+
+def build_adapter_sample() -> dict:
+    """Build contract previews from a synthetic OpenDataLoader JSON page."""
+    page_json = {
+        "page number": 1,
+        "kids": [
+            {
+                "type": "heading",
+                "heading level": 1,
+                "level": "Doctitle",
+                "page number": 1,
+                "bounding box": [10, 700, 200, 730],
+                "content": "문서 제목",
+            },
+            {
+                "type": "heading",
+                "heading level": 2,
+                "level": "Subtitle",
+                "page number": 1,
+                "bounding box": [10, 660, 180, 690],
+                "content": "표 영역",
+            },
+            {
+                "type": "paragraph",
+                "page number": 1,
+                "bounding box": [10, 620, 280, 650],
+                "content": "본문 문장입니다.",
+            },
+            {
+                "type": "table",
+                "id": 10,
+                "page number": 1,
+                "bounding box": [10, 460, 500, 610],
+                "number of rows": 5,
+                "number of columns": 4,
+                "rows": [
+                    {
+                        "type": "table row",
+                        "row number": 1,
+                        "cells": [
+                            _cell("구분", row=1, column=1),
+                            _cell("지원", row=1, column=2),
+                            _cell("지원", row=1, column=3),
+                            _cell("설명", row=1, column=4),
+                        ],
+                    },
+                    {
+                        "type": "table row",
+                        "row number": 2,
+                        "cells": [
+                            _cell("", row=2, column=1),
+                            _cell("수시", row=2, column=2),
+                            _cell("정시", row=2, column=3),
+                            _cell("비고", row=2, column=4),
+                        ],
+                    },
+                    {
+                        "type": "table row",
+                        "row number": 3,
+                        "cells": [
+                            _cell("금액", row=3, column=1),
+                            _cell("", row=3, column=2),
+                            _cell("", row=3, column=3),
+                            _cell("", row=3, column=4),
+                        ],
+                    },
+                    {
+                        "type": "table row",
+                        "row number": 4,
+                        "cells": [
+                            _cell("항목 A", row=4, column=1),
+                            _cell("10,000원", row=4, column=2),
+                            _cell("20,000원", row=4, column=3),
+                            _cell(
+                                "신청 이후 담당 부서 검토와 별도 확인 절차가 필요하므로 "
+                                "개별 안내를 반드시 확인해야 하는 긴 설명 문장입니다. "
+                                "이 내용은 하나의 행/열/값 사실로 쓰기보다 원문 SourceBlock에서 "
+                                "확인해야 하는 안내 문장입니다.",
+                                row=4,
+                                column=4,
+                            ),
+                        ],
+                    },
+                    {
+                        "type": "table row",
+                        "row number": 5,
+                        "cells": [
+                            _cell("항목 B", row=5, column=1),
+                            _cell("-", row=5, column=2),
+                            _cell("30,000원", row=5, column=3),
+                            _cell("검토", row=5, column=4),
+                        ],
+                    },
+                ],
+            },
+            {
+                "type": "list",
+                "page number": 1,
+                "bounding box": [10, 360, 500, 450],
+                "numbering style": "unordered",
+                "number of list items": 2,
+                "list items": [
+                    {
+                        "type": "list item",
+                        "page number": 1,
+                        "content": "첫 번째 항목",
+                        "kids": [
+                            {
+                                "type": "paragraph",
+                                "page number": 1,
+                                "content": "보조 설명",
+                            }
+                        ],
+                    },
+                    {
+                        "type": "list item",
+                        "page number": 1,
+                        "content": "두 번째 항목",
+                        "kids": [],
+                    },
+                ],
+            },
+            {
+                "type": "paragraph",
+                "page number": 1,
+                "bounding box": [10, 300, 500, 340],
+                "content": "반복 라벨 반복 라벨",
+            },
+        ],
+    }
+    result = adapt_opendataloader_json_page(
+        page_json,
+        document_id="adapter-smoke",
+        source="sample.pdf",
+    )
+    return {
+        "parsed_blocks": [contract_to_dict(block) for block in result.parsed_blocks],
+        "section_nodes": [contract_to_dict(section) for section in result.section_nodes],
+        "source_blocks": [contract_to_dict(block) for block in result.source_blocks],
+        "table_facts": [contract_to_dict(fact) for fact in result.table_facts],
+        "evidence_text": render_table_facts_as_evidence_text(result.table_facts),
+        "diagnostics": [diagnostic.__dict__ for diagnostic in result.diagnostics],
+    }
+
+
+def main() -> None:
+    """Verify adapter output without running the DocuMind runtime."""
+    sample = build_adapter_sample()
+
+    parsed_blocks = sample["parsed_blocks"]
+    source_blocks = sample["source_blocks"]
+    table_facts = sample["table_facts"]
+    evidence_text = sample["evidence_text"]
+    diagnostics = sample["diagnostics"]
+
+    assert [block["block_type"] for block in parsed_blocks] == [
+        "heading",
+        "heading",
+        "paragraph",
+        "table",
+        "list",
+        "paragraph",
+    ]
+    assert parsed_blocks[2]["metadata"]["Header 1"] == "문서 제목"
+    assert parsed_blocks[2]["metadata"]["Header 2"] == "표 영역"
+    assert parsed_blocks[3]["text"].splitlines()[0] == "구분 | 지원 | 지원 | 설명"
+    assert "첫 번째 항목 보조 설명" in parsed_blocks[4]["text"]
+    assert "두 번째 항목" in parsed_blocks[4]["text"]
+    assert parsed_blocks[0]["page"] == 1
+    assert parsed_blocks[0]["bbox"] == [10.0, 700.0, 200.0, 730.0]
+    assert source_blocks[0]["raw_text"] == "문서 제목"
+    assert source_blocks[0]["page_span"] == {"start": 1, "end": 1}
+    assert source_blocks[0]["bbox_span"] == [[10.0, 700.0, 200.0, 730.0]]
+
+    money_fact = next(fact for fact in table_facts if fact["value"] == "10,000원")
+    assert money_fact["row_label"] == "항목 A"
+    assert money_fact["column_label"] == "지원 > 수시"
+    assert money_fact["row_header_path"] == ["금액", "항목 A"]
+    assert money_fact["column_path"] == ["지원", "수시"]
+    assert money_fact["value_type"] == "money"
+    assert money_fact["source_block_id"] == source_blocks[3]["source_block_id"]
+    assert money_fact["header_path"] == ["문서 제목", "표 영역"]
+    assert all(fact["value"] != "-" for fact in table_facts)
+    assert all("긴 설명 문장" not in fact["value"] for fact in table_facts)
+    assert evidence_text.startswith("[표 근거]\n표 제목: 표 영역")
+    assert "행: 금액 > 항목 A / 열: 지원 > 수시 / 값: 10,000원" in evidence_text
+    assert "row_label" not in evidence_text
+    assert "column_label" not in evidence_text
+    assert "source_block_id" not in evidence_text
+    assert "긴 설명 문장" not in evidence_text
+
+    group_diagnostics = [
+        item for item in diagnostics if item["code"] == "table_group_row_detected"
+    ]
+    assert group_diagnostics
+    assert group_diagnostics[0]["metadata"]["label"] == "금액"
+
+    skipped_values = [
+        item for item in diagnostics if item["code"] == "table_fact_value_skipped"
+    ]
+    assert skipped_values
+    assert skipped_values[0]["metadata"]["reason"] == "overlong_text_value"
+
+    fallback = [item for item in diagnostics if item["code"] == "fallback_required"]
+    assert fallback
+    fallback_reasons = {
+        reason
+        for item in fallback
+        for reason in item["metadata"].get("reasons", [])
+    }
+    assert "possible_parallel_content_merge" in fallback_reasons
+
+    print("opendataloader contract adapter smoke ok")
+
+
+def _cell(content: str, *, row: int, column: int) -> dict:
+    return {
+        "type": "table cell",
+        "page number": 1,
+        "row number": row,
+        "column number": column,
+        "kids": [
+            {
+                "type": "paragraph",
+                "page number": 1,
+                "content": content,
+            }
+        ],
+    }
+
+
+if __name__ == "__main__":
+    main()

--- a/ai-server/check_opendataloader_contract_adapter.py
+++ b/ai-server/check_opendataloader_contract_adapter.py
@@ -167,9 +167,10 @@ def build_adapter_sample() -> dict:
             },
             {
                 "type": "caption",
+                "linked content id": 10,
                 "page number": 1,
                 "bounding box": [10, 260, 500, 285],
-                "content": "그림 1. 구조 보존 adapter 처리 흐름",
+                "content": "표 1. 지원 금액 현황",
             },
             {
                 "type": "formula",
@@ -240,11 +241,12 @@ def main() -> None:
     assert parsed_blocks[2]["metadata"]["Header 2"] == "표 영역"
     assert parsed_blocks[3]["text"].splitlines()[0] == "구분 | 지원 | 지원 | 설명"
     assert parsed_blocks[3]["text"].splitlines()[1] == "구분 | 수시 | 정시 | 비고"
-    assert block_texts.count("그림 1. 구조 보존 adapter 처리 흐름") == 1
+    assert block_texts.count("표 1. 지원 금액 현황") == 1
     assert block_texts.count("정확도 = 정답 수 / 전체 질문 수") == 1
     assert parsed_blocks[6]["block_type"] == "caption"
     assert parsed_blocks[7]["block_type"] == "formula"
-    assert source_blocks[6]["raw_text"] == "그림 1. 구조 보존 adapter 처리 흐름"
+    assert parsed_blocks[6]["metadata"]["opendataloader_linked_content_id"] == 10
+    assert source_blocks[6]["raw_text"] == "표 1. 지원 금액 현황"
     assert source_blocks[7]["raw_text"] == "정확도 = 정답 수 / 전체 질문 수"
     assert "반복 머리말" not in block_texts
     assert "반복 꼬리말" not in block_texts
@@ -275,6 +277,7 @@ def main() -> None:
     assert money_fact["value_type"] == "money"
     assert money_fact["source_block_id"] == source_blocks[3]["source_block_id"]
     assert money_fact["header_path"] == ["문서 제목", "표 영역"]
+    assert money_fact["caption"] == "표 1. 지원 금액 현황"
 
     shifted_fact = next(fact for fact in table_facts if fact["value"] == "40,000원")
     assert shifted_fact["row_label"] == "항목 C"
@@ -282,10 +285,11 @@ def main() -> None:
     assert shifted_fact["row_header_path"] == ["금액", "항목 C"]
     assert shifted_fact["column_path"] == ["지원", "정시"]
     assert shifted_fact["column_index"] == 2
+    assert shifted_fact["caption"] == "표 1. 지원 금액 현황"
 
     assert all(fact["value"] != "-" for fact in table_facts)
     assert all("긴 설명 문장" not in fact["value"] for fact in table_facts)
-    assert evidence_text.startswith("[표 근거]\n표 제목: 표 영역")
+    assert evidence_text.startswith("[표 근거]\n표 제목: 표 1. 지원 금액 현황")
     assert "행: 금액 > 항목 A / 열: 지원 > 수시 / 값: 10,000원" in evidence_text
     assert "row_label" not in evidence_text
     assert "column_label" not in evidence_text

--- a/ai-server/check_opendataloader_contract_adapter.py
+++ b/ai-server/check_opendataloader_contract_adapter.py
@@ -41,16 +41,15 @@ def build_adapter_sample() -> dict:
                 "id": 10,
                 "page number": 1,
                 "bounding box": [10, 460, 500, 610],
-                "number of rows": 5,
+                "number of rows": 6,
                 "number of columns": 4,
                 "rows": [
                     {
                         "type": "table row",
                         "row number": 1,
                         "cells": [
-                            _cell("구분", row=1, column=1),
-                            _cell("지원", row=1, column=2),
-                            _cell("지원", row=1, column=3),
+                            _cell("구분", row=1, column=1, row_span=2),
+                            _cell("지원", row=1, column=2, column_span=2),
                             _cell("설명", row=1, column=4),
                         ],
                     },
@@ -58,7 +57,6 @@ def build_adapter_sample() -> dict:
                         "type": "table row",
                         "row number": 2,
                         "cells": [
-                            _cell("", row=2, column=1),
                             _cell("수시", row=2, column=2),
                             _cell("정시", row=2, column=3),
                             _cell("비고", row=2, column=4),
@@ -99,6 +97,15 @@ def build_adapter_sample() -> dict:
                             _cell("-", row=5, column=2),
                             _cell("30,000원", row=5, column=3),
                             _cell("검토", row=5, column=4),
+                        ],
+                    },
+                    {
+                        "type": "table row",
+                        "row number": 6,
+                        "cells": [
+                            _cell("항목 C", row=6, column=1),
+                            _cell("40,000원", row=6, column=3),
+                            _cell("완료", row=6, column=4),
                         ],
                     },
                 ],
@@ -174,6 +181,7 @@ def main() -> None:
     assert parsed_blocks[2]["metadata"]["Header 1"] == "문서 제목"
     assert parsed_blocks[2]["metadata"]["Header 2"] == "표 영역"
     assert parsed_blocks[3]["text"].splitlines()[0] == "구분 | 지원 | 지원 | 설명"
+    assert parsed_blocks[3]["text"].splitlines()[1] == "구분 | 수시 | 정시 | 비고"
     assert "첫 번째 항목 보조 설명" in parsed_blocks[4]["text"]
     assert "두 번째 항목" in parsed_blocks[4]["text"]
     assert parsed_blocks[0]["page"] == 1
@@ -190,6 +198,14 @@ def main() -> None:
     assert money_fact["value_type"] == "money"
     assert money_fact["source_block_id"] == source_blocks[3]["source_block_id"]
     assert money_fact["header_path"] == ["문서 제목", "표 영역"]
+
+    shifted_fact = next(fact for fact in table_facts if fact["value"] == "40,000원")
+    assert shifted_fact["row_label"] == "항목 C"
+    assert shifted_fact["column_label"] == "지원 > 정시"
+    assert shifted_fact["row_header_path"] == ["금액", "항목 C"]
+    assert shifted_fact["column_path"] == ["지원", "정시"]
+    assert shifted_fact["column_index"] == 2
+
     assert all(fact["value"] != "-" for fact in table_facts)
     assert all("긴 설명 문장" not in fact["value"] for fact in table_facts)
     assert evidence_text.startswith("[표 근거]\n표 제목: 표 영역")
@@ -223,8 +239,15 @@ def main() -> None:
     print("opendataloader contract adapter smoke ok")
 
 
-def _cell(content: str, *, row: int, column: int) -> dict:
-    return {
+def _cell(
+    content: str,
+    *,
+    row: int,
+    column: int,
+    row_span: int = 1,
+    column_span: int = 1,
+) -> dict:
+    cell = {
         "type": "table cell",
         "page number": 1,
         "row number": row,
@@ -237,6 +260,11 @@ def _cell(content: str, *, row: int, column: int) -> dict:
             }
         ],
     }
+    if row_span > 1:
+        cell["row span"] = row_span
+    if column_span > 1:
+        cell["column span"] = column_span
+    return cell
 
 
 if __name__ == "__main__":

--- a/ai-server/check_opendataloader_contract_adapter.py
+++ b/ai-server/check_opendataloader_contract_adapter.py
@@ -144,6 +144,18 @@ def build_adapter_sample() -> dict:
                 "content": "반복 라벨 반복 라벨",
             },
             {
+                "type": "caption",
+                "page number": 1,
+                "bounding box": [10, 260, 500, 285],
+                "content": "그림 1. 구조 보존 adapter 처리 흐름",
+            },
+            {
+                "type": "formula",
+                "page number": 1,
+                "bounding box": [10, 235, 500, 255],
+                "content": "정확도 = 정답 수 / 전체 질문 수",
+            },
+            {
                 "type": "text_block",
                 "page number": 1,
                 "bounding box": [10, 220, 500, 290],
@@ -194,6 +206,8 @@ def main() -> None:
         "table",
         "list",
         "paragraph",
+        "caption",
+        "formula",
         "paragraph",
         "paragraph",
     ]
@@ -202,6 +216,12 @@ def main() -> None:
     assert parsed_blocks[2]["metadata"]["Header 2"] == "표 영역"
     assert parsed_blocks[3]["text"].splitlines()[0] == "구분 | 지원 | 지원 | 설명"
     assert parsed_blocks[3]["text"].splitlines()[1] == "구분 | 수시 | 정시 | 비고"
+    assert block_texts.count("그림 1. 구조 보존 adapter 처리 흐름") == 1
+    assert block_texts.count("정확도 = 정답 수 / 전체 질문 수") == 1
+    assert parsed_blocks[6]["block_type"] == "caption"
+    assert parsed_blocks[7]["block_type"] == "formula"
+    assert source_blocks[6]["raw_text"] == "그림 1. 구조 보존 adapter 처리 흐름"
+    assert source_blocks[7]["raw_text"] == "정확도 = 정답 수 / 전체 질문 수"
     assert "컨테이너 첫 문장\n컨테이너 둘째 문장" not in block_texts
     assert block_texts.count("컨테이너 첫 문장") == 1
     assert block_texts.count("컨테이너 둘째 문장") == 1

--- a/ai-server/check_rag_contracts.py
+++ b/ai-server/check_rag_contracts.py
@@ -65,6 +65,7 @@ def build_contract_sample() -> dict:
         value="10만 원",
         source_block_id=source_block.source_block_id,
         caption="Table Section",
+        row_header_path=("Group A", "Item A"),
         header_path=("Table Section",),
         confidence=0.95,
     )
@@ -174,6 +175,7 @@ def main() -> None:
     assert decoded["retrieval_chunk"]["section_ids"] == [decoded["section"]["section_id"]]
     assert decoded["table_fact"]["source_block_id"] == decoded["source_block"]["source_block_id"]
     assert decoded["table_fact"]["row_label"] == "Item A"
+    assert decoded["table_fact"]["row_header_path"] == ["Group A", "Item A"]
     assert decoded["table_fact"]["column_label"] == "Value"
     assert decoded["table_fact"]["value"] == "10만 원"
     assert decoded["table_fact"]["value_type"] == "money"

--- a/ai-server/opendataloader_contract_adapter.py
+++ b/ai-server/opendataloader_contract_adapter.py
@@ -696,7 +696,14 @@ def _last_text(values: Sequence[str]) -> str:
     return ""
 
 
-_CONTRACT_ELEMENT_TYPES = {"heading", "paragraph", "table", "list"}
+_CONTRACT_ELEMENT_TYPES = {
+    "heading",
+    "paragraph",
+    "table",
+    "list",
+    "caption",
+    "formula",
+}
 _CONTAINER_ONLY_ELEMENT_TYPES = {"text_block"}
 _ELEMENT_TYPE_ALIASES = {
     "text_block": "paragraph",

--- a/ai-server/opendataloader_contract_adapter.py
+++ b/ai-server/opendataloader_contract_adapter.py
@@ -83,6 +83,7 @@ def adapt_opendataloader_json_page(
     section_by_id: dict[str, SectionNode] = {}
     table_facts: list[TableFact] = []
     heading_path: list[str] = []
+    linked_caption_by_content_id = _linked_caption_by_content_id(candidates)
 
     for block_index, candidate in enumerate(candidates, start=1):
         level = _heading_level(candidate.element)
@@ -140,7 +141,11 @@ def adapt_opendataloader_json_page(
                     document_id=document_id,
                     table_index=block_index,
                     source_block_id=source_block.source_block_id,
-                    caption=_table_caption(heading_path),
+                    caption=_table_caption_for_candidate(
+                        candidate,
+                        heading_path,
+                        linked_caption_by_content_id,
+                    ),
                     header_path=heading_path,
                     diagnostics=diagnostics,
                     block_id=parsed_block.block_id,
@@ -388,6 +393,10 @@ def _base_element_metadata(element: Mapping[str, Any]) -> dict[str, Any]:
     }
     for source_key, target_key in (
         ("id", "opendataloader_element_id"),
+        ("linked content id", "opendataloader_linked_content_id"),
+        ("linked_content_id", "opendataloader_linked_content_id"),
+        ("linked content ids", "opendataloader_linked_content_ids"),
+        ("linked_content_ids", "opendataloader_linked_content_ids"),
         ("level", "opendataloader_level"),
         ("heading level", "opendataloader_heading_level"),
         ("numbering style", "opendataloader_numbering_style"),
@@ -406,6 +415,67 @@ def _base_element_metadata(element: Mapping[str, Any]) -> dict[str, Any]:
     if bbox is not None:
         metadata["bbox"] = list(bbox)
     return metadata
+
+
+def _linked_caption_by_content_id(
+    candidates: Sequence[_ElementCandidate],
+) -> dict[str, str]:
+    caption_by_content_id: dict[str, str] = {}
+    for candidate in candidates:
+        if candidate.element_type != "caption":
+            continue
+        for linked_content_id in _linked_content_ids(candidate.element):
+            caption_by_content_id.setdefault(linked_content_id, candidate.text)
+    return caption_by_content_id
+
+
+def _table_caption_for_candidate(
+    candidate: _ElementCandidate,
+    heading_path: Sequence[str],
+    linked_caption_by_content_id: Mapping[str, str],
+) -> str | None:
+    for content_id in _element_ids(candidate.element):
+        caption = linked_caption_by_content_id.get(content_id)
+        if caption:
+            return caption
+    return _table_caption(heading_path)
+
+
+def _element_ids(element: Mapping[str, Any]) -> tuple[str, ...]:
+    return _id_values(element, _ELEMENT_ID_KEYS)
+
+
+def _linked_content_ids(element: Mapping[str, Any]) -> tuple[str, ...]:
+    return _id_values(element, _LINKED_CONTENT_ID_KEYS)
+
+
+def _id_values(element: Mapping[str, Any], keys: Sequence[str]) -> tuple[str, ...]:
+    values: list[str] = []
+    seen: set[str] = set()
+    for key in keys:
+        if key not in element:
+            continue
+        for value in _iter_id_values(element[key]):
+            if not value or value in seen:
+                continue
+            seen.add(value)
+            values.append(value)
+    return tuple(values)
+
+
+def _iter_id_values(value: Any) -> Iterable[str]:
+    if isinstance(value, Mapping):
+        for key in _ELEMENT_ID_KEYS:
+            if key in value:
+                yield from _iter_id_values(value[key])
+        return
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+        for item in value:
+            yield from _iter_id_values(item)
+        return
+    cleaned = _clean_text(value)
+    if cleaned:
+        yield cleaned
 
 
 def _metadata_for_candidate(
@@ -762,6 +832,25 @@ _ELEMENT_TYPE_ALIASES = {
     "text_block": "paragraph",
     "list_item": "paragraph",
 }
+_ELEMENT_ID_KEYS = (
+    "id",
+    "content id",
+    "content_id",
+    "element id",
+    "element_id",
+)
+_LINKED_CONTENT_ID_KEYS = (
+    "linked content id",
+    "linked_content_id",
+    "linked content ids",
+    "linked_content_ids",
+    "linked content",
+    "linked_content",
+    "linked id",
+    "linked_id",
+    "linked element id",
+    "linked_element_id",
+)
 _NAMED_HEADING_LEVELS = {
     "doctitle": 1,
     "title": 1,

--- a/ai-server/opendataloader_contract_adapter.py
+++ b/ai-server/opendataloader_contract_adapter.py
@@ -1,0 +1,618 @@
+"""Adapter from OpenDataLoader JSON elements to DocuMind RAG contracts.
+
+This module is a side-effect free smoke adapter.  It does not write to
+ChromaDB, call endpoints, or change the runtime upload path.  Its job is to
+prove that OpenDataLoader JSON can be normalized into the existing
+ParsedBlock, SectionNode, SourceBlock, and TableFact contracts.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import json
+import re
+from collections.abc import Iterable, Mapping, Sequence
+from typing import Any
+
+from rag_contract_builders import (
+    build_parsed_block,
+    build_section_node,
+    build_source_block,
+    build_table_cell_fact,
+    infer_table_value_type,
+)
+from rag_contracts import JsonValue, ParsedBlock, SectionNode, SourceBlock, TableFact
+
+
+@dataclass(frozen=True)
+class OpenDataLoaderAdapterDiagnostic:
+    """A non-fatal adapter warning or fallback note for audit output."""
+
+    code: str
+    block_id: str | None = None
+    element_type: str | None = None
+    message: str = ""
+    metadata: dict[str, JsonValue] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class OpenDataLoaderAdapterResult:
+    """Contract candidates produced from one OpenDataLoader JSON page."""
+
+    parsed_blocks: tuple[ParsedBlock, ...]
+    section_nodes: tuple[SectionNode, ...]
+    source_blocks: tuple[SourceBlock, ...]
+    table_facts: tuple[TableFact, ...]
+    diagnostics: tuple[OpenDataLoaderAdapterDiagnostic, ...] = ()
+
+
+@dataclass(frozen=True)
+class _ElementCandidate:
+    element: Mapping[str, Any]
+    element_type: str
+    text: str
+    metadata: dict[str, Any]
+    confidence: float
+    fallback_reasons: tuple[str, ...] = ()
+    table_rows: tuple[tuple[str, ...], ...] = ()
+
+
+def adapt_opendataloader_json_page(
+    page_content: str | Mapping[str, Any],
+    *,
+    document_id: str | int,
+    source: str,
+    document_format: str = "pdf",
+) -> OpenDataLoaderAdapterResult:
+    """Convert one OpenDataLoader JSON page into RAG contract candidates."""
+    page_data = _load_page_data(page_content)
+    page_number = _coerce_int(page_data.get("page number")) or _coerce_int(
+        page_data.get("page")
+    )
+    candidates = _collect_element_candidates(page_data)
+    diagnostics: list[OpenDataLoaderAdapterDiagnostic] = []
+    parsed_blocks: list[ParsedBlock] = []
+    source_blocks: list[SourceBlock] = []
+    section_by_id: dict[str, SectionNode] = {}
+    table_facts: list[TableFact] = []
+    heading_path: list[str] = []
+
+    for block_index, candidate in enumerate(candidates, start=1):
+        level = _heading_level(candidate.element)
+        if candidate.element_type == "heading" and level is not None:
+            heading_path = _updated_heading_path(heading_path, level, candidate.text)
+
+        metadata = _metadata_for_candidate(
+            candidate,
+            page_number=page_number,
+            source=source,
+            heading_path=heading_path,
+        )
+        parsed_block = build_parsed_block(
+            document_id=document_id,
+            document_format=document_format,
+            text=candidate.text,
+            block_index=block_index,
+            metadata=metadata,
+            block_type=candidate.element_type,
+            parser_confidence=candidate.confidence,
+        )
+        parsed_blocks.append(parsed_block)
+
+        section_node = build_section_node(parsed_block)
+        if section_node is not None:
+            section_by_id.setdefault(section_node.section_id, section_node)
+
+        source_block = build_source_block(
+            parsed_block,
+            source_index=block_index,
+            section_id=section_node.section_id if section_node else None,
+        )
+        source_blocks.append(source_block)
+
+        if candidate.fallback_reasons:
+            diagnostics.append(
+                OpenDataLoaderAdapterDiagnostic(
+                    code="fallback_required",
+                    block_id=parsed_block.block_id,
+                    element_type=candidate.element_type,
+                    message="OpenDataLoader JSON preserved text but scope is not safe enough to split automatically.",
+                    metadata={"reasons": list(candidate.fallback_reasons)},
+                )
+            )
+
+        if candidate.element_type == "table":
+            table_facts.extend(
+                _table_facts_from_rows(
+                    candidate.table_rows,
+                    document_id=document_id,
+                    table_index=block_index,
+                    source_block_id=source_block.source_block_id,
+                    caption=_table_caption(heading_path),
+                    header_path=heading_path,
+                    diagnostics=diagnostics,
+                    block_id=parsed_block.block_id,
+                )
+            )
+
+    return OpenDataLoaderAdapterResult(
+        parsed_blocks=tuple(parsed_blocks),
+        section_nodes=tuple(section_by_id.values()),
+        source_blocks=tuple(source_blocks),
+        table_facts=tuple(table_facts),
+        diagnostics=tuple(diagnostics),
+    )
+
+
+def render_table_facts_as_evidence_text(
+    table_facts: Sequence[TableFact],
+    *,
+    max_facts: int = 12,
+) -> str:
+    """Render TableFact candidates as compact Korean evidence for an LLM prompt."""
+    selected_facts = tuple(table_facts[: max(0, max_facts)])
+    if not selected_facts:
+        return ""
+
+    lines: list[str] = ["[표 근거]"]
+    current_table_key: tuple[str, str | None] | None = None
+    for fact in selected_facts:
+        table_key = (fact.table_id, fact.caption)
+        if table_key != current_table_key:
+            current_table_key = table_key
+            caption = _clean_text(fact.caption or _last_text(fact.header_path) or fact.table_id)
+            lines.append(f"표 제목: {caption}")
+
+        row_label = " > ".join(fact.row_header_path) if fact.row_header_path else fact.row_label
+        column_label = " > ".join(fact.column_path) if fact.column_path else fact.column_label
+        lines.append(
+            f"- 행: {_clean_text(row_label)} / 열: {_clean_text(column_label)} / 값: {_clean_text(fact.value)}"
+        )
+
+    if len(table_facts) > len(selected_facts):
+        lines.append(f"- 추가 표 근거 {len(table_facts) - len(selected_facts)}개는 생략했습니다.")
+    return "\n".join(lines)
+
+
+def _load_page_data(page_content: str | Mapping[str, Any]) -> Mapping[str, Any]:
+    if isinstance(page_content, Mapping):
+        return page_content
+    decoded = json.loads(page_content)
+    if not isinstance(decoded, Mapping):
+        raise ValueError("OpenDataLoader JSON page must decode to an object")
+    return decoded
+
+
+def _collect_element_candidates(page_data: Mapping[str, Any]) -> tuple[_ElementCandidate, ...]:
+    candidates: list[_ElementCandidate] = []
+    for element in _iter_child_elements(page_data):
+        element_type = _normalize_element_type(element.get("type"))
+        if element_type not in _CONTRACT_ELEMENT_TYPES:
+            continue
+
+        table_rows = _table_rows(element) if element_type == "table" else ()
+        text = _render_table_text(table_rows) if element_type == "table" else _element_text(element)
+        if not text:
+            continue
+
+        fallback_reasons = _fallback_reasons(element, text, table_rows)
+        candidates.append(
+            _ElementCandidate(
+                element=element,
+                element_type=element_type,
+                text=text,
+                metadata=_base_element_metadata(element),
+                confidence=_confidence(element, text, fallback_reasons),
+                fallback_reasons=fallback_reasons,
+                table_rows=table_rows,
+            )
+        )
+    return tuple(candidates)
+
+
+def _iter_child_elements(page_data: Mapping[str, Any]) -> Iterable[Mapping[str, Any]]:
+    kids = page_data.get("kids") or page_data.get("children") or []
+    if isinstance(kids, Sequence) and not isinstance(kids, (str, bytes)):
+        yield from _iter_elements(kids)
+
+
+def _iter_elements(elements: Iterable[Any]) -> Iterable[Mapping[str, Any]]:
+    for element in elements:
+        if not isinstance(element, Mapping):
+            continue
+        yield element
+        element_type = _normalize_element_type(element.get("type"))
+        if element_type in {"table", "list"}:
+            continue
+        nested = element.get("kids") or element.get("children") or []
+        if isinstance(nested, Sequence) and not isinstance(nested, (str, bytes)):
+            yield from _iter_elements(nested)
+
+
+def _normalize_element_type(value: Any) -> str:
+    normalized = re.sub(r"\s+", "_", str(value or "").strip().lower())
+    return _ELEMENT_TYPE_ALIASES.get(normalized, normalized)
+
+
+def _element_text(element: Mapping[str, Any]) -> str:
+    direct = _clean_text(element.get("content") or element.get("text") or "")
+    if direct:
+        nested_parts = [_element_text(child) for child in _nested_text_children(element)]
+        return _join_text_parts([direct, *nested_parts])
+    if _normalize_element_type(element.get("type")) == "list":
+        return _join_text_parts(_list_item_texts(element))
+    return _join_text_parts(_element_text(child) for child in _nested_text_children(element))
+
+
+def _nested_text_children(element: Mapping[str, Any]) -> tuple[Mapping[str, Any], ...]:
+    nested = element.get("kids") or element.get("children") or []
+    if not isinstance(nested, Sequence) or isinstance(nested, (str, bytes)):
+        return ()
+    return tuple(child for child in nested if isinstance(child, Mapping))
+
+
+def _list_item_texts(element: Mapping[str, Any]) -> tuple[str, ...]:
+    items = element.get("list items") or element.get("items") or []
+    if not isinstance(items, Sequence) or isinstance(items, (str, bytes)):
+        return ()
+    texts: list[str] = []
+    for item in items:
+        if isinstance(item, Mapping):
+            text = _element_text(item)
+            if text:
+                texts.append(text)
+    return tuple(texts)
+
+
+def _table_rows(element: Mapping[str, Any]) -> tuple[tuple[str, ...], ...]:
+    rows = element.get("rows") or []
+    if not isinstance(rows, Sequence) or isinstance(rows, (str, bytes)):
+        return ()
+    resolved_rows: list[tuple[str, ...]] = []
+    for row in rows:
+        if not isinstance(row, Mapping):
+            continue
+        cells = row.get("cells") or []
+        if not isinstance(cells, Sequence) or isinstance(cells, (str, bytes)):
+            continue
+        cell_texts = tuple(_element_text(cell) for cell in cells if isinstance(cell, Mapping))
+        if any(cell_texts):
+            resolved_rows.append(cell_texts)
+    return tuple(resolved_rows)
+
+
+def _render_table_text(rows: Sequence[Sequence[str]]) -> str:
+    return "\n".join(" | ".join(_clean_text(cell) for cell in row) for row in rows)
+
+
+def _base_element_metadata(element: Mapping[str, Any]) -> dict[str, Any]:
+    metadata: dict[str, Any] = {
+        "parser_name": "opendataloader_pdf",
+        "opendataloader_type": _normalize_element_type(element.get("type")),
+    }
+    for source_key, target_key in (
+        ("id", "opendataloader_element_id"),
+        ("level", "opendataloader_level"),
+        ("heading level", "opendataloader_heading_level"),
+        ("numbering style", "opendataloader_numbering_style"),
+        ("number of rows", "opendataloader_number_of_rows"),
+        ("number of columns", "opendataloader_number_of_columns"),
+        ("number of list items", "opendataloader_number_of_list_items"),
+    ):
+        if source_key in element:
+            metadata[target_key] = element[source_key]
+    page = _coerce_int(element.get("page number") or element.get("page"))
+    if page is not None:
+        metadata["page"] = page
+        metadata["page_start"] = page
+        metadata["page_end"] = page
+    bbox = _bbox(element)
+    if bbox is not None:
+        metadata["bbox"] = list(bbox)
+    return metadata
+
+
+def _metadata_for_candidate(
+    candidate: _ElementCandidate,
+    *,
+    page_number: int | None,
+    source: str,
+    heading_path: Sequence[str],
+) -> dict[str, Any]:
+    metadata = dict(candidate.metadata)
+    metadata["source"] = source
+    metadata["block_type"] = candidate.element_type
+    if page_number is not None:
+        metadata.setdefault("page", page_number)
+        metadata.setdefault("page_start", page_number)
+        metadata.setdefault("page_end", page_number)
+    for index, title in enumerate(heading_path[:6], start=1):
+        metadata[f"Header {index}"] = title
+    if candidate.fallback_reasons:
+        metadata["adapter_fallback_reasons"] = list(candidate.fallback_reasons)
+    return metadata
+
+
+def _heading_level(element: Mapping[str, Any]) -> int | None:
+    explicit = _coerce_int(element.get("heading level"))
+    if explicit is not None and explicit > 0:
+        return min(explicit, 6)
+    level = str(element.get("level") or "").strip().lower()
+    if level in _NAMED_HEADING_LEVELS:
+        return _NAMED_HEADING_LEVELS[level]
+    parsed = _coerce_int(level)
+    if parsed is not None and parsed > 0:
+        return min(parsed, 6)
+    return None
+
+
+def _updated_heading_path(current_path: Sequence[str], level: int, title: str) -> list[str]:
+    path = list(current_path[: max(level - 1, 0)])
+    path.append(title)
+    return path[:6]
+
+
+def _table_facts_from_rows(
+    rows: Sequence[Sequence[str]],
+    *,
+    document_id: str | int,
+    table_index: int,
+    source_block_id: str,
+    caption: str | None,
+    header_path: Sequence[str],
+    diagnostics: list[OpenDataLoaderAdapterDiagnostic],
+    block_id: str,
+) -> tuple[TableFact, ...]:
+    normalized_rows = tuple(
+        tuple(_clean_text(cell) for cell in row)
+        for row in rows
+        if any(_clean_text(cell) for cell in row)
+    )
+    if len(normalized_rows) < 2:
+        diagnostics.append(
+            OpenDataLoaderAdapterDiagnostic(
+                code="table_fact_skipped",
+                block_id=block_id,
+                element_type="table",
+                message="Table did not have both a header row and a data row.",
+            )
+        )
+        return ()
+
+    header_row_count = _table_header_row_count(normalized_rows)
+    header_rows = normalized_rows[:header_row_count]
+    data_rows = normalized_rows[header_row_count:]
+    column_paths = _table_column_paths(header_rows)
+    facts: list[TableFact] = []
+    current_row_group: str | None = None
+    for row_offset, row in enumerate(data_rows, start=header_row_count):
+        if _is_table_group_row(row):
+            current_row_group = next((cell for cell in row if cell), None)
+            diagnostics.append(
+                OpenDataLoaderAdapterDiagnostic(
+                    code="table_group_row_detected",
+                    block_id=block_id,
+                    element_type="table",
+                    message="A table row with one label-like cell was kept as row_header_path context.",
+                    metadata={"row_index": row_offset, "label": current_row_group or ""},
+                )
+            )
+            continue
+
+        row_label = row[0] if row and row[0] else f"row {row_offset + 1}"
+        for column_index, value in enumerate(row[1:], start=1):
+            if not _is_fact_value(value):
+                continue
+            skip_reason = _table_fact_value_skip_reason(value)
+            if skip_reason:
+                diagnostics.append(
+                    OpenDataLoaderAdapterDiagnostic(
+                        code="table_fact_value_skipped",
+                        block_id=block_id,
+                        element_type="table",
+                        message="A table cell was not converted to TableFact because it is unsafe as a compact fact value.",
+                        metadata={
+                            "row_index": row_offset,
+                            "column_index": column_index,
+                            "reason": skip_reason,
+                        },
+                    )
+                )
+                continue
+            column_path = (
+                column_paths[column_index]
+                if column_index < len(column_paths)
+                else (f"column {column_index + 1}",)
+            )
+            column_label = " > ".join(column_path)
+            row_header_path = (
+                (current_row_group, row_label)
+                if current_row_group
+                else (row_label,)
+            )
+            facts.append(
+                build_table_cell_fact(
+                    document_id=document_id,
+                    table_index=table_index,
+                    row_index=row_offset,
+                    column_index=column_index,
+                    row_label=row_label,
+                    column_label=column_label,
+                    value=value,
+                    source_block_id=source_block_id,
+                    caption=caption,
+                    row_header_path=row_header_path,
+                    column_path=column_path,
+                    header_path=tuple(header_path),
+                    confidence=0.85,
+                )
+            )
+    return tuple(facts)
+
+
+def _is_fact_value(value: str) -> bool:
+    cleaned = _clean_text(value)
+    return bool(cleaned and cleaned not in _EMPTY_TABLE_VALUES)
+
+
+def _table_header_row_count(rows: Sequence[Sequence[str]]) -> int:
+    header_count = 1
+    for row in rows[1:3]:
+        if _row_looks_like_header_extension(row):
+            header_count += 1
+        else:
+            break
+    return header_count
+
+
+def _row_looks_like_header_extension(row: Sequence[str]) -> bool:
+    cells = [_clean_text(cell) for cell in row]
+    non_empty = [cell for cell in cells if cell]
+    if not non_empty:
+        return False
+    if cells and cells[0]:
+        return False
+    return not any(_table_cell_has_compact_value(cell) for cell in non_empty)
+
+
+def _table_column_paths(header_rows: Sequence[Sequence[str]]) -> tuple[tuple[str, ...], ...]:
+    column_count = max((len(row) for row in header_rows), default=0)
+    column_paths: list[tuple[str, ...]] = []
+    for column_index in range(column_count):
+        parts: list[str] = []
+        for row in header_rows:
+            cell = _clean_text(row[column_index] if column_index < len(row) else "")
+            if cell and cell not in parts:
+                parts.append(cell)
+        column_paths.append(tuple(parts) if parts else (f"column {column_index + 1}",))
+    return tuple(column_paths)
+
+
+def _is_table_group_row(row: Sequence[str]) -> bool:
+    cells = [_clean_text(cell) for cell in row]
+    non_empty = [cell for cell in cells if cell]
+    if len(non_empty) != 1:
+        return False
+    return not _table_cell_has_compact_value(non_empty[0])
+
+
+def _table_fact_value_skip_reason(value: str) -> str | None:
+    cleaned = _clean_text(value)
+    if not cleaned or cleaned in _EMPTY_TABLE_VALUES:
+        return "empty_value"
+    if len(cleaned) > _MAX_COMPACT_TEXT_FACT_CHARS and not _table_cell_has_compact_value(cleaned):
+        return "overlong_text_value"
+    return None
+
+
+def _table_cell_has_compact_value(value: str) -> bool:
+    value_type, _ = infer_table_value_type(_clean_text(value))
+    return value_type in {"money", "count", "date", "number"}
+
+
+def _table_caption(heading_path: Sequence[str]) -> str | None:
+    return heading_path[-1] if heading_path else None
+
+
+def _fallback_reasons(
+    element: Mapping[str, Any],
+    text: str,
+    table_rows: Sequence[Sequence[str]],
+) -> tuple[str, ...]:
+    reasons: list[str] = []
+    if _has_adjacent_repeated_phrase(text):
+        reasons.append("possible_parallel_content_merge")
+    if _has_adjacent_repeated_label_suffix(text):
+        reasons.append("possible_parallel_label_merge")
+    if _normalize_element_type(element.get("type")) == "table" and not table_rows:
+        reasons.append("table_without_rows")
+    return tuple(reasons)
+
+
+def _has_adjacent_repeated_phrase(text: str) -> bool:
+    words = _clean_text(text).split()
+    if len(words) < 2:
+        return False
+    max_width = min(4, len(words) // 2)
+    for width in range(1, max_width + 1):
+        for index in range(0, len(words) - (2 * width) + 1):
+            if words[index : index + width] == words[index + width : index + (2 * width)]:
+                return True
+    return False
+
+
+def _has_adjacent_repeated_label_suffix(text: str) -> bool:
+    words = [
+        re.sub(r"^[^\w가-힣]+|[^\w가-힣]+$", "", word)
+        for word in _clean_text(text).split()
+    ]
+    words = [word for word in words if len(word) >= 4]
+    for left, right in zip(words, words[1:]):
+        if left == right:
+            continue
+        if left[-2:] == right[-2:]:
+            return True
+    return False
+
+
+def _confidence(
+    element: Mapping[str, Any],
+    text: str,
+    fallback_reasons: Sequence[str],
+) -> float:
+    if fallback_reasons:
+        return 0.55
+    if _bbox(element) is not None and text:
+        return 0.9
+    if text:
+        return 0.75
+    return 0.4
+
+
+def _bbox(element: Mapping[str, Any]) -> tuple[float, float, float, float] | None:
+    bbox = element.get("bounding box") or element.get("bbox")
+    if not isinstance(bbox, Sequence) or isinstance(bbox, (str, bytes)) or len(bbox) != 4:
+        return None
+    try:
+        return tuple(float(value) for value in bbox)  # type: ignore[return-value]
+    except (TypeError, ValueError):
+        return None
+
+
+def _coerce_int(value: Any) -> int | None:
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _clean_text(value: Any) -> str:
+    return re.sub(r"\s+", " ", str(value or "").replace("<br>", " ")).strip()
+
+
+def _join_text_parts(parts: Iterable[str]) -> str:
+    return "\n".join(part for part in (_clean_text(part) for part in parts) if part)
+
+
+def _last_text(values: Sequence[str]) -> str:
+    for value in reversed(values):
+        cleaned = _clean_text(value)
+        if cleaned:
+            return cleaned
+    return ""
+
+
+_CONTRACT_ELEMENT_TYPES = {"heading", "paragraph", "table", "list"}
+_ELEMENT_TYPE_ALIASES = {
+    "text_block": "paragraph",
+    "list_item": "paragraph",
+}
+_NAMED_HEADING_LEVELS = {
+    "doctitle": 1,
+    "title": 1,
+    "subtitle": 2,
+}
+_EMPTY_TABLE_VALUES = {"-", "–", "—", "ㆍ", ".", ""}
+_MAX_COMPACT_TEXT_FACT_CHARS = 80

--- a/ai-server/opendataloader_contract_adapter.py
+++ b/ai-server/opendataloader_contract_adapter.py
@@ -269,15 +269,51 @@ def _table_rows(element: Mapping[str, Any]) -> tuple[tuple[str, ...], ...]:
     if not isinstance(rows, Sequence) or isinstance(rows, (str, bytes)):
         return ()
     resolved_rows: list[tuple[str, ...]] = []
-    for row in rows:
+    row_span_carry: dict[int, dict[int, str]] = {}
+    for row_position, row in enumerate(rows):
         if not isinstance(row, Mapping):
             continue
+        row_number = _positive_int_from_mapping(
+            row,
+            _ROW_NUMBER_KEYS,
+            default=row_position + 1,
+        )
+        slots: dict[int, str] = dict(row_span_carry.pop(row_number, {}))
         cells = row.get("cells") or []
         if not isinstance(cells, Sequence) or isinstance(cells, (str, bytes)):
             continue
-        cell_texts = tuple(_element_text(cell) for cell in cells if isinstance(cell, Mapping))
-        if any(cell_texts):
-            resolved_rows.append(cell_texts)
+        next_column_index = 0
+        for cell in cells:
+            if not isinstance(cell, Mapping):
+                continue
+            fallback_column_index = _next_available_column_index(
+                slots,
+                next_column_index,
+            )
+            column_index = _zero_based_column_index(cell, fallback=fallback_column_index)
+            column_span = _positive_int_from_mapping(cell, _COLUMN_SPAN_KEYS, default=1)
+            row_span = _positive_int_from_mapping(cell, _ROW_SPAN_KEYS, default=1)
+            cell_text = _element_text(cell)
+
+            for span_offset in range(column_span):
+                resolved_column_index = column_index + span_offset
+                slots[resolved_column_index] = cell_text
+                for row_offset in range(1, row_span):
+                    carry_row_number = row_number + row_offset
+                    row_span_carry.setdefault(carry_row_number, {})[
+                        resolved_column_index
+                    ] = cell_text
+
+            next_column_index = max(next_column_index, column_index + column_span)
+
+        if slots:
+            width = max(slots) + 1
+            cell_texts = tuple(
+                _clean_text(slots.get(index, ""))
+                for index in range(width)
+            )
+            if any(cell_texts):
+                resolved_rows.append(cell_texts)
     return tuple(resolved_rows)
 
 
@@ -458,20 +494,26 @@ def _is_fact_value(value: str) -> bool:
 def _table_header_row_count(rows: Sequence[Sequence[str]]) -> int:
     header_count = 1
     for row in rows[1:3]:
-        if _row_looks_like_header_extension(row):
+        previous_row = rows[header_count - 1]
+        if _row_looks_like_header_extension(row, previous_row):
             header_count += 1
         else:
             break
     return header_count
 
 
-def _row_looks_like_header_extension(row: Sequence[str]) -> bool:
+def _row_looks_like_header_extension(
+    row: Sequence[str],
+    previous_row: Sequence[str] | None = None,
+) -> bool:
     cells = [_clean_text(cell) for cell in row]
     non_empty = [cell for cell in cells if cell]
     if not non_empty:
         return False
     if cells and cells[0]:
-        return False
+        previous_first = _clean_text(previous_row[0]) if previous_row else ""
+        if cells[0] != previous_first:
+            return False
     return not any(_table_cell_has_compact_value(cell) for cell in non_empty)
 
 
@@ -588,6 +630,41 @@ def _coerce_int(value: Any) -> int | None:
         return None
 
 
+def _positive_int_from_mapping(
+    values: Mapping[str, Any],
+    keys: Sequence[str],
+    *,
+    default: int,
+) -> int:
+    for key in keys:
+        if key not in values:
+            continue
+        parsed = _coerce_int(values[key])
+        if parsed is not None and parsed > 0:
+            return parsed
+    return default
+
+
+def _zero_based_column_index(values: Mapping[str, Any], *, fallback: int) -> int:
+    parsed = None
+    for key in _COLUMN_NUMBER_KEYS:
+        if key in values:
+            parsed = _coerce_int(values[key])
+            break
+    if parsed is None:
+        return fallback
+    if parsed <= 0:
+        return 0
+    return parsed - 1
+
+
+def _next_available_column_index(slots: Mapping[int, str], start: int) -> int:
+    candidate = max(0, start)
+    while candidate in slots:
+        candidate += 1
+    return candidate
+
+
 def _clean_text(value: Any) -> str:
     return re.sub(r"\s+", " ", str(value or "").replace("<br>", " ")).strip()
 
@@ -616,3 +693,7 @@ _NAMED_HEADING_LEVELS = {
 }
 _EMPTY_TABLE_VALUES = {"-", "–", "—", "ㆍ", ".", ""}
 _MAX_COMPACT_TEXT_FACT_CHARS = 80
+_ROW_NUMBER_KEYS = ("row number", "row_number", "row")
+_COLUMN_NUMBER_KEYS = ("column number", "column_number", "col number", "col_number")
+_ROW_SPAN_KEYS = ("row span", "row_span", "rowspan")
+_COLUMN_SPAN_KEYS = ("column span", "column_span", "col span", "col_span", "colspan")

--- a/ai-server/opendataloader_contract_adapter.py
+++ b/ai-server/opendataloader_contract_adapter.py
@@ -220,18 +220,33 @@ def _iter_elements(elements: Iterable[Any]) -> Iterable[Mapping[str, Any]]:
     for element in elements:
         if not isinstance(element, Mapping):
             continue
-        yield element
         element_type = _normalize_element_type(element.get("type"))
+        nested = _nested_text_children(element)
+        if not _is_container_only_element(element, nested):
+            yield element
         if element_type in {"table", "list"}:
             continue
-        nested = element.get("kids") or element.get("children") or []
-        if isinstance(nested, Sequence) and not isinstance(nested, (str, bytes)):
+        if nested:
             yield from _iter_elements(nested)
 
 
 def _normalize_element_type(value: Any) -> str:
-    normalized = re.sub(r"\s+", "_", str(value or "").strip().lower())
+    normalized = _raw_element_type(value)
     return _ELEMENT_TYPE_ALIASES.get(normalized, normalized)
+
+
+def _raw_element_type(value: Any) -> str:
+    return re.sub(r"\s+", "_", str(value or "").strip().lower())
+
+
+def _is_container_only_element(
+    element: Mapping[str, Any],
+    nested: Sequence[Mapping[str, Any]],
+) -> bool:
+    return bool(
+        nested
+        and _raw_element_type(element.get("type")) in _CONTAINER_ONLY_ELEMENT_TYPES
+    )
 
 
 def _element_text(element: Mapping[str, Any]) -> str:
@@ -682,6 +697,7 @@ def _last_text(values: Sequence[str]) -> str:
 
 
 _CONTRACT_ELEMENT_TYPES = {"heading", "paragraph", "table", "list"}
+_CONTAINER_ONLY_ELEMENT_TYPES = {"text_block"}
 _ELEMENT_TYPE_ALIASES = {
     "text_block": "paragraph",
     "list_item": "paragraph",

--- a/ai-server/opendataloader_contract_adapter.py
+++ b/ai-server/opendataloader_contract_adapter.py
@@ -8,7 +8,7 @@ ParsedBlock, SectionNode, SourceBlock, and TableFact contracts.
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 import json
 import re
 from collections.abc import Iterable, Mapping, Sequence
@@ -21,7 +21,14 @@ from rag_contract_builders import (
     build_table_cell_fact,
     infer_table_value_type,
 )
-from rag_contracts import JsonValue, ParsedBlock, SectionNode, SourceBlock, TableFact
+from rag_contracts import (
+    JsonValue,
+    PageSpan,
+    ParsedBlock,
+    SectionNode,
+    SourceBlock,
+    TableFact,
+)
 
 
 @dataclass(frozen=True)
@@ -101,7 +108,12 @@ def adapt_opendataloader_json_page(
 
         section_node = build_section_node(parsed_block)
         if section_node is not None:
-            section_by_id.setdefault(section_node.section_id, section_node)
+            existing_section = section_by_id.get(section_node.section_id)
+            section_by_id[section_node.section_id] = (
+                _merge_section_nodes(existing_section, section_node)
+                if existing_section is not None
+                else section_node
+            )
 
         source_block = build_source_block(
             parsed_block,
@@ -224,10 +236,43 @@ def _iter_elements(elements: Iterable[Any]) -> Iterable[Mapping[str, Any]]:
         nested = _nested_text_children(element)
         if not _is_container_only_element(element, nested):
             yield element
-        if element_type in {"table", "list"}:
+        if element_type in _SUBTREE_STOP_ELEMENT_TYPES:
             continue
         if nested:
             yield from _iter_elements(nested)
+
+
+def _merge_section_nodes(existing: SectionNode, incoming: SectionNode) -> SectionNode:
+    return replace(
+        existing,
+        page_span=_merge_page_spans(existing.page_span, incoming.page_span),
+        block_ids=_append_unique(existing.block_ids, incoming.block_ids),
+    )
+
+
+def _merge_page_spans(left: PageSpan | None, right: PageSpan | None) -> PageSpan | None:
+    if left is None:
+        return right
+    if right is None:
+        return left
+
+    starts = [value for value in (left.start, right.start) if value is not None]
+    ends = [value for value in (left.end, right.end) if value is not None]
+    return PageSpan(
+        start=min(starts) if starts else None,
+        end=max(ends) if ends else None,
+    )
+
+
+def _append_unique(left: Sequence[str], right: Sequence[str]) -> tuple[str, ...]:
+    merged: list[str] = []
+    seen: set[str] = set()
+    for value in (*left, *right):
+        if value in seen:
+            continue
+        seen.add(value)
+        merged.append(value)
+    return tuple(merged)
 
 
 def _normalize_element_type(value: Any) -> str:
@@ -705,6 +750,14 @@ _CONTRACT_ELEMENT_TYPES = {
     "formula",
 }
 _CONTAINER_ONLY_ELEMENT_TYPES = {"text_block"}
+_SUBTREE_STOP_ELEMENT_TYPES = {
+    "table",
+    "list",
+    "header",
+    "footer",
+    "page_header",
+    "page_footer",
+}
 _ELEMENT_TYPE_ALIASES = {
     "text_block": "paragraph",
     "list_item": "paragraph",

--- a/ai-server/rag_contract_builders.py
+++ b/ai-server/rag_contract_builders.py
@@ -165,14 +165,20 @@ def build_table_cell_fact(
     value: str,
     source_block_id: str,
     caption: str | None = None,
+    row_header_path: Sequence[str] = (),
     column_path: Sequence[str] = (),
     header_path: Sequence[str] = (),
     fact_type: str = "cell",
     confidence: float | None = None,
 ) -> TableFact:
     """Create a typed TableFact from one table cell and its row/column labels."""
+    cleaned_row_label = _clean_cell_text(row_label)
     cleaned_value = _clean_cell_text(value)
     value_type, unit = infer_table_value_type(cleaned_value)
+    row_path_parts = [_clean_cell_text(str(part)) for part in row_header_path]
+    resolved_row_header_path = tuple(part for part in row_path_parts if part)
+    if not resolved_row_header_path and cleaned_row_label:
+        resolved_row_header_path = (cleaned_row_label,)
     resolved_column_path = tuple(
         str(part).strip()
         for part in column_path
@@ -185,7 +191,7 @@ def build_table_cell_fact(
         fact_id=_table_fact_id(document_id, table_index, row_index, column_index),
         fact_type=fact_type,
         table_id=_contract_id(document_id, "table", table_index),
-        row_label=_clean_cell_text(row_label) or "해당 행",
+        row_label=cleaned_row_label or "해당 행",
         column_label=_clean_cell_text(column_label) or f"열 {column_index + 1}",
         value=cleaned_value,
         source_block_id=source_block_id,
@@ -193,6 +199,7 @@ def build_table_cell_fact(
         unit=unit,
         row_index=row_index,
         column_index=column_index,
+        row_header_path=resolved_row_header_path,
         column_path=resolved_column_path,
         header_path=tuple(str(part).strip() for part in header_path if str(part).strip()),
         caption=_clean_cell_text(caption or "") or None,

--- a/ai-server/rag_contracts.py
+++ b/ai-server/rag_contracts.py
@@ -119,6 +119,7 @@ class TableFact:
     unit: str | None = None
     row_index: int | None = None
     column_index: int | None = None
+    row_header_path: tuple[str, ...] = ()
     column_path: tuple[str, ...] = ()
     header_path: tuple[str, ...] = ()
     caption: str | None = None


### PR DESCRIPTION
## 배경

#98은 #94 학과 카드 source contamination(출처 오염), #96 면접 예상 질문 retrieval miss(검색 누락), #97 TableFact row selection(표 행 선택) 문제를 바로 heuristic(휴리스틱, 경험적 규칙)으로 고치기 전에 OpenDataLoader JSON(OpenDataLoader가 만든 JSON 문서 구조)을 DocuMind RAG contract(DocuMind RAG 데이터 계약)로 옮기는 기준을 잡는 작업입니다.

## 변경 내용

- OpenDataLoader JSON element(JSON 문서 요소)를 재귀 순회하는 side-effect free adapter(부작용 없는 변환기)를 추가했습니다.
- heading(제목), paragraph(문단), table(표), list(목록), page(페이지), bbox(좌표)를 ParsedBlock(파서 결과 정리 블록), SourceBlock(사용자에게 보여줄 원문 출처 블록), SectionNode(문서 제목 계층 블록), TableFact(표의 행/열/값 구조화 근거) 후보로 변환합니다.
- TableFact(표의 행/열/값 구조화 근거)에 row_header_path(행 제목 경로)를 추가해 표 내부 group row(그룹 행) 문맥을 보존합니다.
- TableFact(표의 행/열/값 구조화 근거) 후보를 EXAONE(EXAONE 언어모델)이 읽기 쉬운 한국어 evidence text(근거 텍스트)로 렌더링하는 smoke test(가벼운 검증)를 추가했습니다.
- runtime upload flow(실제 업로드 흐름), ChromaDB schema(벡터 저장소 스키마), retrieval ranking(검색 순위), prompt(모델 입력문), source response(출처 응답)는 변경하지 않았습니다.

## 변경 파일

- ai-server/rag_contracts.py
- ai-server/rag_contract_builders.py
- ai-server/check_rag_contracts.py
- ai-server/opendataloader_contract_adapter.py
- ai-server/check_opendataloader_contract_adapter.py

## 검증

- py_compile(파이썬 문법 검사) 통과
- check_rag_contracts.py(RAG 계약 가벼운 검증): rag_contracts smoke ok
- check_opendataloader_contract_adapter.py(OpenDataLoader 변환기 가벼운 검증): opendataloader contract adapter smoke ok
- git diff --check(공백/패치 형식 검사) 통과

## 이슈

Closes #98
Related #73