### PR TITLE
[AI/RAG] selected_table_facts 근거를 query 답변에 연결

### DIFF
--- a/ai-server/check_table_fact_evidence.py
+++ b/ai-server/check_table_fact_evidence.py
@@ -1,0 +1,221 @@
+"""Smoke checks for selected TableFact evidence text readiness."""
+
+from __future__ import annotations
+
+from rag_contract_builders import build_table_cell_fact
+from rag_table_fact_selector import (
+    build_table_fact_evidence_preview,
+    select_table_facts_for_question,
+)
+
+
+def main() -> None:
+    """Verify evidence text rendering stays trace-only and conservative."""
+    table_facts = [
+        _fact(0, 0, "유형 I", "전형", "농어촌"),
+        _fact(0, 1, "유형 I", "전형", "유형 I"),
+        _fact(0, 2, "유형 I", "지원자격", "중학교 입학부터 고등학교 졸업까지 거주"),
+        _fact(0, 3, "유형 I", "제출서류", "학교생활기록부"),
+        _fact(1, 0, "유형 II", "전형", "농어촌"),
+        _fact(1, 1, "유형 II", "전형", "유형 II"),
+        _fact(1, 2, "유형 II", "지원자격", "초등학교 입학부터 고등학교 졸업까지 거주"),
+        _fact(1, 3, "유형 II", "제출서류", "가족관계증명서"),
+        _fact(2, 2, "공통", "지원자격", "지원자격을 졸업일까지 유지"),
+    ]
+
+    comparison_result = select_table_facts_for_question(
+        "유형 I과 유형 II의 차이는 무엇인가요?",
+        table_facts,
+    )
+    comparison_preview = build_table_fact_evidence_preview(comparison_result)
+    assert comparison_preview.prompt_candidate_ready is True
+    assert "comparison_rows_covered" in comparison_preview.reasons
+    assert "행: 유형 I / 열: 지원자격" in comparison_preview.evidence_text
+    assert "행: 유형 II / 열: 지원자격" in comparison_preview.evidence_text
+    assert "공통 맥락: 전형=농어촌" in comparison_preview.evidence_text
+    assert "행: 공통" not in comparison_preview.evidence_text
+    assert "열: 전형" not in comparison_preview.evidence_text
+    assert "row_label" not in comparison_preview.evidence_text
+    assert "source_block_id" not in comparison_preview.evidence_text
+
+    scoped_comparison_result = select_table_facts_for_question(
+        "유형 I과 유형 II의 농어촌 전형 지원자격이 어떻게 돼?",
+        table_facts,
+    )
+    scoped_comparison_preview = build_table_fact_evidence_preview(
+        scoped_comparison_result
+    )
+    assert scoped_comparison_preview.prompt_candidate_ready is True
+    assert "공통 맥락: 전형=농어촌" in scoped_comparison_preview.evidence_text
+    assert "행: 유형 I / 열: 지원자격" in scoped_comparison_preview.evidence_text
+    assert "행: 유형 II / 열: 지원자격" in scoped_comparison_preview.evidence_text
+
+    shared_scope_result = select_table_facts_for_question(
+        "농어촌 전형 지원 자격은",
+        table_facts,
+    )
+    shared_scope_preview = build_table_fact_evidence_preview(shared_scope_result)
+    assert shared_scope_preview.prompt_candidate_ready is True
+    assert "shared_context_scoped_rows" in shared_scope_preview.reasons
+    assert "공통 맥락: 전형=농어촌" in shared_scope_preview.evidence_text
+    assert "행: 유형 I / 열: 지원자격" in shared_scope_preview.evidence_text
+    assert "행: 유형 II / 열: 지원자격" in shared_scope_preview.evidence_text
+    assert "행: 공통" not in shared_scope_preview.evidence_text
+
+    type_scope_result = select_table_facts_for_question(
+        "농어촌 유형 지원자격이 어떻게 돼?",
+        table_facts,
+    )
+    type_scope_preview = build_table_fact_evidence_preview(type_scope_result)
+    assert type_scope_preview.prompt_candidate_ready is True
+    assert "shared_context_scoped_rows" in type_scope_preview.reasons
+    assert "공통 맥락: 전형=농어촌" in type_scope_preview.evidence_text
+    assert "행: 유형 I / 열: 지원자격" in type_scope_preview.evidence_text
+    assert "행: 유형 II / 열: 지원자격" in type_scope_preview.evidence_text
+    assert "행: 공통" not in type_scope_preview.evidence_text
+
+    single_cell_result = select_table_facts_for_question(
+        "유형 I의 지원자격은 무엇인가요?",
+        table_facts,
+    )
+    single_cell_preview = build_table_fact_evidence_preview(single_cell_result)
+    assert single_cell_preview.prompt_candidate_ready is True
+    assert "single_target_row" in single_cell_preview.reasons
+    assert "target_column_matched" in single_cell_preview.reasons
+    assert "행: 유형 I / 열: 지원자격" in single_cell_preview.evidence_text
+    assert "행: 유형 I / 열: 제출서류" not in single_cell_preview.evidence_text
+
+    column_only_result = select_table_facts_for_question(
+        "지원자격은 무엇인가요?",
+        table_facts,
+    )
+    column_only_preview = build_table_fact_evidence_preview(column_only_result)
+    assert column_only_preview.prompt_candidate_ready is False
+    assert "target_row_unresolved_for_evidence" in _diagnostic_codes(
+        column_only_preview
+    )
+
+    repeated_answer_result = select_table_facts_for_question(
+        "지원자격은 무엇인가요?",
+        [
+            _fact(0, 1, "일반고", "지원자격", "고등학교 졸업자"),
+            _fact(1, 1, "특성화고", "지원자격", "고등학교 졸업자"),
+        ],
+    )
+    repeated_answer_preview = build_table_fact_evidence_preview(
+        repeated_answer_result
+    )
+    assert repeated_answer_preview.prompt_candidate_ready is False
+    assert "shared_context_scoped_rows" not in repeated_answer_preview.reasons
+    assert "target_row_unresolved_for_evidence" in _diagnostic_codes(
+        repeated_answer_preview
+    )
+
+    many_row_facts = [
+        fact
+        for row_index in range(9)
+        for fact in (
+            _fact(row_index, 0, f"유형 {row_index}", "전형", "농어촌"),
+            _fact(row_index, 1, f"유형 {row_index}", "지원자격", f"조건 {row_index}"),
+        )
+    ]
+    selection_truncated_result = select_table_facts_for_question(
+        "농어촌 전형 지원자격은?",
+        many_row_facts,
+    )
+    selection_truncated_preview = build_table_fact_evidence_preview(
+        selection_truncated_result
+    )
+    assert selection_truncated_preview.prompt_candidate_ready is False
+    assert "selected_table_facts_truncated" in _diagnostic_codes(
+        selection_truncated_preview
+    )
+
+    render_truncated_result = select_table_facts_for_question(
+        "농어촌 전형 지원자격은?",
+        many_row_facts,
+        max_facts=20,
+    )
+    render_truncated_preview = build_table_fact_evidence_preview(
+        render_truncated_result
+    )
+    assert render_truncated_preview.truncated is True
+    assert render_truncated_preview.prompt_candidate_ready is False
+    assert "truncated_table_fact_evidence" in _diagnostic_codes(
+        render_truncated_preview
+    )
+
+    unresolved_comparison = select_table_facts_for_question(
+        "유형 I과 유형 II의 차이는 무엇인가요?",
+        [_fact(0, 1, "유형 II", "지원자격", "초등학교 입학부터 거주")],
+    )
+    unresolved_preview = build_table_fact_evidence_preview(unresolved_comparison)
+    assert unresolved_preview.prompt_candidate_ready is False
+    assert "comparison_target_rows_unresolved" in _diagnostic_codes(
+        unresolved_preview
+    )
+    assert "no_selected_table_facts_for_evidence" in _diagnostic_codes(
+        unresolved_preview
+    )
+    assert unresolved_preview.evidence_text == ""
+
+    multiple_table_result = select_table_facts_for_question(
+        "유형 I의 지원자격은 무엇인가요?",
+        [
+            _fact(0, 1, "유형 I", "지원자격", "첫 번째 표 조건", table_index=1),
+            _fact(0, 1, "유형 I", "지원자격", "두 번째 표 조건", table_index=2),
+        ],
+    )
+    multiple_table_preview = build_table_fact_evidence_preview(multiple_table_result)
+    assert multiple_table_preview.prompt_candidate_ready is False
+    assert "multiple_tables_selected" in _diagnostic_codes(multiple_table_preview)
+
+    label_only_result = select_table_facts_for_question(
+        "유형 I과 유형 II의 차이는 무엇인가요?",
+        [
+            _fact(0, 0, "유형 I", "전형", "농어촌"),
+            _fact(0, 1, "유형 I", "전형", "유형 I"),
+            _fact(1, 0, "유형 II", "전형", "농어촌"),
+            _fact(1, 1, "유형 II", "전형", "유형 II"),
+        ],
+    )
+    label_only_preview = build_table_fact_evidence_preview(label_only_result)
+    assert label_only_preview.prompt_candidate_ready is False
+    assert label_only_preview.evidence_text == ""
+    assert "no_renderable_table_fact_evidence" in _diagnostic_codes(label_only_preview)
+
+    print("table fact evidence smoke ok")
+
+
+def _fact(
+    row_index: int,
+    column_index: int,
+    row_label: str,
+    column_label: str,
+    value: str,
+    *,
+    table_index: int = 1,
+):
+    return build_table_cell_fact(
+        document_id="evidence-smoke",
+        table_index=table_index,
+        row_index=row_index,
+        column_index=column_index,
+        row_label=row_label,
+        column_label=column_label,
+        value=value,
+        source_block_id=f"source-{table_index}",
+        caption="정원외 특별전형 지원자격",
+        row_header_path=(row_label,),
+        column_path=(column_label,),
+        header_path=("모집요강", "지원자격"),
+        confidence=0.9,
+    )
+
+
+def _diagnostic_codes(preview) -> set[str]:
+    return {diagnostic.code for diagnostic in preview.diagnostics}
+
+
+if __name__ == "__main__":
+    main()

--- a/ai-server/check_table_fact_runtime_extraction.py
+++ b/ai-server/check_table_fact_runtime_extraction.py
@@ -3,9 +3,13 @@
 from __future__ import annotations
 
 from main import (
+    _build_priority_table_fact_answer,
+    _build_rag_prompt,
     _extract_table_fact_pairs,
     _extract_table_fact_row_subject,
     _extract_table_facts,
+    _priority_table_fact_answer_for_request,
+    _priority_table_fact_evidence_for_prompt,
     _typed_table_fact_contract_candidates,
 )
 
@@ -99,6 +103,66 @@ def main() -> None:
     }
     assert stale_fact_sources == {"extracted_from_candidate_doc"}
     assert "오래된행" not in stale_fact_rows
+
+    priority_evidence = _priority_table_fact_evidence_for_prompt(
+        "지역전형 지원 자격은",
+        [sample],
+        [{"document_id": "runtime-table-smoke"}],
+        ["runtime-table-smoke_1"],
+    )
+    assert priority_evidence is not None
+    assert "공통 맥락: 전형=지역전형" in priority_evidence.evidence_text
+    assert "행: 유형Ⅰ / 열: 지원자격" in priority_evidence.evidence_text
+    assert "행: 유형Ⅱ / 열: 지원자격" in priority_evidence.evidence_text
+    assert "행: 공통" not in priority_evidence.evidence_text
+
+    prompt = _build_rag_prompt(
+        None,
+        "[출처 1]\n표 원문",
+        "지역전형 지원 자격은",
+        priority_evidence.evidence_text,
+    )
+    assert "[우선 표 근거]" in prompt
+    assert "공통 맥락: 전형=지역전형" in prompt
+
+    priority_answer = _build_priority_table_fact_answer(priority_evidence)
+    assert priority_answer is not None
+    assert "유형Ⅰ: 중학교 입학일부터 고등학교 졸업일까지 거주한 지원자" in priority_answer
+    assert "유형Ⅱ: 초등학교 입학일부터 고등학교 졸업일까지 거주한 지원자" in priority_answer
+    assert _priority_table_fact_answer_for_request(priority_evidence, None) == priority_answer
+    assert _priority_table_fact_answer_for_request(
+        priority_evidence,
+        "JSON 형식으로만 답하세요.",
+    ) is None
+
+    type_priority_evidence = _priority_table_fact_evidence_for_prompt(
+        "지역전형 유형 지원자격은",
+        [sample],
+        [{"document_id": "runtime-table-smoke"}],
+        ["runtime-table-smoke_1"],
+    )
+    assert type_priority_evidence is not None
+    assert "공통 맥락: 전형=지역전형" in type_priority_evidence.evidence_text
+    type_priority_answer = _build_priority_table_fact_answer(type_priority_evidence)
+    assert type_priority_answer is not None
+    assert "유형Ⅰ: 중학교 입학일부터 고등학교 졸업일까지 거주한 지원자" in type_priority_answer
+    assert "유형Ⅱ: 초등학교 입학일부터 고등학교 졸업일까지 거주한 지원자" in type_priority_answer
+
+    repeated_answer_sample = """
+###### 학과별 지원자격
+
+|구분|지원자격|
+|---|---|
+|일반고|고등학교 졸업자|
+|특성화고|고등학교 졸업자|
+"""
+    ambiguous_priority_evidence = _priority_table_fact_evidence_for_prompt(
+        "지원자격은 무엇인가요?",
+        [repeated_answer_sample],
+        [{"document_id": "runtime-table-smoke"}],
+        ["runtime-table-smoke_2"],
+    )
+    assert ambiguous_priority_evidence is None
 
     print("table fact runtime extraction smoke ok")
 

--- a/ai-server/main.py
+++ b/ai-server/main.py
@@ -33,7 +33,10 @@ from rag_contract_builders import (
     section_path_warnings,
 )
 from rag_contracts import TableFact, contract_to_dict
-from rag_table_fact_selector import select_table_facts_for_question
+from rag_table_fact_selector import (
+    build_table_fact_evidence_preview,
+    select_table_facts_for_question,
+)
 
 try:
     from kiwipiepy import Kiwi
@@ -2169,6 +2172,16 @@ class RagTraceRequest(BaseModel):
     vector_preview_size: int = Field(default=8, ge=0, le=32)
 
 
+@dataclass(frozen=True)
+class PriorityTableFactEvidence:
+    """Prompt에 우선 배치할 수 있는 검증된 표 근거."""
+
+    evidence_text: str
+    chunk_id: str
+    source_index: int
+    reasons: tuple[str, ...] = ()
+
+
 DEFAULT_SYSTEM_PROMPT = (
     "너는 인하공업전문대학 문서를 근거로 답변하는 안내 챗봇이다."
 )
@@ -4141,12 +4154,28 @@ def _expand_table_fact_results(docs: list[str], metadatas: list[dict], ids: list
     return expanded_docs, expanded_metadatas, expanded_ids
 
 
-def _build_rag_prompt(system_prompt: str | None, context: str, question: str) -> str:
+def _build_rag_prompt(
+    system_prompt: str | None,
+    context: str,
+    question: str,
+    priority_table_evidence: str = "",
+) -> str:
     """검색 근거와 사용자 질문을 LLM 입력 프롬프트로 조합한다."""
     prompt_policy = system_prompt.strip() if system_prompt and system_prompt.strip() else DEFAULT_SYSTEM_PROMPT
+    priority_block = ""
+    if priority_table_evidence.strip():
+        priority_block = f"""
+[우선 표 근거]
+{priority_table_evidence.strip()}
+
+[우선 표 근거 사용 규칙]
+- [우선 표 근거]가 있으면 이 블록의 행, 열, 값 관계를 [검색 근거]보다 먼저 사용한다.
+- [우선 표 근거]에 없는 조건, 전형, 서류, 해석은 만들지 않는다.
+"""
     return f"""{prompt_policy}
 
 {MANDATORY_RAG_PROMPT}
+{priority_block}
 
 [검색 근거]
 {context}
@@ -4545,10 +4574,26 @@ def _selected_table_fact_previews(
         preview["matched_row_terms"] = list(selection.matched_row_terms)
         preview["matched_column_terms"] = list(selection.matched_column_terms)
         selected_previews.append(preview)
+    evidence_preview = build_table_fact_evidence_preview(selection_result)
     return {
         "comparison_mode": selection_result.comparison_mode,
         "target_row_labels": list(selection_result.target_row_labels),
         "selected_facts": selected_previews,
+        "evidence_preview": {
+            "runtime_connection": "trace_only",
+            "prompt_candidate_ready": evidence_preview.prompt_candidate_ready,
+            "evidence_text": evidence_preview.evidence_text,
+            "reasons": list(evidence_preview.reasons),
+            "truncated": evidence_preview.truncated,
+            "diagnostics": [
+                {
+                    "code": diagnostic.code,
+                    "message": diagnostic.message,
+                    "details": diagnostic.details or {},
+                }
+                for diagnostic in evidence_preview.diagnostics
+            ],
+        },
         "diagnostics": [
             {
                 "code": diagnostic.code,
@@ -4558,6 +4603,100 @@ def _selected_table_fact_previews(
             for diagnostic in selection_result.diagnostics
         ],
     }
+
+
+def _priority_table_fact_evidence_for_prompt(
+    question: str,
+    docs: list[str],
+    metadatas: list[dict],
+    ids: list[str],
+) -> PriorityTableFactEvidence | None:
+    """최종 검색 후보에서 prompt에 올릴 수 있는 첫 번째 표 근거를 고른다."""
+    for source_index, (doc, meta, chunk_id) in enumerate(
+        zip(docs, metadatas, ids),
+        start=1,
+    ):
+        meta = meta or {}
+        source_block_id = str(meta.get("source_block_id") or "")
+        table_fact_candidates = _typed_table_fact_contract_candidates(
+            str(chunk_id),
+            doc,
+            meta,
+            source_block_id,
+        )
+        if not table_fact_candidates:
+            continue
+        selection_result = select_table_facts_for_question(
+            question,
+            [table_fact for table_fact, _ in table_fact_candidates],
+        )
+        evidence_preview = build_table_fact_evidence_preview(selection_result)
+        if not evidence_preview.prompt_candidate_ready or not evidence_preview.evidence_text:
+            continue
+        return PriorityTableFactEvidence(
+            evidence_text=evidence_preview.evidence_text,
+            chunk_id=str(chunk_id),
+            source_index=source_index,
+            reasons=evidence_preview.reasons,
+        )
+    return None
+
+
+def _build_priority_table_fact_answer(
+    evidence: PriorityTableFactEvidence | None,
+) -> str | None:
+    """검증된 표 근거가 있으면 LLM 없이 행/열/값 기반 답변을 만든다."""
+    if evidence is None or not evidence.evidence_text.strip():
+        return None
+
+    common_contexts: list[str] = []
+    answer_lines: list[str] = []
+    for line in evidence.evidence_text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("공통 맥락:"):
+            context = stripped.split(":", 1)[1].strip()
+            if context:
+                common_contexts.append(context)
+            continue
+        match = re.match(r"- 행: (?P<row>.+?) / 열: (?P<column>.+?) / 값: (?P<value>.+)$", stripped)
+        if not match:
+            continue
+        row = match.group("row").strip()
+        column = match.group("column").strip()
+        value = match.group("value").strip()
+        if not row or not column or not value:
+            continue
+        if column == "지원자격" or column.endswith(" > 지원자격"):
+            answer_lines.append(f"- {row}: {value}")
+        else:
+            answer_lines.append(f"- {row} / {column}: {value}")
+
+    if not answer_lines:
+        return None
+
+    prefix = "표 근거 기준 답변입니다."
+    if common_contexts:
+        prefix += f"\n공통 맥락: {', '.join(common_contexts)}"
+    return f"{prefix}\n" + "\n".join(answer_lines)
+
+
+def _priority_table_fact_answer_for_request(
+    evidence: PriorityTableFactEvidence | None,
+    system_prompt: str | None,
+) -> str | None:
+    """관리자 prompt가 있으면 고정 답변 대신 LLM이 형식 지시를 적용하게 둔다."""
+    if system_prompt and system_prompt.strip():
+        return None
+    return _build_priority_table_fact_answer(evidence)
+
+
+def _priority_table_fact_answer_disabled_reason(
+    evidence: PriorityTableFactEvidence | None,
+    system_prompt: str | None,
+) -> str | None:
+    if evidence is not None and system_prompt and system_prompt.strip():
+        return "custom_system_prompt"
+    return None
 
 
 def _contract_trace_preview(
@@ -5195,8 +5334,27 @@ def _trace_query_retrieval(
     final_docs = focused_docs[:top_k]
     final_metadatas = focused_metadatas[:top_k]
     final_ids = focused_ids[:top_k]
+    priority_table_evidence = (
+        _priority_table_fact_evidence_for_prompt(
+            question,
+            final_docs,
+            final_metadatas,
+            final_ids,
+        )
+        if final_docs
+        else None
+    )
     context = _build_context(final_docs, final_metadatas, final_ids, analysis) if final_docs else ""
-    prompt = _build_rag_prompt(system_prompt, context, question) if final_docs else ""
+    prompt = (
+        _build_rag_prompt(
+            system_prompt,
+            context,
+            question,
+            priority_table_evidence.evidence_text if priority_table_evidence else "",
+        )
+        if final_docs
+        else ""
+    )
     final_candidates = [
         _format_rerank_candidate(
             index + 1,
@@ -5266,6 +5424,23 @@ def _trace_query_retrieval(
             "final_candidates": final_candidates,
         },
         "final_context": context,
+        "priority_table_evidence": {
+            "runtime_connection": "query_prompt",
+            "chunk_id": priority_table_evidence.chunk_id,
+            "source_index": priority_table_evidence.source_index,
+            "reasons": list(priority_table_evidence.reasons),
+            "evidence_text": priority_table_evidence.evidence_text,
+            "deterministic_answer": _priority_table_fact_answer_for_request(
+                priority_table_evidence,
+                system_prompt,
+            ),
+            "deterministic_answer_disabled_reason": (
+                _priority_table_fact_answer_disabled_reason(
+                    priority_table_evidence,
+                    system_prompt,
+                )
+            ),
+        } if priority_table_evidence else None,
         "final_prompt_preview": _preview_text(prompt, 3000),
         "timing": {
             "embedding_elapsed": _round_float(embedding_elapsed, 4),
@@ -5361,9 +5536,24 @@ def _prepare_query(question: str, top_k: int, system_prompt: str | None = None) 
         return None, [], metrics
 
     context_build_start = time.perf_counter()
+    priority_table_evidence = _priority_table_fact_evidence_for_prompt(
+        question,
+        docs,
+        metadatas,
+        ids,
+    )
     context = _build_context(docs, metadatas, ids, analysis)
     # 프롬프트 조합: 관리자 설정을 반영하되 문서 외 내용 답변 방지 제약은 서버에서 항상 덧붙인다.
-    prompt = _build_rag_prompt(system_prompt, context, question)
+    prompt = _build_rag_prompt(
+        system_prompt,
+        context,
+        question,
+        priority_table_evidence.evidence_text if priority_table_evidence else "",
+    )
+    priority_table_fact_answer = _priority_table_fact_answer_for_request(
+        priority_table_evidence,
+        system_prompt,
+    )
 
     # 출처 목록 구성: document_id, source(파일명), 페이지, 청크 미리보기, 사용자 표시용 헤더 포함
     sources = []
@@ -5413,6 +5603,17 @@ def _prepare_query(question: str, top_k: int, system_prompt: str | None = None) 
         "retrieval_chunk_query_error": results.get("retrieval_chunk_query_error"),
         "query_intent": analysis.intent,
         "query_subject_terms": sorted(analysis.subject_terms),
+        "priority_table_evidence_used": priority_table_evidence is not None,
+        "priority_table_evidence_chunk_id": (
+            priority_table_evidence.chunk_id if priority_table_evidence else None
+        ),
+        "priority_table_fact_answer": priority_table_fact_answer,
+        "priority_table_fact_answer_disabled_reason": (
+            _priority_table_fact_answer_disabled_reason(
+                priority_table_evidence,
+                system_prompt,
+            )
+        ),
     }
     logger.info(
         "[query_context] top_k=%s retrieval_limit=%s raw_docs=%s retrieval_chunk_vector=%s legacy_vector=%s bm25_raw_chunks=%s lexical_table_facts=%s docs=%s intent=%s subject_terms=%s context_chars=%s source_chars=%s distances=%s distance_min=%s distance_max=%s distance_avg=%s",
@@ -5585,6 +5786,18 @@ async def query_document(request: QueryRequest):
     if prompt is None:
         return {"answer": "관련 내용을 문서에서 찾을 수 없습니다.", "sources": []}
 
+    priority_answer = query_metrics.get("priority_table_fact_answer")
+    if priority_answer:
+        logger.info(
+            "[query] priority_table_fact_answer sources=%s context_chars=%s prompt_chars=%s prepare=%.2fs total=%.2fs",
+            len(sources),
+            query_metrics["context_chars"],
+            query_metrics["prompt_chars"],
+            query_metrics["prepare_elapsed"],
+            time.perf_counter() - query_start,
+        )
+        return {"answer": priority_answer, "sources": sources}
+
     # async 핸들러에서 ainvoke()로 이벤트 루프 블로킹 방지
     llm_start = time.perf_counter()
     answer = await llm.ainvoke(prompt)
@@ -5632,6 +5845,30 @@ async def query_stream(request: QueryRequest):
             empty_stream(),
             media_type="text/event-stream",
             headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"}
+        )
+
+    priority_answer = query_metrics.get("priority_table_fact_answer")
+    if priority_answer:
+        async def priority_stream():
+            yield f"data: {json.dumps({'answer': priority_answer}, ensure_ascii=False)}\n\n"
+            payload = json.dumps(
+                {"done": True, "answer": priority_answer, "sources": sources},
+                ensure_ascii=False,
+            )
+            yield f"data: {payload}\n\n"
+
+        logger.info(
+            "[query_stream] priority_table_fact_answer sources=%s context_chars=%s prompt_chars=%s prepare=%.2fs total=%.2fs",
+            len(sources),
+            query_metrics["context_chars"],
+            query_metrics["prompt_chars"],
+            query_metrics["prepare_elapsed"],
+            time.perf_counter() - stream_start,
+        )
+        return StreamingResponse(
+            priority_stream(),
+            media_type="text/event-stream",
+            headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
         )
 
     async def token_stream():

--- a/ai-server/rag_table_fact_selector.py
+++ b/ai-server/rag_table_fact_selector.py
@@ -1,9 +1,8 @@
 """Question-aware selection helpers for typed TableFact candidates.
 
 This module is intentionally side-effect free. It does not call ChromaDB,
-change retrieval ranking, alter prompts, or connect to ``/query``. Its job is
-to smoke-test whether typed table facts can be narrowed to the rows that a
-question actually asks about.
+change retrieval ranking, or mutate prompts. Its job is to decide whether typed
+table facts can be narrowed to the rows that a question actually asks about.
 """
 
 from __future__ import annotations
@@ -43,6 +42,19 @@ class TableFactSelectionResult:
     comparison_mode: bool
     target_row_labels: tuple[str, ...] = ()
     diagnostics: tuple[TableFactSelectionDiagnostic, ...] = ()
+    normalized_question: str = ""
+    truncated: bool = False
+
+
+@dataclass(frozen=True)
+class TableFactEvidencePreview:
+    """Preview of whether selected facts are safe prompt candidates."""
+
+    prompt_candidate_ready: bool
+    evidence_text: str
+    reasons: tuple[str, ...] = ()
+    diagnostics: tuple[TableFactSelectionDiagnostic, ...] = ()
+    truncated: bool = False
 
 
 def select_table_facts_for_question(
@@ -69,7 +81,7 @@ def select_table_facts_for_question(
         diagnostics.append(
             TableFactSelectionDiagnostic(
                 code="comparison_target_rows_unresolved",
-                message="Comparison question did not resolve at least two explicit target rows.",
+                message="비교 질문에서 명확한 비교 대상 행을 두 개 이상 찾지 못했습니다.",
                 details={"matched_row_labels": list(matched_rows)},
             )
         )
@@ -84,7 +96,7 @@ def select_table_facts_for_question(
             diagnostics.append(
                 TableFactSelectionDiagnostic(
                     code="non_target_rows_excluded",
-                    message="Question matched explicit target rows, so non-target rows were excluded.",
+                    message="질문에서 명확한 대상 행이 잡혀 대상이 아닌 행을 제외했습니다.",
                     details={
                         "excluded_count": excluded_count,
                         "target_row_labels": list(target_row_labels),
@@ -94,26 +106,52 @@ def select_table_facts_for_question(
 
     column_scoped = tuple(selection for selection in selected if selection.matched_column_terms)
     if column_scoped:
-        excluded_count = len(selected) - len(column_scoped)
-        selected = column_scoped
+        question_scoped_contexts = _question_scoped_shared_context_selections(
+            selected,
+            normalized_question,
+        )
+        next_selected = _unique_selections(
+            [*column_scoped, *question_scoped_contexts]
+        )
+        excluded_count = len(selected) - len(next_selected)
+        selected = next_selected
         if excluded_count:
             diagnostics.append(
                 TableFactSelectionDiagnostic(
                     code="non_target_columns_excluded",
-                    message="Question matched explicit target columns, so non-target columns were excluded.",
+                    message="질문에서 명확한 대상 열이 잡혀 대상이 아닌 열을 제외했습니다.",
                     details={"excluded_count": excluded_count},
                 )
             )
+
+    if not target_row_labels and not _term_in_text("공통", normalized_question):
+        non_common_rows = tuple(
+            selection for selection in selected if not _is_common_row(selection.fact)
+        )
+        non_common_row_labels = _dedupe(
+            _row_identity(selection.fact)
+            for selection in non_common_rows
+            if _row_identity(selection.fact)
+        )
+        if len(non_common_row_labels) >= 2 and len(non_common_rows) < len(selected):
+            diagnostics.append(
+                TableFactSelectionDiagnostic(
+                    code="generic_common_rows_excluded",
+                    message="질문이 공통 조건을 직접 묻지 않아 일반 공통 행을 우선 근거에서 제외했습니다.",
+                    details={"excluded_count": len(selected) - len(non_common_rows)},
+                )
+            )
+            selected = non_common_rows
 
     if not selected and table_facts:
         diagnostics.append(
             TableFactSelectionDiagnostic(
                 code="no_table_fact_selected",
-                message="No TableFact had enough row, column, or table context overlap with the question.",
+                message="질문과 충분히 겹치는 행, 열, 표 맥락을 가진 표 근거가 없습니다.",
             )
         )
 
-    selected = tuple(
+    sorted_selected = tuple(
         sorted(
             selected,
             key=lambda selection: (
@@ -123,14 +161,330 @@ def select_table_facts_for_question(
                 selection.fact.column_index if selection.fact.column_index is not None else 10**9,
                 selection.fact.fact_id,
             ),
-        )[: max(0, max_facts)]
+        )
     )
+    selection_limit = max(0, max_facts)
+    selected = sorted_selected[:selection_limit]
     return TableFactSelectionResult(
         selections=selected,
         comparison_mode=comparison_mode,
         target_row_labels=target_row_labels,
         diagnostics=tuple(diagnostics),
+        normalized_question=normalized_question,
+        truncated=len(sorted_selected) > selection_limit,
     )
+
+
+def build_table_fact_evidence_preview(
+    selection_result: TableFactSelectionResult,
+    *,
+    max_lines: int = 8,
+) -> TableFactEvidencePreview:
+    """Render selected facts and explain whether they are safe prompt candidates.
+
+    This function is still side-effect free. Runtime code may use the readiness
+    result for trace output or for prompt injection after its own retrieval checks.
+    """
+    diagnostics: list[TableFactSelectionDiagnostic] = []
+    reasons: list[str] = []
+    selections = selection_result.selections
+
+    if not selections:
+        diagnostics.append(
+            TableFactSelectionDiagnostic(
+                code="no_selected_table_facts_for_evidence",
+                message="근거 텍스트로 바꿀 선택된 표 근거가 없습니다.",
+            )
+        )
+        return TableFactEvidencePreview(
+            prompt_candidate_ready=False,
+            evidence_text="",
+            diagnostics=tuple([*selection_result.diagnostics, *diagnostics]),
+        )
+
+    if selection_result.truncated:
+        diagnostics.append(
+            TableFactSelectionDiagnostic(
+                code="selected_table_facts_truncated",
+                message="선택된 표 근거가 최대 선택 개수를 넘어 즉시 답변 후보에서 제외했습니다.",
+                details={"selected_count": len(selections)},
+            )
+        )
+
+    table_ids = _dedupe(selection.fact.table_id for selection in selections)
+    if len(table_ids) > 1:
+        diagnostics.append(
+            TableFactSelectionDiagnostic(
+                code="multiple_tables_selected",
+                message="선택된 표 근거가 여러 표에서 나와 prompt 후보 근거로 쓰기 안전하지 않습니다.",
+                details={"table_count": len(table_ids)},
+            )
+        )
+    else:
+        reasons.append("single_table")
+
+    selected_row_identities = [
+        _row_identity(selection.fact)
+        for selection in selections
+    ]
+    selected_row_labels = _dedupe(
+        row_identity
+        for row_identity in selected_row_identities
+        if row_identity
+    )
+    target_row_labels = selection_result.target_row_labels
+    question_scoped_shared_contexts = _question_scoped_shared_evidence_contexts(
+        selections,
+        selection_result.normalized_question,
+    )
+    if selection_result.comparison_mode:
+        missing_targets = sorted(set(target_row_labels) - set(selected_row_labels))
+        if len(target_row_labels) < 2 or missing_targets:
+            diagnostics.append(
+                TableFactSelectionDiagnostic(
+                    code="comparison_rows_incomplete_for_evidence",
+                    message="비교 질문의 prompt 후보 근거에는 비교 대상 행이 모두 들어 있어야 합니다.",
+                    details={
+                        "target_row_labels": list(target_row_labels),
+                        "selected_row_labels": list(selected_row_labels),
+                        "missing_target_row_labels": missing_targets,
+                    },
+                )
+            )
+        else:
+            reasons.append("comparison_rows_covered")
+    else:
+        if not target_row_labels:
+            if len(selected_row_labels) >= 2 and question_scoped_shared_contexts:
+                reasons.append("shared_context_scoped_rows")
+            else:
+                diagnostics.append(
+                    TableFactSelectionDiagnostic(
+                        code="target_row_unresolved_for_evidence",
+                        message="비교 질문이 아닌 경우에는 prompt 후보 근거로 쓰기 전에 질문 대상 행이 명확해야 합니다.",
+                        details={"selected_row_labels": list(selected_row_labels)},
+                    )
+                )
+        elif len(target_row_labels) > 1:
+            reasons.append("multiple_target_rows")
+        else:
+            reasons.append("single_target_row")
+
+        if not any(selection.matched_column_terms for selection in selections):
+            diagnostics.append(
+                TableFactSelectionDiagnostic(
+                    code="target_column_unresolved_for_evidence",
+                    message="비교 질문이 아닌 경우에는 prompt 후보 근거로 쓰기 전에 질문 대상 열이 명확해야 합니다.",
+                )
+            )
+        else:
+            reasons.append("target_column_matched")
+
+    evidence_text, truncated = render_selected_table_facts_as_evidence_text(
+        selections,
+        max_lines=max_lines,
+    )
+    if not evidence_text:
+        diagnostics.append(
+            TableFactSelectionDiagnostic(
+                code="no_renderable_table_fact_evidence",
+                message="선택된 표 근거가 라벨 반복값이나 공통값만 포함해 답변 근거 문장으로 만들 수 없습니다.",
+            )
+        )
+    elif truncated:
+        diagnostics.append(
+            TableFactSelectionDiagnostic(
+                code="truncated_table_fact_evidence",
+                message="선택된 표 근거가 미리보기 최대 줄 수를 넘어 즉시 답변 후보에서 제외했습니다.",
+                details={"max_lines": max_lines},
+            )
+        )
+    all_diagnostics = (*selection_result.diagnostics, *diagnostics)
+    return TableFactEvidencePreview(
+        prompt_candidate_ready=not diagnostics,
+        evidence_text=evidence_text,
+        reasons=_dedupe(reasons),
+        diagnostics=all_diagnostics,
+        truncated=truncated,
+    )
+
+
+def render_selected_table_facts_as_evidence_text(
+    selections: Sequence[TableFactSelection],
+    *,
+    max_lines: int = 8,
+) -> tuple[str, bool]:
+    """Render selected table facts as compact Korean key-value evidence text."""
+    if not selections:
+        return "", False
+
+    renderable_selections = _renderable_evidence_selections(selections)
+    if not renderable_selections:
+        return "", False
+
+    shared_contexts = _shared_evidence_contexts(selections)
+    max_lines = max(0, max_lines)
+    lines = ["[표 근거 후보]"]
+    emitted = 0
+    truncated = False
+    current_caption = None
+    for selection in renderable_selections:
+        if emitted >= max_lines:
+            truncated = True
+            break
+        fact = selection.fact
+        caption = _display_caption(fact)
+        if caption and caption != current_caption:
+            lines.append(f"표 제목: {caption}")
+            if shared_contexts:
+                lines.append(f"공통 맥락: {', '.join(shared_contexts)}")
+            current_caption = caption
+        row_label = _display_path(fact.row_header_path, fact.row_label)
+        column_label = _display_path(fact.column_path, fact.column_label)
+        lines.append(f"- 행: {row_label} / 열: {column_label} / 값: {fact.value}")
+        emitted += 1
+
+    if truncated:
+        lines.append(f"- 추가 표 근거 {len(renderable_selections) - emitted}개는 미리보기에서 생략됨")
+    return "\n".join(lines), truncated
+
+
+def _renderable_evidence_selections(
+    selections: Sequence[TableFactSelection],
+) -> tuple[TableFactSelection, ...]:
+    rows = _dedupe(
+        _row_identity(selection.fact)
+        for selection in selections
+        if _row_identity(selection.fact)
+    )
+    shared_comparison_values = (
+        _shared_column_values(selections) if len(rows) >= 2 else set()
+    )
+    renderable: list[TableFactSelection] = []
+    for selection in selections:
+        fact = selection.fact
+        if _is_label_echo_fact(fact):
+            continue
+        column_value_key = (
+            _normalize_text(fact.column_label),
+            _normalize_text(fact.value),
+        )
+        if column_value_key in shared_comparison_values:
+            continue
+        renderable.append(selection)
+    return tuple(renderable)
+
+
+def _shared_evidence_contexts(
+    selections: Sequence[TableFactSelection],
+) -> tuple[str, ...]:
+    shared_values = _shared_column_values(selections)
+    contexts: list[str] = []
+    seen: set[str] = set()
+    for selection in selections:
+        fact = selection.fact
+        key = (
+            _normalize_text(fact.column_label),
+            _normalize_text(fact.value),
+        )
+        if key not in shared_values or _is_label_echo_fact(fact):
+            continue
+        column_label = _display_path(fact.column_path, fact.column_label)
+        context = f"{column_label}={fact.value}"
+        if context in seen:
+            continue
+        seen.add(context)
+        contexts.append(context)
+    return tuple(contexts)
+
+
+def _question_scoped_shared_evidence_contexts(
+    selections: Sequence[TableFactSelection],
+    normalized_question: str,
+) -> tuple[str, ...]:
+    """Return shared row context only when its value is explicitly in the question."""
+    if not normalized_question:
+        return ()
+
+    shared_values = _shared_column_values(selections)
+    contexts: list[str] = []
+    seen: set[str] = set()
+    for selection in selections:
+        fact = selection.fact
+        key = (
+            _normalize_text(fact.column_label),
+            _normalize_text(fact.value),
+        )
+        if key not in shared_values or _is_label_echo_fact(fact):
+            continue
+        if not _term_in_text(key[1], normalized_question):
+            continue
+        column_label = _display_path(fact.column_path, fact.column_label)
+        context = f"{column_label}={fact.value}"
+        if context in seen:
+            continue
+        seen.add(context)
+        contexts.append(context)
+    return tuple(contexts)
+
+
+def _question_scoped_shared_context_selections(
+    selections: Sequence[TableFactSelection],
+    normalized_question: str,
+) -> tuple[TableFactSelection, ...]:
+    """Keep shared scope cells needed to explain multi-row column answers."""
+    if not normalized_question:
+        return ()
+
+    shared_values = _shared_column_values(selections)
+    scoped: list[TableFactSelection] = []
+    for selection in selections:
+        fact = selection.fact
+        key = (
+            _normalize_text(fact.column_label),
+            _normalize_text(fact.value),
+        )
+        if key not in shared_values or _is_label_echo_fact(fact):
+            continue
+        if _term_in_text(key[1], normalized_question):
+            scoped.append(selection)
+    return tuple(scoped)
+
+
+def _shared_column_values(
+    selections: Sequence[TableFactSelection],
+) -> set[tuple[str, str]]:
+    rows_by_column_value: dict[tuple[str, str], set[str]] = {}
+    for selection in selections:
+        fact = selection.fact
+        key = (_normalize_text(fact.column_label), _normalize_text(fact.value))
+        if not key[0] or not key[1]:
+            continue
+        rows_by_column_value.setdefault(key, set()).add(_row_identity(fact))
+    return {
+        key
+        for key, row_labels in rows_by_column_value.items()
+        if len(row_labels) >= 2
+    }
+
+
+def _is_label_echo_fact(fact: TableFact) -> bool:
+    value = _normalize_text(fact.value)
+    if not value:
+        return True
+    label_terms = _normalized_terms(
+        [
+            fact.row_label,
+            *fact.row_header_path,
+            fact.column_label,
+            *fact.column_path,
+        ]
+    )
+    return value in label_terms
+
+
+def _is_common_row(fact: TableFact) -> bool:
+    return _row_identity(fact) in {"공통", "공통 지원자격", "공통 조건"}
 
 
 def _score_table_fact(
@@ -225,6 +579,21 @@ def _context_terms(fact: TableFact) -> tuple[str, ...]:
     return _normalized_terms(values)
 
 
+def _display_caption(fact: TableFact) -> str:
+    if fact.caption:
+        return fact.caption.strip()
+    if fact.header_path:
+        return fact.header_path[-1].strip()
+    return ""
+
+
+def _display_path(path: Sequence[str], fallback: str) -> str:
+    values = [str(value).strip() for value in path if str(value).strip()]
+    if values:
+        return " > ".join(values)
+    return str(fallback or "").strip()
+
+
 def _row_identity(fact: TableFact) -> str:
     row_label = fact.row_header_path[-1] if fact.row_header_path else fact.row_label
     return _normalize_text(row_label)
@@ -277,6 +646,20 @@ def _dedupe(values: Iterable[str]) -> tuple[str, ...]:
         seen.add(value)
         deduped.append(value)
     return tuple(deduped)
+
+
+def _unique_selections(
+    selections: Iterable[TableFactSelection],
+) -> tuple[TableFactSelection, ...]:
+    unique: list[TableFactSelection] = []
+    seen: set[str] = set()
+    for selection in selections:
+        fact_id = selection.fact.fact_id
+        if fact_id in seen:
+            continue
+        seen.add(fact_id)
+        unique.append(selection)
+    return tuple(unique)
 
 
 _ASCII_ROMAN_NUMERALS = {


### PR DESCRIPTION
### 관련 이슈
Closes #101
Related #73
Related #97

### 작업 내용
- `selected_table_facts`를 `evidence_text(근거 텍스트)`로 렌더링하고, `prompt_candidate_ready(prompt 후보 준비 여부)`가 true인 경우만 실제 `/query` 답변 경로에 연결했습니다.
- `/query`와 `/query/stream`에서 검증된 표 근거가 있으면 EXAONE 호출 전에 행/열/값 기반 deterministic answer(결정적 답변)를 반환하도록 했습니다.
- `/debug/rag-trace`에 `priority_table_evidence(우선 표 근거)`와 `runtime_connection=query_prompt`를 표시해 trace(추적 화면)와 실제 답변 연결 여부를 같이 볼 수 있게 했습니다.
- `전형=농어촌`처럼 질문에 직접 나온 공통값은 `공통 맥락`으로 보존하고, `지원자격은 무엇인가요?`처럼 행이 불명확한 질문은 우선 표 근거로 승격하지 않도록 반례를 추가했습니다.
- `농어촌 유형 지원자격이 어떻게 돼?`처럼 `전형`이라는 열 이름을 직접 쓰지 않는 질문도 `농어촌` 공통 맥락을 보존해 유형Ⅰ/Ⅱ 지원자격 답변으로 연결되도록 보강했습니다.

### 리뷰 포인트
- `_question_scoped_shared_evidence_contexts()`가 여러 행의 공통값을 너무 넓게 허용하지 않는지 봐주세요. 의도는 “공통값의 value(값)가 질문에 직접 나온 경우”만 여러 행 답변 범위로 인정하는 것입니다.
- `/query`와 `/query/stream`은 같은 `_prepare_query()` 결과를 쓰므로 우선 표 답변 경로가 두 API에서 같은 기준으로 동작해야 합니다.

### 변경 파일
- `ai-server/rag_table_fact_selector.py`: 표 근거 선택 결과를 한국어 근거 텍스트로 만들고 prompt 후보 안전성을 판단합니다.
- `ai-server/main.py`: 검증된 표 근거를 prompt와 실제 `/query`, `/query/stream` 답변에 연결합니다.
- `ai-server/check_table_fact_evidence.py`: 라벨성 노이즈, 공통 맥락, 애매한 질문 반례를 고정합니다.
- `ai-server/check_table_fact_runtime_extraction.py`: runtime Markdown 표 추출 결과가 우선 표 근거와 결정적 답변으로 연결되는지 확인합니다.

### 확인한 내용
- `농어촌 전형 지원 자격은` `/query` 결과가 `공통 맥락: 전형=농어촌`, `유형Ⅰ`, `유형Ⅱ` 지원자격만 반환하는 것을 확인했습니다.
- 같은 질문의 `/query/stream`도 동일한 답변을 SSE로 반환하는 것을 확인했습니다.
- `/debug/rag-trace`에서 같은 질문은 chunk `73_29`, `runtime_connection=query_prompt`, `[우선 표 근거]` 포함으로 확인했습니다.
- selector(선택기) smoke에서 `농어촌 유형 지원자격이 어떻게 돼?`도 `공통 맥락: 전형=농어촌`, 유형Ⅰ/Ⅱ 지원자격 근거로 연결됨을 확인했습니다.
- `/debug/rag-trace`에서 `지원자격은 무엇인가요?`는 `priority_table_evidence=null`이고 최종 prompt에 `[우선 표 근거]`가 없음을 확인했습니다.
- `ai-server/venv/bin/python -m py_compile ai-server/rag_table_fact_selector.py ai-server/main.py ai-server/check_table_fact_evidence.py ai-server/check_table_fact_runtime_extraction.py` 통과
- `ai-server/venv/bin/python ai-server/check_table_fact_evidence.py` 통과
- `ai-server/venv/bin/python ai-server/check_table_fact_runtime_extraction.py` 통과
- `ai-server/venv/bin/python ai-server/check_table_fact_selector.py` 통과
- `ai-server/venv/bin/python ai-server/check_rag_contracts.py` 통과
- `ai-server/venv/bin/python ai-server/check_opendataloader_contract_adapter.py` 통과
- `git diff --check` 통과

### 후속 범위
- 이번 PR은 표 근거가 안전하게 좁혀진 경우의 답변 연결까지 다룹니다. `sources` 목록을 정답 근거 중심으로 좁히는 작업과 ListFact/CardFact 같은 표 외 구조는 후속 issue에서 다룹니다.
