### PR TITLE
[AI/RAG] TableFact 표 행 선택 디버그 검증 추가

### DIFF
--- a/ai-server/check_table_fact_runtime_extraction.py
+++ b/ai-server/check_table_fact_runtime_extraction.py
@@ -1,0 +1,45 @@
+"""Smoke checks for runtime Markdown table fact extraction."""
+
+from __future__ import annotations
+
+from main import (
+    _extract_table_fact_pairs,
+    _extract_table_fact_row_subject,
+    _extract_table_facts,
+)
+
+
+def main() -> None:
+    """Verify row labels survive grouped Markdown table extraction."""
+    sample = """
+###### 전형 지원자격
+
+|전형| |지원자격|
+|---|---|---|
+|지역전형|유형Ⅰ|중학교 입학일부터 고등학교 졸업일까지 거주한 지원자|
+| |유형Ⅱ|초등학교 입학일부터 고등학교 졸업일까지 거주한 지원자|
+| |공통|지원자격을 졸업일까지 유지해야 함|
+|---|---|---|
+"""
+    facts = _extract_table_facts(sample, {"document_id": "runtime-table-smoke"})
+    subjects = [_extract_table_fact_row_subject(fact) for fact in facts]
+
+    assert "유형Ⅰ" in subjects
+    assert "유형Ⅱ" in subjects
+    assert "공통" in subjects
+    assert "---" not in subjects
+
+    fact_by_subject = {
+        _extract_table_fact_row_subject(fact): _extract_table_fact_pairs(fact)
+        for fact in facts
+    }
+    assert ("전형", "지역전형") in fact_by_subject["유형Ⅰ"]
+    assert ("전형", "유형Ⅰ") in fact_by_subject["유형Ⅰ"]
+    assert ("전형", "지역전형") in fact_by_subject["유형Ⅱ"]
+    assert ("전형", "유형Ⅱ") in fact_by_subject["유형Ⅱ"]
+
+    print("table fact runtime extraction smoke ok")
+
+
+if __name__ == "__main__":
+    main()

--- a/ai-server/check_table_fact_runtime_extraction.py
+++ b/ai-server/check_table_fact_runtime_extraction.py
@@ -6,6 +6,7 @@ from main import (
     _extract_table_fact_pairs,
     _extract_table_fact_row_subject,
     _extract_table_facts,
+    _typed_table_fact_contract_candidates,
 )
 
 
@@ -37,6 +38,67 @@ def main() -> None:
     assert ("전형", "유형Ⅰ") in fact_by_subject["유형Ⅰ"]
     assert ("전형", "지역전형") in fact_by_subject["유형Ⅱ"]
     assert ("전형", "유형Ⅱ") in fact_by_subject["유형Ⅱ"]
+
+    ordinary_sample = """
+###### 학과별 지원자격
+
+|모집단위|전형|지원자격|
+|---|---|---|
+|컴퓨터정보공학과|일반고|일반고 졸업자|
+"""
+    ordinary_facts = _extract_table_facts(
+        ordinary_sample,
+        {"document_id": "runtime-table-smoke"},
+    )
+    ordinary_subjects = [
+        _extract_table_fact_row_subject(fact)
+        for fact in ordinary_facts
+    ]
+    assert "컴퓨터정보공학과" in ordinary_subjects
+    assert "일반고" not in ordinary_subjects
+
+    wide_sample = """
+###### 전형 지원자격
+
+|전형| |지원자격|항목1|항목2|항목3|항목4|항목5|항목6|항목7|항목8|
+|---|---|---|---|---|---|---|---|---|---|---|
+|지역전형|유형Ⅰ|조건1|A1|B1|C1|D1|E1|F1|G1|H1|
+| |유형Ⅱ|조건2|A2|B2|C2|D2|E2|F2|G2|H2|
+"""
+    typed_candidates = _typed_table_fact_contract_candidates(
+        chunk_id="wide-table-smoke",
+        doc=wide_sample,
+        meta={"document_id": "runtime-table-smoke"},
+        source_block_id="source-wide-table-smoke",
+    )
+    typed_rows = {
+        table_fact.row_label
+        for table_fact, _ in typed_candidates
+    }
+    assert "유형Ⅰ" in typed_rows
+    assert "유형Ⅱ" in typed_rows
+
+    stale_fact_candidates = _typed_table_fact_contract_candidates(
+        chunk_id="stale-fact-smoke",
+        doc=sample,
+        meta={
+            "document_id": "runtime-table-smoke",
+            "matched_table_facts": [
+                "전형 지원자격: 오래된행 행 정보는 지원자격=오래된 값이다."
+            ],
+        },
+        source_block_id="source-stale-fact-smoke",
+    )
+    stale_fact_sources = {
+        fact_source
+        for _, fact_source in stale_fact_candidates
+    }
+    stale_fact_rows = {
+        table_fact.row_label
+        for table_fact, _ in stale_fact_candidates
+    }
+    assert stale_fact_sources == {"extracted_from_candidate_doc"}
+    assert "오래된행" not in stale_fact_rows
 
     print("table fact runtime extraction smoke ok")
 

--- a/ai-server/check_table_fact_selector.py
+++ b/ai-server/check_table_fact_selector.py
@@ -1,0 +1,95 @@
+"""Smoke checks for question-aware typed TableFact selection."""
+
+from __future__ import annotations
+
+from rag_contract_builders import build_table_cell_fact
+from rag_table_fact_selector import select_table_facts_for_question
+
+
+def main() -> None:
+    """Verify row-scoped TableFact selection without running DocuMind runtime."""
+    table_facts = [
+        _fact(0, 1, "유형 I", "지원자격", "일반고 졸업자"),
+        _fact(0, 2, "유형 I", "제출서류", "학교생활기록부"),
+        _fact(1, 1, "유형 II", "지원자격", "검정고시 출신자"),
+        _fact(1, 2, "유형 II", "제출서류", "검정고시 성적증명서"),
+        _fact(2, 1, "공통 지원자격", "지원자격", "고등학교 졸업 이상"),
+        _fact(3, 1, "추가선발", "지원자격", "미충원 시 별도 선발"),
+        _fact(0, 1, "면접학과", "계", "50,000원", table_index=2),
+    ]
+
+    comparison_result = select_table_facts_for_question(
+        "유형 I과 유형 II의 차이는 무엇인가요?",
+        table_facts,
+    )
+    comparison_rows = {selection.fact.row_label for selection in comparison_result.selections}
+    assert comparison_result.comparison_mode is True
+    assert comparison_result.target_row_labels == ("유형 1", "유형 2")
+    assert comparison_rows == {"유형 I", "유형 II"}
+    assert "공통 지원자격" not in comparison_rows
+    assert "추가선발" not in comparison_rows
+    assert "면접학과" not in comparison_rows
+
+    single_row_result = select_table_facts_for_question(
+        "유형 1의 지원자격은 무엇인가요?",
+        table_facts,
+    )
+    single_rows = {selection.fact.row_label for selection in single_row_result.selections}
+    assert single_row_result.comparison_mode is False
+    assert single_row_result.target_row_labels == ("유형 1",)
+    assert single_rows == {"유형 I"}
+    assert all(selection.fact.column_label == "지원자격" for selection in single_row_result.selections)
+
+    column_only_result = select_table_facts_for_question(
+        "지원자격은 무엇인가요?",
+        table_facts,
+        max_facts=4,
+    )
+    column_rows = {selection.fact.row_label for selection in column_only_result.selections}
+    assert column_only_result.target_row_labels == ()
+    assert {"유형 I", "유형 II", "공통 지원자격", "추가선발"}.issuperset(column_rows)
+    assert "면접학과" not in column_rows
+
+    unresolved_comparison = select_table_facts_for_question(
+        "유형 I과 유형 II의 차이는 무엇인가요?",
+        [
+            _fact(0, 1, "유형 II", "지원자격", "검정고시 출신자"),
+            _fact(1, 1, "공통", "지원자격", "고등학교 졸업 이상"),
+        ],
+    )
+    assert unresolved_comparison.comparison_mode is True
+    assert unresolved_comparison.target_row_labels == ()
+    assert unresolved_comparison.selections == ()
+    assert unresolved_comparison.diagnostics[0].code == "comparison_target_rows_unresolved"
+
+    print("table fact selector smoke ok")
+
+
+def _fact(
+    row_index: int,
+    column_index: int,
+    row_label: str,
+    column_label: str,
+    value: str,
+    *,
+    table_index: int = 1,
+):
+    return build_table_cell_fact(
+        document_id="selector-smoke",
+        table_index=table_index,
+        row_index=row_index,
+        column_index=column_index,
+        row_label=row_label,
+        column_label=column_label,
+        value=value,
+        source_block_id=f"source-{table_index}",
+        caption="전형 유형 비교표" if table_index == 1 else "전형료 표",
+        row_header_path=(row_label,),
+        column_path=(column_label,),
+        header_path=("문서 제목", "전형 유형"),
+        confidence=0.9,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/ai-server/main.py
+++ b/ai-server/main.py
@@ -32,7 +32,8 @@ from rag_contract_builders import (
     section_path_quality,
     section_path_warnings,
 )
-from rag_contracts import contract_to_dict
+from rag_contracts import TableFact, contract_to_dict
+from rag_table_fact_selector import select_table_facts_for_question
 
 try:
     from kiwipiepy import Kiwi
@@ -713,7 +714,7 @@ def _clean_table_cell(cell: str) -> str:
 
 def _is_empty_table_cell(cell: str) -> bool:
     """Markdown 파싱 과정에서 생긴 빈 cell인지 확인한다."""
-    return not cell or cell in {"-", "–", "—"}
+    return not cell or cell in {"-", "–", "—"} or bool(re.fullmatch(r"[-–—]+", cell))
 
 
 def _normalize_table_symbol(symbol: str) -> str:
@@ -801,6 +802,8 @@ def _is_probable_subheader_row(row: list[str]) -> bool:
         return False
     if any(re.search(r"\d", cell) for cell in non_empty_cells):
         return False
+    if any(len(cell) > 24 or len(cell.split()) >= 4 for cell in non_empty_cells):
+        return False
     return True
 
 
@@ -844,8 +847,7 @@ def _select_row_subject(row: list[str], column_labels: list[str]) -> tuple[str, 
         label = column_labels[index] if index < len(column_labels) else f"열 {index + 1}"
         descriptors.append(f"{label}={cell}")
         if (
-            not preferred_subject
-            and any(keyword in label for keyword in ("모집단위", "학과", "항목", "요소", "구분", "전형", "프로젝트 유형"))
+            any(keyword in label for keyword in ("모집단위", "학과", "항목", "요소", "구분", "전형", "프로젝트 유형"))
             and not re.fullmatch(r"[\d.,]+", cell)
         ):
             preferred_subject = cell
@@ -4440,22 +4442,32 @@ def _query_intent_contract_preview(question: str, analysis: QueryAnalysis) -> di
     return contract_to_dict(query_intent)
 
 
-def _typed_table_fact_contract_previews(
+def _typed_table_fact_contract_candidates(
     chunk_id: str,
     doc: str,
     meta: dict,
     source_block_id: str,
     max_facts: int = 8,
-) -> list[dict]:
-    """runtime table_fact 문자열을 typed TableFact preview로 변환한다."""
-    facts = _get_matched_table_facts(meta)
-    fact_source = "matched_table_facts"
-    if not facts and meta.get("chunk_role") == "table_fact":
-        facts = [doc.strip()] if doc.strip() else []
-        fact_source = "candidate_table_fact_document"
-    elif not facts and "|" in doc:
-        facts = _extract_table_facts(doc, meta)
-        fact_source = "extracted_from_candidate_doc"
+) -> list[tuple[TableFact, str]]:
+    """runtime table_fact 문자열을 typed TableFact 후보로 변환한다."""
+    fact_entries: list[tuple[str, str]] = []
+    seen_facts: set[str] = set()
+
+    def append_facts(facts: list[str], fact_source: str) -> None:
+        for fact in facts:
+            normalized_fact = fact.strip()
+            if not normalized_fact or normalized_fact in seen_facts:
+                continue
+            seen_facts.add(normalized_fact)
+            fact_entries.append((normalized_fact, fact_source))
+
+    if "|" in doc and meta.get("chunk_role") != "table_fact":
+        append_facts(_extract_table_facts(doc, meta), "extracted_from_candidate_doc")
+
+    append_facts(_get_matched_table_facts(meta), "matched_table_facts")
+
+    if not fact_entries and meta.get("chunk_role") == "table_fact":
+        append_facts([doc.strip()] if doc.strip() else [], "candidate_table_fact_document")
 
     header_path = tuple(
         str(meta.get(header_key) or "").strip()
@@ -4464,8 +4476,8 @@ def _typed_table_fact_contract_previews(
     )
     table_index = _contract_block_index(chunk_id, meta)
     resolved_source_block_id = str(meta.get("source_block_id") or source_block_id)
-    previews: list[dict] = []
-    for row_index, fact in enumerate(facts):
+    candidates: list[tuple[TableFact, str]] = []
+    for row_index, (fact, fact_source) in enumerate(fact_entries):
         row_label = _extract_table_fact_row_subject(fact)
         if not row_label:
             continue
@@ -4487,15 +4499,59 @@ def _typed_table_fact_contract_previews(
                 caption=caption,
                 header_path=header_path,
             )
-            preview = contract_to_dict(table_fact)
-            preview["preview_source"] = fact_source
-            previews.append(preview)
-            if len(previews) >= max_facts:
-                return previews
-    return previews
+            candidates.append((table_fact, fact_source))
+            if len(candidates) >= max_facts:
+                return candidates
+    return candidates
 
 
-def _contract_trace_preview(chunk_id: str, doc: str, meta: dict, preview_chars: int = 240) -> dict:
+def _typed_table_fact_preview(table_fact: TableFact, fact_source: str) -> dict:
+    preview = contract_to_dict(table_fact)
+    preview["preview_source"] = fact_source
+    return preview
+
+
+def _selected_table_fact_previews(
+    question: str,
+    table_fact_candidates: list[tuple[TableFact, str]],
+) -> dict:
+    typed_facts = [table_fact for table_fact, _ in table_fact_candidates]
+    selection_result = select_table_facts_for_question(question, typed_facts)
+    fact_source_by_id = {
+        table_fact.fact_id: fact_source
+        for table_fact, fact_source in table_fact_candidates
+    }
+    selected_previews = []
+    for selection in selection_result.selections:
+        preview = contract_to_dict(selection.fact)
+        preview["preview_source"] = fact_source_by_id.get(selection.fact.fact_id, "")
+        preview["selection_score"] = selection.score
+        preview["selection_reasons"] = list(selection.reasons)
+        preview["matched_row_terms"] = list(selection.matched_row_terms)
+        preview["matched_column_terms"] = list(selection.matched_column_terms)
+        selected_previews.append(preview)
+    return {
+        "comparison_mode": selection_result.comparison_mode,
+        "target_row_labels": list(selection_result.target_row_labels),
+        "selected_facts": selected_previews,
+        "diagnostics": [
+            {
+                "code": diagnostic.code,
+                "message": diagnostic.message,
+                "details": diagnostic.details or {},
+            }
+            for diagnostic in selection_result.diagnostics
+        ],
+    }
+
+
+def _contract_trace_preview(
+    chunk_id: str,
+    doc: str,
+    meta: dict,
+    preview_chars: int = 240,
+    question: str | None = None,
+) -> dict:
     """현재 trace 후보를 ParsedBlock/SourceBlock 진단 preview로 변환한다."""
     meta = meta or {}
     try:
@@ -4524,11 +4580,20 @@ def _contract_trace_preview(chunk_id: str, doc: str, meta: dict, preview_chars: 
         )
         page_span = source_block.page_span
         section_path = list(section_node.path) if section_node else []
-        typed_table_facts = _typed_table_fact_contract_previews(
+        typed_table_fact_candidates = _typed_table_fact_contract_candidates(
             str(chunk_id),
             doc,
             meta,
             source_block.source_block_id,
+        )
+        typed_table_facts = [
+            _typed_table_fact_preview(table_fact, fact_source)
+            for table_fact, fact_source in typed_table_fact_candidates
+        ]
+        selected_table_facts = (
+            _selected_table_fact_previews(question, typed_table_fact_candidates)
+            if question and typed_table_fact_candidates
+            else None
         )
         return {
             "parsed_block_id": parsed_block.block_id,
@@ -4584,13 +4649,20 @@ def _contract_trace_preview(chunk_id: str, doc: str, meta: dict, preview_chars: 
                 preview_chars=preview_chars,
             ),
             "typed_table_facts": typed_table_facts,
+            "selected_table_facts": selected_table_facts,
         }
     except Exception:
         logger.exception("[rag_contract_preview] failed chunk_id=%s", chunk_id)
         return {"error": "contract_preview_failed"}
 
 
-def _candidate_location_summary(chunk_id: str, doc: str, meta: dict, preview_chars: int = 360) -> dict:
+def _candidate_location_summary(
+    chunk_id: str,
+    doc: str,
+    meta: dict,
+    preview_chars: int = 360,
+    question: str | None = None,
+) -> dict:
     """trace 후보의 문서 위치와 본문 미리보기를 만든다."""
     meta = meta or {}
     return {
@@ -4605,7 +4677,12 @@ def _candidate_location_summary(chunk_id: str, doc: str, meta: dict, preview_cha
         "chunk_index": meta.get("chunk_index", _parse_chunk_index(str(chunk_id))),
         "header_path": _format_header_path(meta),
         "content_preview": _preview_text(doc, preview_chars),
-        "contract_preview": _contract_trace_preview(str(chunk_id), doc, meta),
+        "contract_preview": _contract_trace_preview(
+            str(chunk_id),
+            doc,
+            meta,
+            question=question,
+        ),
     }
 
 
@@ -4741,7 +4818,7 @@ def _format_rerank_candidate(
 
     trace_key = _candidate_parent_key(str(chunk_id), meta)
     retrieval = trace_by_id.get(str(chunk_id)) or trace_by_id.get(trace_key) or {"retrieval_methods": []}
-    formatted = _candidate_location_summary(chunk_id, doc, meta)
+    formatted = _candidate_location_summary(chunk_id, doc, meta, question=question)
     formatted.update({
         "rank": rank,
         "selected_for_prompt": selected,

--- a/ai-server/main.py
+++ b/ai-server/main.py
@@ -795,8 +795,15 @@ def _parse_markdown_table(block_text: str) -> tuple[list[list[str]], list[list[s
     return padded_headers, padded_body
 
 
-def _is_probable_subheader_row(row: list[str]) -> bool:
+def _is_probable_subheader_row(row: list[str], header_rows: list[list[str]] | None = None) -> bool:
     """본문 첫 줄이 실제 데이터가 아니라 병합 header 보강 row인지 추정한다."""
+    if header_rows and not any(
+        _is_empty_table_cell(cell)
+        for header_row in header_rows
+        for cell in header_row
+    ):
+        return False
+
     non_empty_cells = [cell for cell in row if not _is_empty_table_cell(cell)]
     if len(non_empty_cells) < 2:
         return False
@@ -841,6 +848,7 @@ def _select_row_subject(row: list[str], column_labels: list[str]) -> tuple[str, 
     descriptors: list[str] = []
     subject = ""
     preferred_subject = ""
+    preferred_subject_label = ""
     for index, cell in enumerate(row):
         if _is_empty_table_cell(cell):
             continue
@@ -850,7 +858,12 @@ def _select_row_subject(row: list[str], column_labels: list[str]) -> tuple[str, 
             any(keyword in label for keyword in ("모집단위", "학과", "항목", "요소", "구분", "전형", "프로젝트 유형"))
             and not re.fullmatch(r"[\d.,]+", cell)
         ):
-            preferred_subject = cell
+            normalized_label = re.sub(r"\s+", "", label)
+            if not preferred_subject:
+                preferred_subject = cell
+                preferred_subject_label = normalized_label
+            elif normalized_label == preferred_subject_label:
+                preferred_subject = cell
         if not subject and not re.fullmatch(r"[\d.,]+", cell):
             subject = cell
         if len(descriptors) >= 3:
@@ -977,7 +990,7 @@ def _extract_table_facts(text: str, metadata: dict) -> list[str]:
         if not header_rows or not body_rows:
             continue
 
-        subheader_row = body_rows[0] if body_rows and _is_probable_subheader_row(body_rows[0]) else None
+        subheader_row = body_rows[0] if body_rows and _is_probable_subheader_row(body_rows[0], header_rows) else None
         data_rows = body_rows[1:] if subheader_row else body_rows
         column_labels = _compose_column_labels(header_rows, subheader_row)
         generate_matrix_facts = _should_generate_matrix_facts(column_labels)
@@ -4447,7 +4460,6 @@ def _typed_table_fact_contract_candidates(
     doc: str,
     meta: dict,
     source_block_id: str,
-    max_facts: int = 8,
 ) -> list[tuple[TableFact, str]]:
     """runtime table_fact 문자열을 typed TableFact 후보로 변환한다."""
     fact_entries: list[tuple[str, str]] = []
@@ -4461,10 +4473,15 @@ def _typed_table_fact_contract_candidates(
             seen_facts.add(normalized_fact)
             fact_entries.append((normalized_fact, fact_source))
 
-    if "|" in doc and meta.get("chunk_role") != "table_fact":
-        append_facts(_extract_table_facts(doc, meta), "extracted_from_candidate_doc")
+    extracted_facts = (
+        _extract_table_facts(doc, meta)
+        if "|" in doc and meta.get("chunk_role") != "table_fact"
+        else []
+    )
+    append_facts(extracted_facts, "extracted_from_candidate_doc")
 
-    append_facts(_get_matched_table_facts(meta), "matched_table_facts")
+    if not fact_entries:
+        append_facts(_get_matched_table_facts(meta), "matched_table_facts")
 
     if not fact_entries and meta.get("chunk_role") == "table_fact":
         append_facts([doc.strip()] if doc.strip() else [], "candidate_table_fact_document")
@@ -4500,8 +4517,6 @@ def _typed_table_fact_contract_candidates(
                 header_path=header_path,
             )
             candidates.append((table_fact, fact_source))
-            if len(candidates) >= max_facts:
-                return candidates
     return candidates
 
 
@@ -4586,9 +4601,12 @@ def _contract_trace_preview(
             meta,
             source_block.source_block_id,
         )
+        typed_table_fact_preview_limit = 8
         typed_table_facts = [
             _typed_table_fact_preview(table_fact, fact_source)
-            for table_fact, fact_source in typed_table_fact_candidates
+            for table_fact, fact_source in typed_table_fact_candidates[
+                :typed_table_fact_preview_limit
+            ]
         ]
         selected_table_facts = (
             _selected_table_fact_previews(question, typed_table_fact_candidates)
@@ -4649,6 +4667,11 @@ def _contract_trace_preview(
                 preview_chars=preview_chars,
             ),
             "typed_table_facts": typed_table_facts,
+            "typed_table_fact_count": len(typed_table_fact_candidates),
+            "typed_table_fact_preview_limit": typed_table_fact_preview_limit,
+            "typed_table_fact_preview_truncated": (
+                len(typed_table_fact_candidates) > typed_table_fact_preview_limit
+            ),
             "selected_table_facts": selected_table_facts,
         }
     except Exception:

--- a/ai-server/rag_table_fact_selector.py
+++ b/ai-server/rag_table_fact_selector.py
@@ -1,0 +1,309 @@
+"""Question-aware selection helpers for typed TableFact candidates.
+
+This module is intentionally side-effect free. It does not call ChromaDB,
+change retrieval ranking, alter prompts, or connect to ``/query``. Its job is
+to smoke-test whether typed table facts can be narrowed to the rows that a
+question actually asks about.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import re
+from collections.abc import Iterable, Sequence
+
+from rag_contracts import TableFact
+
+
+@dataclass(frozen=True)
+class TableFactSelection:
+    """One selected table fact with row/column match diagnostics."""
+
+    fact: TableFact
+    score: int
+    reasons: tuple[str, ...] = ()
+    matched_row_terms: tuple[str, ...] = ()
+    matched_column_terms: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class TableFactSelectionDiagnostic:
+    """A non-fatal selector note for audit and smoke output."""
+
+    code: str
+    message: str
+    details: dict[str, str | int | list[str]] | None = None
+
+
+@dataclass(frozen=True)
+class TableFactSelectionResult:
+    """The selected table facts and selector-level diagnostics."""
+
+    selections: tuple[TableFactSelection, ...]
+    comparison_mode: bool
+    target_row_labels: tuple[str, ...] = ()
+    diagnostics: tuple[TableFactSelectionDiagnostic, ...] = ()
+
+
+def select_table_facts_for_question(
+    question: str,
+    table_facts: Sequence[TableFact],
+    *,
+    max_facts: int = 12,
+) -> TableFactSelectionResult:
+    """Select TableFact rows that are most relevant to a question."""
+    normalized_question = _normalize_text(question)
+    comparison_mode = _is_comparison_question(normalized_question)
+    scored = tuple(
+        selection
+        for fact in table_facts
+        if (selection := _score_table_fact(fact, normalized_question)).score > 0
+    )
+
+    target_row_labels = _target_row_labels(scored, comparison_mode)
+    diagnostics: list[TableFactSelectionDiagnostic] = []
+    selected = scored
+    if comparison_mode and not target_row_labels:
+        selected = ()
+        matched_rows = _matched_row_labels(scored)
+        diagnostics.append(
+            TableFactSelectionDiagnostic(
+                code="comparison_target_rows_unresolved",
+                message="Comparison question did not resolve at least two explicit target rows.",
+                details={"matched_row_labels": list(matched_rows)},
+            )
+        )
+    elif target_row_labels:
+        selected = tuple(
+            selection
+            for selection in scored
+            if _row_identity(selection.fact) in target_row_labels
+        )
+        excluded_count = len(scored) - len(selected)
+        if excluded_count:
+            diagnostics.append(
+                TableFactSelectionDiagnostic(
+                    code="non_target_rows_excluded",
+                    message="Question matched explicit target rows, so non-target rows were excluded.",
+                    details={
+                        "excluded_count": excluded_count,
+                        "target_row_labels": list(target_row_labels),
+                    },
+                )
+            )
+
+    column_scoped = tuple(selection for selection in selected if selection.matched_column_terms)
+    if column_scoped:
+        excluded_count = len(selected) - len(column_scoped)
+        selected = column_scoped
+        if excluded_count:
+            diagnostics.append(
+                TableFactSelectionDiagnostic(
+                    code="non_target_columns_excluded",
+                    message="Question matched explicit target columns, so non-target columns were excluded.",
+                    details={"excluded_count": excluded_count},
+                )
+            )
+
+    if not selected and table_facts:
+        diagnostics.append(
+            TableFactSelectionDiagnostic(
+                code="no_table_fact_selected",
+                message="No TableFact had enough row, column, or table context overlap with the question.",
+            )
+        )
+
+    selected = tuple(
+        sorted(
+            selected,
+            key=lambda selection: (
+                -selection.score,
+                selection.fact.table_id,
+                selection.fact.row_index if selection.fact.row_index is not None else 10**9,
+                selection.fact.column_index if selection.fact.column_index is not None else 10**9,
+                selection.fact.fact_id,
+            ),
+        )[: max(0, max_facts)]
+    )
+    return TableFactSelectionResult(
+        selections=selected,
+        comparison_mode=comparison_mode,
+        target_row_labels=target_row_labels,
+        diagnostics=tuple(diagnostics),
+    )
+
+
+def _score_table_fact(
+    fact: TableFact,
+    normalized_question: str,
+) -> TableFactSelection:
+    score = 0
+    reasons: list[str] = []
+    matched_row_terms: list[str] = []
+    matched_column_terms: list[str] = []
+
+    for term in _row_terms(fact):
+        if _term_in_text(term, normalized_question):
+            score += 40
+            reasons.append("row_match")
+            matched_row_terms.append(term)
+
+    for term in _column_terms(fact):
+        if _term_in_text(term, normalized_question):
+            score += 18
+            reasons.append("column_match")
+            matched_column_terms.append(term)
+
+    for term in _context_terms(fact):
+        if _term_in_text(term, normalized_question):
+            score += 6
+            reasons.append("table_context_match")
+
+    value_text = _normalize_text(fact.value)
+    if value_text and _term_in_text(value_text, normalized_question):
+        score += 10
+        reasons.append("value_match")
+
+    return TableFactSelection(
+        fact=fact,
+        score=score,
+        reasons=_dedupe(reasons),
+        matched_row_terms=_dedupe(matched_row_terms),
+        matched_column_terms=_dedupe(matched_column_terms),
+    )
+
+
+def _target_row_labels(
+    selections: Sequence[TableFactSelection],
+    comparison_mode: bool,
+) -> tuple[str, ...]:
+    labels = _matched_row_labels(selections)
+    if comparison_mode:
+        return labels if len(labels) >= 2 else ()
+    if len(labels) == 1:
+        return labels
+    return labels
+
+
+def _matched_row_labels(
+    selections: Sequence[TableFactSelection],
+) -> tuple[str, ...]:
+    labels: list[str] = []
+    seen: set[str] = set()
+    for selection in sorted(
+        selections,
+        key=lambda item: (-len(item.matched_row_terms), -item.score, item.fact.fact_id),
+    ):
+        if not selection.matched_row_terms:
+            continue
+        row_label = _row_identity(selection.fact)
+        if not row_label or row_label in seen:
+            continue
+        seen.add(row_label)
+        labels.append(row_label)
+    return tuple(labels)
+
+
+def _row_terms(fact: TableFact) -> tuple[str, ...]:
+    values = [fact.row_label, *fact.row_header_path]
+    if fact.row_header_path:
+        values.append(" ".join(fact.row_header_path))
+        values.append(" > ".join(fact.row_header_path))
+    return _normalized_terms(values)
+
+
+def _column_terms(fact: TableFact) -> tuple[str, ...]:
+    values = [fact.column_label, *fact.column_path]
+    if fact.column_path:
+        values.append(" ".join(fact.column_path))
+        values.append(" > ".join(fact.column_path))
+    return _normalized_terms(values)
+
+
+def _context_terms(fact: TableFact) -> tuple[str, ...]:
+    values = [fact.caption or "", *fact.header_path]
+    return _normalized_terms(values)
+
+
+def _row_identity(fact: TableFact) -> str:
+    row_label = fact.row_header_path[-1] if fact.row_header_path else fact.row_label
+    return _normalize_text(row_label)
+
+
+def _normalized_terms(values: Iterable[str]) -> tuple[str, ...]:
+    return tuple(
+        term
+        for term in _dedupe(_normalize_text(value) for value in values)
+        if len(_compact(term)) >= 2 and term not in _STOPWORDS
+    )
+
+
+def _term_in_text(term: str, normalized_text: str) -> bool:
+    if not term:
+        return False
+    return term in normalized_text or _compact(term) in _compact(normalized_text)
+
+
+def _is_comparison_question(normalized_question: str) -> bool:
+    return any(term in normalized_question for term in _COMPARISON_TERMS)
+
+
+def _normalize_text(value: object) -> str:
+    text = str(value or "").upper()
+    text = _normalize_roman_numerals(text)
+    text = re.sub(r"[^0-9A-Z가-힣]+", " ", text)
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def _normalize_roman_numerals(text: str) -> str:
+    for source, target in _UNICODE_ROMAN_NUMERALS.items():
+        text = text.replace(source, target)
+    return _ASCII_ROMAN_TOKEN_RE.sub(
+        lambda match: _ASCII_ROMAN_NUMERALS[match.group(1)],
+        text,
+    )
+
+
+def _compact(value: str) -> str:
+    return re.sub(r"\s+", "", value)
+
+
+def _dedupe(values: Iterable[str]) -> tuple[str, ...]:
+    deduped: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        if not value or value in seen:
+            continue
+        seen.add(value)
+        deduped.append(value)
+    return tuple(deduped)
+
+
+_ASCII_ROMAN_NUMERALS = {
+    "I": "1",
+    "II": "2",
+    "III": "3",
+    "IV": "4",
+    "V": "5",
+}
+_UNICODE_ROMAN_NUMERALS = {
+    "Ⅰ": "1",
+    "Ⅱ": "2",
+    "Ⅲ": "3",
+    "Ⅳ": "4",
+    "Ⅴ": "5",
+}
+_ASCII_ROMAN_TOKEN_RE = re.compile(r"(?<![0-9A-Z])(IV|III|II|I|V)(?![0-9A-Z])")
+_COMPARISON_TERMS = ("차이", "비교", "다른", "각각", "VS", "VERSUS")
+_STOPWORDS = {
+    "값",
+    "관련",
+    "기준",
+    "내용",
+    "무엇",
+    "무엇인가요",
+    "비교",
+    "차이",
+    "표",
+    "해당",
+}


### PR DESCRIPTION
### 관련 이슈

Closes #97
Related #73

### 배경

#97은 유형 비교 질문에서 질문 대상이 아닌 표 행이 근거에 섞이는 문제를 줄이기 위한 작업입니다.

예를 들어 `농어촌 유형 I과 유형 II의 차이는 무엇인가요?`라는 질문에서는 `유형Ⅰ`, `유형Ⅱ` 행이 필요하고, `공통` 행이나 다른 표의 행은 우선 근거로 섞이면 안 됩니다.

### 작업 내용

- 질문 기준으로 `TableFact(표의 행/열/값 구조화 근거)`의 `row(행)`와 `column(열)`을 선택하는 helper(도우미 함수)를 추가했습니다.
- `/debug/rag-trace(디버그 검색 추적 API)` 응답의 `contract_preview.selected_table_facts(선택된 표 근거 후보)`에 선택 결과를 표시했습니다.
- raw Markdown table(원문 마크다운 표)을 현재 추출 로직으로 다시 읽어 `matched_table_facts(runtime metadata에 붙은 기존 표 근거 문자열)`의 오래된 추출 결과보다 우선 사용하도록 보정했습니다.
- grouped table(묶음 표)에서 `유형Ⅰ`, `유형Ⅱ` 행이 보존되도록 하고, `---` 같은 Markdown table separator(마크다운 표 구분선)가 가짜 행으로 들어오지 않게 했습니다.

### 변경 파일

| 파일 | 변경 내용 |
|---|---|
| `ai-server/rag_table_fact_selector.py` | 질문 기준으로 `TableFact(표의 행/열/값 구조화 근거)` 후보의 target row(목표 행), target column(목표 열)을 고르는 selector(선택기)를 추가했습니다. |
| `ai-server/check_table_fact_selector.py` | 비교 질문, 단일 행 질문, 열 중심 질문에서 selector(선택기)가 어떤 row(행)를 남기는지 검증했습니다. |
| `ai-server/check_table_fact_runtime_extraction.py` | grouped Markdown table(묶음 마크다운 표)에서 `유형Ⅰ`, `유형Ⅱ`, `공통` row(행)가 보존되고 `---` 가짜 row(행)가 제외되는지 검증했습니다. |
| `ai-server/main.py` | `/debug/rag-trace(디버그 검색 추적 API)`에 `selected_table_facts(선택된 표 근거 후보)`를 붙이고, Markdown table(마크다운 표) 추출의 row(행) 식별 문제를 보정했습니다. |

### 확인 결과

| 확인 항목 | 결과 | 해석 |
|---|---|---|
| 정적 검증 | 통과 | 변경 파일과 관련 contract(데이터 계약) 파일에 문법 오류가 없습니다. |
| selector smoke test(선택기 가벼운 검증) | 통과 | 비교 질문은 `유형Ⅰ`, `유형Ⅱ`만 남기고, 단일 행 질문은 해당 row(행)와 column(열)만 남깁니다. |
| runtime table extraction smoke test(실제 실행 흐름 표 추출 가벼운 검증) | 통과 | grouped Markdown table(묶음 마크다운 표)에서 `유형Ⅰ`, `유형Ⅱ`, `공통` row(행)를 보존하고 `---` 가짜 row(행)를 제외합니다. |
| RAG contract smoke test(RAG 데이터 계약 가벼운 검증) | 통과 | 기존 `TableFact(표의 행/열/값 구조화 근거)` contract(데이터 계약)와 builder(생성 함수) 동작을 깨지 않았습니다. |
| OpenDataLoader adapter smoke test(OpenDataLoader 변환기 가벼운 검증) | 통과 | #98에서 만든 JSON adapter(변환기) 계약과 충돌하지 않습니다. |
| 실제 `/debug/rag-trace(디버그 검색 추적 API)` 비교 질문 | 통과 | `농어촌 유형 I과 유형 II의 차이는 무엇인가요?`에서 `73_29` 후보의 target row(목표 행)가 `유형1`, `유형2`로 잡히고 `공통` row(행)는 제외됩니다. |
| 실제 `/debug/rag-trace(디버그 검색 추적 API)` 단일 행 질문 | 통과 | `농어촌 유형 I의 지원자격은 무엇인가요?`에서 `유형Ⅰ` row(행)의 `지원자격` column(열)만 남습니다. |
| 실제 `/query(질의 응답 API)` 회귀 확인 | 한계 확인 | source(출처)에는 정답 표가 보이지만 답변은 아직 부정확했습니다. 이번 PR은 선택 결과를 prompt(모델 입력문)에 연결하지 않으므로 답변 개선은 후속 범위입니다. |

### 리뷰 포인트

- `selected_table_facts(선택된 표 근거 후보)`가 `/debug/rag-trace(디버그 검색 추적 API)`에서만 계산되는 구조가 적절한지 봐주세요.
- Markdown table(마크다운 표)에서 더 구체적인 식별 cell(칸)을 row label(행 이름)로 쓰는 보정이 다른 표 유형에 과하게 적용될 위험이 없는지 봐주세요.
- 비교 질문에서 target row(목표 행)가 2개 이상 잡히지 않으면 선택 결과를 비우고 diagnostic(진단 정보)을 남기는 방식이 맞는지 봐주세요.

### 후속 범위

- `selected_table_facts(선택된 표 근거 후보)`를 언제 `SelectedContext(선택된 답변 근거 묶음)`로 승격할지 기준이 필요합니다.
- 모든 질문에서 표를 우선 근거로 넣으면 source contamination(출처 오염)이 생길 수 있으므로, 다음 child issue(파생 이슈)에서 표 우선 적용 조건과 fallback(대체 경로)을 설계해야 합니다.
- 실제 `/query(질의 응답 API)` 답변 개선은 prompt(모델 입력문)에 evidence text(모델이 읽을 근거 문장)를 연결한 뒤 별도로 검증해야 합니다.
